### PR TITLE
Introduce configurationchanged event.

### DIFF
--- a/lib/media/simple_abr_manager.js
+++ b/lib/media/simple_abr_manager.js
@@ -138,6 +138,8 @@ shaka.media.SimpleAbrManager.prototype.start = function(estimator,
                             this.onBandwidth_.bind(this));
   this.eventManager_.listen(this.videoSource_, 'adaptation',
                             this.onAdaptation_.bind(this));
+  this.eventManager_.listen(this.videoSource_, 'trackschanged',
+                            this.chooseNewTrack_.bind(this));
 };
 
 
@@ -202,22 +204,33 @@ shaka.media.SimpleAbrManager.findActiveTrack_ = function(trackList) {
 
 
 /**
- * Handles bandwidth update events and makes adaptation decisions.
+ * Handles bandwidth update events.
  *
  * @param {!Event} event
  * @private
  */
 shaka.media.SimpleAbrManager.prototype.onBandwidth_ = function(event) {
+  if (Date.now() < this.nextAdaptationTime_) {
+    return;
+  }
+
+  this.chooseNewTrack_(event);
+};
+
+
+/**
+ * Makes adaptation decisions.
+ *
+ * @param {!Event} event
+ * @private
+ */
+shaka.media.SimpleAbrManager.prototype.chooseNewTrack_ = function(event) {
   if (!this.enabled_) {
     return;
   }
 
   // Alias.
   var SimpleAbrManager = shaka.media.SimpleAbrManager;
-
-  if (Date.now() < this.nextAdaptationTime_) {
-    return;
-  }
 
   var chosen = this.chooseVideoTrack_();
 


### PR DESCRIPTION
Add a configurationchanged event that fires when videoSource.configure()
is called. This is useful for components that need to know when certain
configurations have changed such as when bandwidth restrictions have
been changed. In this case, the simple_abr_manager can force a video track
update when restrictions have been changed instead of waiting for a
bandwidth update.

This is the kind of thing I have in mind for #160 as an alternative solution.