### PR TITLE
Added support for AMD in build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ third_party/closure/goog/deps.js
 shaka-player.compiled.js
 shaka-player.compiled.debug.js
 shaka-player.compiled.debug.map
+amd.js
 docs/api
 docs/reference

--- a/build/build.sh
+++ b/build/build.sh
@@ -39,7 +39,7 @@ rm -f "$dir"/shaka-player.compiled.js
 
 # Compile with AMD module support
 (library_sources_0; closure_sources_0) | compile_0 \
-  --output_wrapper='var o = {}; (function(){%output% define(o.shaka);}.bind(o))()' \
+  --output_wrapper='(function(){%output% define(this.shaka);})()' \
   --js_output_file "$dir"/amd.js
 
 # Fork the non-debug version before appending debug info.

--- a/build/build.sh
+++ b/build/build.sh
@@ -37,6 +37,11 @@ rm -f "$dir"/shaka-player.compiled.js
   --create_source_map "$dir"/shaka-player.compiled.debug.map \
   --js_output_file "$dir"/shaka-player.compiled.debug.js
 
+# Compile with AMD module support
+(library_sources_0; closure_sources_0) | compile_0 \
+  --output_wrapper='var o = {}; (function(){%output% define(o.shaka);}.bind(o))()' \
+  --js_output_file "$dir"/amd.js
+
 # Fork the non-debug version before appending debug info.
 cp "$dir"/shaka-player.compiled{.debug,}.js
 


### PR DESCRIPTION
Build process now supports AMD.

Example usage:

    (function() {
      'use strict';

      require(['node_modules/shaka-player/amd'], function(shaka) {
        shaka.polyfill.Fullscreen.install();
        shaka.polyfill.MediaKeys.install();
        shaka.polyfill.VideoPlaybackQuality.install();

        var player = new shaka.player.Player(document.getElementById('foo'));
        var playerSource = new shaka.player.HttpVideoSource('http://video.webmfiles.org/elephants-dream.webm');
        player.load(playerSource).then(function() {
          player.play();
        });
      });
    }());