### PR TITLE
drm_info isCompatible "properly" compares callbacks

### DIFF
--- a/lib/player/drm_info.js
+++ b/lib/player/drm_info.js
@@ -431,8 +431,8 @@ shaka.player.DrmInfo.prototype.isCompatible = function(other) {
   return (this.keySystem == other.keySystem) &&
          (this.licenseServerUrl == other.licenseServerUrl) &&
          (this.withCredentials == other.withCredentials) &&
-         (this.licensePostProcessor == other.licensePostProcessor) &&
-         (this.licensePreProcessor == other.licensePreProcessor) &&
+         (''+this.licensePostProcessor == ''+other.licensePostProcessor) &&
+         (''+this.licensePreProcessor == ''+other.licensePreProcessor) &&
          (this.distinctiveIdentifierRequired ==
           other.distinctiveIdentifierRequired) &&
          (this.persistentStateRequired == other.persistentStateRequired) &&


### PR DESCRIPTION
Without this fix there can only be one valid representation for each adaptation set if there is DRM with a pre/post license fetch callback.

Yuck.

In plain english: multiple bitrates don't work if you use DRM + callbacks. `createStreamSetInfo` will kick out all but the first representation.

Not sure if you guys want to explore a more robust way to compare those callbacks. Obviously this will blow up if somebody passed different closures to identical drm configs.