### PR TITLE
Fix query parameter encoding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,4 +15,5 @@
 
 Google Inc. <*@google.com>
 Jason Palmer <jason@jason-palmer.com>
+Oskar Arvidsson <oskar@irock.se>
 Sanborn Hilland <sanbornh@rogers.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Jason Palmer <jason@jason-palmer.com>
 Joey Parrish <joeyparrish@google.com>
 Natalie Harris <natalieharris@google.com>
+Oskar Arvidsson <oskar@irock.se>
 Sanborn Hilland <sanbornh@rogers.com>
 Timothy Drews <tdrews@google.com>
 Vasanth Polipelli <vasanthap@google.com>

--- a/third_party/closure/goog/uri/uri.js
+++ b/third_party/closure/goog/uri/uri.js
@@ -277,7 +277,7 @@ goog.Uri.prototype.resolve = function(relativeUri) {
   }
 
   if (overridden) {
-    absoluteUri.setQueryData(relativeUri.getDecodedQuery());
+    absoluteUri.setQueryData(relativeUri.getQueryData().clone());
   } else {
     overridden = relativeUri.hasFragment();
   }


### PR DESCRIPTION
This fixes handling of URIs with special characters. Without this patch, segment URIs such as e.g. http://example.com/0.webm?param=%26 are translated to http://example.com/0.webm?param=&.