### PR TITLE
mpd parser: Handle minimumUpdatePeriod being set to 0.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,3 +29,4 @@ Oskar Arvidsson <oskar@irock.se>
 Sanborn Hilland <sanbornh@rogers.com>
 Timothy Drews <tdrews@google.com>
 Vasanth Polipelli <vasanthap@google.com>
+Vignesh Venkatasubramanian <vigneshv@google.com>

--- a/lib/dash/mpd_parser.js
+++ b/lib/dash/mpd_parser.js
@@ -830,12 +830,21 @@ shaka.dash.mpd.Mpd.prototype.parse = function(parent, elem) {
                      mpd.parseDuration_,
                      this.minBufferTime);
 
-  // Disallow zero.
   this.minUpdatePeriod =
       mpd.parseAttr_(elem,
                      'minimumUpdatePeriod',
                      mpd.parseDuration_,
-                     this.minUpdatePeriod) || null;
+                     this.minUpdatePeriod);
+
+  // If minimumUpdatePeriod is set to 0, then we shouldn't refresh the manifest
+  // unless there is explicit signalling in the stream, according to:
+  // http://azure.microsoft.com/blog/2014/09/13/dash-live-streaming-with-azure-media-service/
+  // There is no way to get the signal from within the stream in MSE as of now.
+  // So, if we see a minimumUpdatePeriod of zero, we merely set it to 10
+  // seconds.
+  if (this.minUpdatePeriod == 0) {
+    this.minUpdatePeriod = 10;
+  }
 
   this.availabilityStartTime =
       mpd.parseAttr_(elem,


### PR DESCRIPTION
For live streams, minimumUpdatePeriod can be set to 0. It means that
we shouldn't refresh the manifest until there's an explicit signal
from within the stream. As of now, there's no way to get that signal
from MSE. So as a workaround, if we see a minimumUpdatePeriod of 0,
we set it to 10 seconds. This is similar to how Exoplayer [1] and Dash.js [2]
handle this case.

[1] https://github.com/Dash-Industry-Forum/dash.js/blob/fe14ee023c0e3aa073284ce034758942e8f3c7bf/build/test/js/utils/MPDHelper.js#L12
[2] https://github.com/google/ExoPlayer/blob/953e1118a58a269ded8b0246874bd827d900fcf0/library/src/main/java/com/google/android/exoplayer/dash/DashChunkSource.java#L270