### PR TITLE
Check for define.amd along with typeof(define)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@
 
 Google Inc. <*@google.com>
 Jason Palmer <jason@jason-palmer.com>
+Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
 Roi Lipman <roilipman@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@
 # Please keep the list sorted.
 
 Jason Palmer <jason@jason-palmer.com>
+Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Joey Parrish <joeyparrish@google.com>
 Jono Ward <jonoward@gmail.com>
 Natalie Harris <natalieharris@google.com>

--- a/build/wrapper.template.js
+++ b/build/wrapper.template.js
@@ -1,6 +1,6 @@
 (function(){var g={};
 (function(window){%output%}.bind(g,this))();
 if (typeof(module)!="undefined"&&module.exports)module.exports=g.shaka;
-else if (typeof(define)!="undefined")define(function(){return g.shaka});
+else if (typeof(define)!="undefined" && define.amd)define(function(){return g.shaka});
 else this.shaka=g.shaka;
 })();


### PR DESCRIPTION
To prevent crashing with other module loaders that support `define`, but are not full AMD module loaders, check for `define.amd` as well before defining the AMD module.