### PR TITLE
Correct typo in getAdaptationEnabled causing it to return undefined

### DIFF
--- a/lib/player/player.js
+++ b/lib/player/player.js
@@ -583,7 +583,7 @@ shaka.player.Player.prototype.enableAdaptation = function(enabled) {
  * @deprecated Please use getConfiguration().
  */
 shaka.player.Player.prototype.getAdaptationEnabled = function() {
-  return /** @type {boolean} */(this.getConfiguration['enableAdaptation']);
+  return /** @type {boolean} */(this.getConfiguration()['enableAdaptation']);
 };
 
 


### PR DESCRIPTION
I realize getAdaptationEnabled is deprecated but it was returning undefined. Until it gets taken out I assume it should be returning the correct value.