### PR TITLE
Remove extra space causing compiler to fail.

### DIFF
--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -691,7 +691,7 @@ shaka.player.Player.prototype.getRestrictions = function() {
 
 
 /**
- * @param {number} startTime Desired time (in seconds) for playback 
+ * @param {number} startTime Desired time (in seconds) for playback
  *      to begin from.
  * @export
  */


### PR DESCRIPTION
Sorry guys, when I updated that comment I didn't check that it compiled properly. I accidentally left a trailing space in the comment.