### PR TITLE
Optional offset param to IVideoSource.selectVideoTrack for partial buffer clear

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,4 +19,5 @@ Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
 Roi Lipman <roilipman@gmail.com>
 Sanborn Hilland <sanbornh@rogers.com>
+TalkTalk Plc <*@talktalkplc.com>
 uStudio Inc. <*@ustudio.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Jason Palmer <jason@jason-palmer.com>
 Joey Parrish <joeyparrish@google.com>
+Jono Ward <jonoward@gmail.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>

--- a/lib/media/i_stream.js
+++ b/lib/media/i_stream.js
@@ -74,9 +74,13 @@ shaka.media.IStream.prototype.hasEnded = function() {};
  *     when the stream starts for the first time.
  * @param {boolean} clearBuffer If true, removes the previous stream's content
  *     before switching to the new stream.
+ * @param {number=} opt_clearBufferOffset if |clearBuffer| and
+ *     |opt_clearBufferOffset|
+ *     are truthy, clear the stream buffer from the offset (in front of video
+ *     currentTime) to the end of the stream.
  */
 shaka.media.IStream.prototype.switch = function(
-    streamInfo, minBufferTime, clearBuffer) {};
+    streamInfo, minBufferTime, clearBuffer, opt_clearBufferOffset) {};
 
 
 /**

--- a/lib/media/simple_abr_manager.js
+++ b/lib/media/simple_abr_manager.js
@@ -159,6 +159,28 @@ shaka.media.SimpleAbrManager.prototype.getInitialVideoTrackId = function() {
 
 
 /**
+ * Select the specified video track.
+ *
+ * @param {shaka.player.VideoTrack} track the track to the switch to
+ * @param {boolean} clearBuffer If true, removes the previous stream's content
+ *     before switching to the new stream.
+ * @param {number=} opt_clearBufferOffset if |clearBuffer| and
+ *     |opt_clearBufferOffset| are truthy, clear the stream buffer from the
+ *     offset (in front of video currentTime) to the end of the stream.
+ *
+ * @protected
+ * @expose
+ */
+shaka.media.SimpleAbrManager.prototype.selectVideoTrack = function(
+    track, clearBuffer, opt_clearBufferOffset) {
+  shaka.asserts.assert(this.videoSource_);
+
+  this.videoSource_.selectVideoTrack(
+      track.id, clearBuffer, opt_clearBufferOffset);
+};
+
+
+/**
  * Find the active track in the list.
  *
  * @param {!Array.<T>} trackList
@@ -207,7 +229,7 @@ shaka.media.SimpleAbrManager.prototype.onBandwidth_ = function(event) {
     }
 
     shaka.log.info('Video adaptation:', chosen);
-    this.videoSource_.selectVideoTrack(chosen.id, false);
+    this.selectVideoTrack(chosen, false);
   }
 
   // Can't adapt again until we get confirmation of this one.

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -302,6 +302,39 @@ shaka.media.SourceBufferManager.prototype.clear = function() {
 
 
 /**
+ * Resets the virtual source buffer and clears all media from the underlying
+ * SourceBuffer after the given timestamp. The returned promise will resolve
+ * immediately if there is no media within the underlying SourceBuffer. This
+ * cannot be called if another operation is in progress.
+ *
+ * @param {number} timestamp
+ *
+ * @return {!Promise}
+ */
+shaka.media.SourceBufferManager.prototype.clearAfter = function(timestamp) {
+  shaka.log.v1('clearAfter');
+
+  // Check state.
+  shaka.asserts.assert(!this.task_);
+  if (this.task_) {
+    var error =
+        new Error('Cannot clearAfter: previous operation not complete.');
+    error.type = 'stream';
+    return Promise.reject(error);
+  }
+
+  this.task_ = new shaka.util.Task();
+
+  this.task_.append(function() {
+    var p = this.clearAfter_(timestamp);
+    return [p, this.abort_.bind(this)];
+  }.bind(this));
+
+  return this.startTask_();
+};
+
+
+/**
  * Aborts the current operation if one exists.
  * The returned promise will never be rejected.
  *
@@ -450,6 +483,49 @@ shaka.media.SourceBufferManager.prototype.clear_ = function() {
   // Clear |inserted_| immediately since any inserted segments will be
   // gone soon.
   this.inserted_ = [];
+
+  this.operationPromise_ = new shaka.util.PublicPromise();
+  return this.operationPromise_;
+};
+
+
+/**
+ * Clear the source buffer after the given timestamp (aligned to the next
+ * segment boundary).
+ *
+ * @param {number} timestamp
+ *
+ * @return {!Promise}
+ * @private
+ */
+shaka.media.SourceBufferManager.prototype.clearAfter_ = function(timestamp) {
+  shaka.asserts.assert(!this.operationPromise_);
+
+  if (this.sourceBuffer_.buffered.length == 0) {
+    shaka.log.v1('Nothing to clear.');
+    shaka.asserts.assert(this.inserted_.length == 0);
+    return Promise.resolve();
+  }
+
+  var index = shaka.media.SegmentReference.find(this.inserted_, timestamp);
+
+  // If no segment found, or it's the last one, bail out gracefully.
+  if (index == -1 || index == this.inserted_.length - 1) {
+    shaka.log.v1('No segments on or after timestamp, nothing to clear.');
+    return Promise.resolve();
+  }
+
+  try {
+    // This will trigger an 'updateend' event.
+    this.sourceBuffer_.remove(
+        this.inserted_[index + 1].startTime,
+        Number.POSITIVE_INFINITY);
+  } catch (exception) {
+    shaka.log.debug('Failed to clear buffer:', exception);
+    return Promise.reject(exception);
+  }
+
+  this.inserted_ = this.inserted_.slice(0, index + 1);
 
   this.operationPromise_ = new shaka.util.PublicPromise();
   return this.operationPromise_;

--- a/lib/media/stream.js
+++ b/lib/media/stream.js
@@ -242,7 +242,7 @@ shaka.media.Stream.prototype.hasEnded = function() {
 
 /** @override */
 shaka.media.Stream.prototype.switch = function(
-    streamInfo, minBufferTime, clearBuffer) {
+    streamInfo, minBufferTime, clearBuffer, opt_clearBufferOffset) {
   if (streamInfo == this.streamInfo_) {
     shaka.log.debug('Already using stream', streamInfo);
     return;
@@ -275,7 +275,7 @@ shaka.media.Stream.prototype.switch = function(
           // it was called at an appopriate time.
           this.setUpdateTimer_(0);
         } else if (clearBuffer) {
-          this.resync_(true /* forceClear */);
+          this.resync_(true /* forceClear */, opt_clearBufferOffset);
         } else {
           shaka.asserts.assert((this.updateTimer_ != null) || this.fetching_);
         }
@@ -303,14 +303,20 @@ shaka.media.Stream.prototype.resync = function() {
  * Resync the stream.
  *
  * @param {boolean} forceClear
+ * @param {number=} opt_clearBufferOffset if |forceClear| and
+ *     |opt_clearBufferOffset| are truthy, clear the stream buffer from the
+ *     offset (in front of video currentTime) to the end of the stream.
+ *
  * @private
  */
-shaka.media.Stream.prototype.resync_ = function(forceClear) {
+shaka.media.Stream.prototype.resync_ = function(
+    forceClear, opt_clearBufferOffset) {
   if (!this.streamInfo_ || this.resyncing_) {
     return;
   }
 
   shaka.asserts.assert((this.updateTimer_ != null) || this.fetching_);
+  shaka.asserts.assert(!opt_clearBufferOffset || opt_clearBufferOffset > 0);
 
   this.resyncing_ = true;
   this.cancelUpdateTimer_();
@@ -331,8 +337,15 @@ shaka.media.Stream.prototype.resync_ = function(forceClear) {
             !this.sbm_.isBuffered(currentTime) ||
             !this.sbm_.isInserted(currentTime)) {
           shaka.log.debug('Nudge needed!');
-          this.needsNudge_ = true;
-          return this.sbm_.clear();
+
+          if (opt_clearBufferOffset) {
+            return this.sbm_.clearAfter(
+                this.video_.currentTime + opt_clearBufferOffset);
+          } else {
+            this.needsNudge_ = true;
+            return this.sbm_.clear();
+          }
+
         } else {
           return Promise.resolve();
         }

--- a/lib/media/text_stream.js
+++ b/lib/media/text_stream.js
@@ -107,7 +107,7 @@ shaka.media.TextStream.prototype.hasEnded = function() {
 
 /** @override */
 shaka.media.TextStream.prototype.switch = function(
-    streamInfo, minBufferTime, clearBuffer) {
+    streamInfo, minBufferTime, clearBuffer, opt_clearBufferOffset) {
   shaka.log.info('Switching stream to', streamInfo);
 
   streamInfo.segmentIndexSource.create().then(shaka.util.TypedBind(this,

--- a/lib/player/http_video_source.js
+++ b/lib/player/http_video_source.js
@@ -144,7 +144,7 @@ shaka.player.HttpVideoSource.prototype.selectConfigurations =
 
 /** @override */
 shaka.player.HttpVideoSource.prototype.selectVideoTrack =
-    function(id, clearBuffer) {
+    function(id, clearBuffer, opt_clearBufferOffset) {
   return false;
 };
 

--- a/lib/player/i_video_source.js
+++ b/lib/player/i_video_source.js
@@ -147,12 +147,15 @@ shaka.player.IVideoSource.prototype.selectConfigurations =
  * @param {number} id The |id| field of the desired VideoTrack object.
  * @param {boolean} clearBuffer If true, removes the previous stream's content
  *     before switching to the new stream.
+ * @param {number=} opt_clearBufferOffset if |clearBuffer| and
+ *     |opt_clearBufferOffset| are truthy, clear the stream buffer from the
+ *     offset (in front of video currentTime) to the end of the stream.
  *
  * @return {boolean} True on success; otherwise, return false if the specified
  *     VideoTrack does not exist or if a video stream does not exist.
  */
 shaka.player.IVideoSource.prototype.selectVideoTrack =
-    function(id, clearBuffer) {};
+    function(id, clearBuffer, opt_clearBufferOffset) {};
 
 
 /**

--- a/lib/player/stream_video_source.js
+++ b/lib/player/stream_video_source.js
@@ -149,7 +149,8 @@ shaka.player.StreamVideoSource = function(manifestInfo, estimator, abrManager) {
 
   /**
    * @private {!Object.<string, {streamInfo: !shaka.media.StreamInfo,
-   *                             clearBuffer: boolean}>}
+   *                             clearBuffer: boolean,
+   *                             clearBufferOffset: (number|undefined)}>}
    */
   this.deferredSwitches_ = {};
 
@@ -689,8 +690,8 @@ shaka.player.StreamVideoSource.prototype.selectConfigurations =
 
 /** @override */
 shaka.player.StreamVideoSource.prototype.selectVideoTrack =
-    function(id, clearBuffer) {
-  return this.selectTrack_('video', id, clearBuffer);
+    function(id, clearBuffer, opt_clearBufferOffset) {
+  return this.selectTrack_('video', id, clearBuffer, opt_clearBufferOffset);
 };
 
 
@@ -802,12 +803,15 @@ shaka.player.StreamVideoSource.prototype.isLive = function() {
  *     or 'text'.
  * @param {number} id The |uniqueId| field of the desired StreamInfo.
  * @param {boolean} clearBuffer
+ * @param {number=} opt_clearBufferOffset if |clearBuffer| and
+ *     |opt_clearBufferOffset| are truthy, clear the stream buffer from the
+ *     offset (in front of video currentTime) to the end of the stream.
  *
  * @return {boolean} True on success.
  * @private
  */
 shaka.player.StreamVideoSource.prototype.selectTrack_ =
-    function(type, id, clearBuffer) {
+    function(type, id, clearBuffer, opt_clearBufferOffset) {
   if (!this.streamSetsByType.has(type)) {
     shaka.log.warning(
         'Cannot select', type, 'track', id,
@@ -847,7 +851,10 @@ shaka.player.StreamVideoSource.prototype.selectTrack_ =
 
         this.deferredSwitches_[type] = {
           streamInfo: streamInfo,
-          clearBuffer: (tuple != null && tuple.clearBuffer) || clearBuffer
+          clearBuffer: (tuple != null && tuple.clearBuffer) || clearBuffer,
+          clearBufferOffset:
+              (tuple != null && tuple.clearBufferOffset) ||
+              opt_clearBufferOffset
         };
         return true;
       }
@@ -858,7 +865,8 @@ shaka.player.StreamVideoSource.prototype.selectTrack_ =
       this.streamsByType_[type].switch(
           streamInfo,
           this.manifestInfo.minBufferTime,
-          clearBuffer);
+          clearBuffer,
+          opt_clearBufferOffset);
       return true;
     }
   }
@@ -1363,7 +1371,8 @@ shaka.player.StreamVideoSource.prototype.processDeferredSwitches_ = function() {
     stream.switch(
         tuple.streamInfo,
         this.manifestInfo.minBufferTime,
-        tuple.clearBuffer);
+        tuple.clearBuffer,
+        tuple.clearBufferOffset);
   }
 
   this.deferredSwitches_ = {};


### PR DESCRIPTION
Mainly for use in a custom ABR manager, where calling StreamVideoSource.selectVideoTrack could pass an optional offset param, which is the number of seconds in front of video.currentTime that the buffer should be cleared from. 

Useful when configuring the player with a large buffer that should be truncated when upgrading from a lower bitrate to a higher one (so that the user sees the newer bitrate without having to player through the size of the buffer)

Addresses issue #95 