### PR TITLE
Load without errors in IE 9

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Google Inc. <*@google.com>
 Jason Palmer <jason@jason-palmer.com>
 Oskar Arvidsson <oskar@irock.se>
 Sanborn Hilland <sanbornh@rogers.com>
+uStudio Inc. <*@ustudio.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ Joey Parrish <joeyparrish@google.com>
 Natalie Harris <natalieharris@google.com>
 Oskar Arvidsson <oskar@irock.se>
 Sanborn Hilland <sanbornh@rogers.com>
+Thomas Stephens <thomas@ustudio.com>
 Timothy Drews <tdrews@google.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -49,6 +49,7 @@ shaka.asserts.patchAssert_ = function() {
   if (!assert) {
     console.assert = function() {};
   } else if (!assert.bind) {
+    // IE 9 does not provide a .bind for the built-in console functions.
     console.assert = function() {
       assert.apply(console, arguments);
     }

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -44,7 +44,7 @@ shaka.asserts.unreachable = function() {};
 
 
 shaka.asserts.patchAssert_ = function() {
-  var assert = console['assert'];
+  var assert = console.assert;
 
   if (!assert) {
     console.assert = function() {};
@@ -52,7 +52,7 @@ shaka.asserts.patchAssert_ = function() {
     // IE 9 does not provide a .bind for the built-in console functions.
     console.assert = function() {
       assert.apply(console, arguments);
-    }
+    };
   }
 };
 

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -43,7 +43,7 @@ shaka.asserts.notImplemented = function() {};
 shaka.asserts.unreachable = function() {};
 
 
-/** @private @type {function()} */
+/** @private {function()} */
 shaka.asserts.patchAssert_ = function() {
   var assert = console.assert;
 

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -43,8 +43,23 @@ shaka.asserts.notImplemented = function() {};
 shaka.asserts.unreachable = function() {};
 
 
+shaka.asserts.patchAssert_ = function() {
+  var assert = console['assert'];
+
+  if (!assert) {
+    console.assert = function() {};
+  } else if (!assert.bind) {
+    console.assert = function() {
+      assert.apply(console, arguments);
+    }
+  }
+};
+
+
 // Install assert functions.
 if (shaka.asserts.ENABLE_ASSERTS) {
+  shaka.asserts.patchAssert_();
+
   shaka.asserts.assert =
       console.assert.bind(console);
 
@@ -54,4 +69,3 @@ if (shaka.asserts.ENABLE_ASSERTS) {
   shaka.asserts.unreachable =
       console.assert.bind(console, 0 == 1, 'Unreachable reached.');
 }
-

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -43,6 +43,7 @@ shaka.asserts.notImplemented = function() {};
 shaka.asserts.unreachable = function() {};
 
 
+/** @private @type {function()} */
 shaka.asserts.patchAssert_ = function() {
   var assert = console.assert;
 

--- a/lib/debug/asserts.js
+++ b/lib/debug/asserts.js
@@ -43,7 +43,7 @@ shaka.asserts.notImplemented = function() {};
 shaka.asserts.unreachable = function() {};
 
 
-/** @private {function()} */
+/** @private */
 shaka.asserts.patchAssert_ = function() {
   var assert = console.assert;
 

--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -82,11 +82,11 @@ shaka.log.patchConsole_ = function(logName) {
   }
 };
 
-shaka.log.patchConsole_("error");
-shaka.log.patchConsole_("warn");
-shaka.log.patchConsole_("info");
-shaka.log.patchConsole_("log");
-shaka.log.patchConsole_("debug");
+shaka.log.patchConsole_('error');
+shaka.log.patchConsole_('warn');
+shaka.log.patchConsole_('info');
+shaka.log.patchConsole_('log');
+shaka.log.patchConsole_('debug');
 
 if (!COMPILED) {
   /**

--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -79,7 +79,7 @@ shaka.log.patchConsole_ = function(logName) {
     // IE 9 does not provide a .bind for the built-in logging functions.
     console[logName] = function() {
       logFunction.apply(console, arguments);
-    }
+    };
   }
 };
 

--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -76,6 +76,7 @@ shaka.log.patchConsole_ = function(logName) {
   if (!logFunction) {
     console[logName] = nop;
   } else if (!logFunction.bind) {
+    // IE 9 does not provide a .bind for the built-in logging functions.
     console[logName] = function() {
       logFunction.apply(console, arguments);
     }

--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -69,6 +69,24 @@ shaka.log.v1 = function() {};
 /** @type {function(*, ...[*])} */
 shaka.log.v2 = function() {};
 
+shaka.log.patchConsole_ = function(logName) {
+  var nop = function() {};
+  var logFunction = console[logName];
+
+  if (!logFunction) {
+    console[logName] = nop;
+  } else if (!logFunction.bind) {
+    console[logName] = function() {
+      logFunction.apply(console, arguments);
+    }
+  }
+};
+
+shaka.log.patchConsole_("error");
+shaka.log.patchConsole_("warn");
+shaka.log.patchConsole_("info");
+shaka.log.patchConsole_("log");
+shaka.log.patchConsole_("debug");
 
 if (!COMPILED) {
   /**
@@ -118,4 +136,3 @@ if (shaka.log.MAX_LOG_LEVEL >= shaka.log.Level.V1) {
 if (shaka.log.MAX_LOG_LEVEL >= shaka.log.Level.V2) {
   shaka.log.v2 = console.debug.bind(console);
 }
-

--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -69,6 +69,11 @@ shaka.log.v1 = function() {};
 /** @type {function(*, ...[*])} */
 shaka.log.v2 = function() {};
 
+
+/**
+ * @private
+ * @param {string} logName
+ */
 shaka.log.patchConsole_ = function(logName) {
   var nop = function() {};
   var logFunction = console[logName];

--- a/lib/debug/timer.js
+++ b/lib/debug/timer.js
@@ -111,11 +111,10 @@ shaka.timer.get = function(name) {
 
 
 /** @private {function():number} */
-shaka.timer.now_ = window.performance ?
+shaka.timer.now_ = window.performance && window.performance.now ?
                        window.performance.now.bind(window.performance) :
                        Date.now;
 
 
 /** @private {!Object.<string, {begin: number, end: number}>} */
 shaka.timer.timers_ = {};
-

--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -155,7 +155,9 @@ shaka.player.Player.isBrowserSupported = function() {
       !!document.exitFullscreen &&
       'fullscreenElement' in document &&
       // Node.children is used by mpd_parser.js, and body is a Node instance.
-      !!document.body.children;
+      !!document.body.children &&
+      // Uint8Array is used frequently for parsing binary data
+      !!window.Uint8Array;
 };
 
 
@@ -956,4 +958,3 @@ shaka.player.Player.MEDIA_ERROR_MAP_ = {
   4: // MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED
       'The browser does not support the media content.'
 };
-

--- a/support.js
+++ b/support.js
@@ -303,8 +303,9 @@ if (async.length) {
 }
 
 function onLoaded(fn) {
-  if (document.readyState == "loading") {
-    document.addEventListener('DOMContentLoaded', fn);
+  if (document.readyState == "loading" ||
+      document.readyState == "interactive") {
+    window.addEventListener('load', fn);
   } else {
     fn();
   }

--- a/support.js
+++ b/support.js
@@ -15,34 +15,34 @@
  */
 
 // Status values for the report entries.
-const kGood = 0;
-const kInfo = 1;
-const kBad = 2;
+var kGood = 0;
+var kInfo = 1;
+var kBad = 2;
 
-const vp8Type = 'video/webm; codecs="vp8"';
-const vp9Type = 'video/webm; codecs="vp9"';
-const mp4Type = 'video/mp4; codecs="avc1.42E01E"';
-const tsType = 'video/mp2t; codecs="avc1.42E01E"';
+var vp8Type = 'video/webm; codecs="vp8"';
+var vp9Type = 'video/webm; codecs="vp9"';
+var mp4Type = 'video/mp4; codecs="avc1.42E01E"';
+var tsType = 'video/mp2t; codecs="avc1.42E01E"';
 
-const clearKeyId = 'org.w3.clearkey';
-const widevineId = 'com.widevine.alpha';
-const playReadyId = 'com.microsoft.playready';
-const adobeAccessId = 'com.adobe.access';
-const fairPlayId = 'com.apple.fairplay';
+var clearKeyId = 'org.w3.clearkey';
+var widevineId = 'com.widevine.alpha';
+var playReadyId = 'com.microsoft.playready';
+var adobeAccessId = 'com.adobe.access';
+var fairPlayId = 'com.apple.fairplay';
 
-const classPrefixes = [
+var classPrefixes = [
   'WebKit',
   'MS',
   'Moz'
 ];
 
-const propertyPrefixes = [
+var propertyPrefixes = [
   'webkit',
   'ms',
   'moz'
 ];
 
-const keySystemPrefixes = [
+var keySystemPrefixes = [
   'webkit-'
 ];
 

--- a/support.js
+++ b/support.js
@@ -304,6 +304,9 @@ if (async.length) {
 }
 
 function onLoaded(fn) {
+  // IE 9 fires DOMContentLoaded, and enters the "interactive"
+  // readyState, before document.body has been initialized, so wait
+  // for window.load
   if (document.readyState == "loading" ||
       document.readyState == "interactive") {
     window.addEventListener('load', fn);

--- a/support.js
+++ b/support.js
@@ -230,6 +230,7 @@ function testForKeySystem(ks, required) {
 testForClass(window, 'HTMLMediaElement', true);
 testForClass(window, 'MediaSource', true);
 testForClass(window, 'Promise', true);
+testForClass(window, 'Uint8Array', true);
 
 // Optional:
 testForClass(window, 'VTTCue', false);

--- a/support.js
+++ b/support.js
@@ -307,8 +307,8 @@ function onLoaded(fn) {
   // IE 9 fires DOMContentLoaded, and enters the "interactive"
   // readyState, before document.body has been initialized, so wait
   // for window.load
-  if (document.readyState == "loading" ||
-      document.readyState == "interactive") {
+  if (document.readyState == 'loading' ||
+      document.readyState == 'interactive') {
     window.addEventListener('load', fn);
   } else {
     fn();


### PR DESCRIPTION
This ports our fixes back into the Shaka source.

@ustudio/dev Can somebody review this, before I open a PR back to the upstream source?