### PR TITLE
enable setPlaybackStartTime on live streams

### DIFF
--- a/lib/player/stream_video_source.js
+++ b/lib/player/stream_video_source.js
@@ -1545,19 +1545,17 @@ shaka.player.StreamVideoSource.prototype.startStreams_ = function(
 
   // Determine the stream start time.
   var streamStartTime;
-  if (this.manifestInfo.live) {
+  // If a specific start time was set, and it's within the stream limits, use
+  // that as the start time.
+  if (this.playbackStartTime_ &&
+      this.playbackStartTime_ <= streamLimits.end &&
+      this.playbackStartTime_ >= streamLimits.start) {
+    streamStartTime = this.playbackStartTime_;
+  } else if (this.manifestInfo.live) {
     shaka.asserts.assert(streamLimits.end != Number.POSITIVE_INFINITY);
     streamStartTime = streamLimits.end;
   } else {
-    // If a specific start time was set, and it's within the stream limits, use
-    // that as the start time.
-    if (this.playbackStartTime_ &&
-        this.playbackStartTime_ <= streamLimits.end &&
-        this.playbackStartTime_ >= streamLimits.start) {
-      streamStartTime = this.playbackStartTime_;
-    } else {
-      streamStartTime = streamLimits.start;
-    }
+    streamStartTime = streamLimits.start;
   }
 
   shaka.log.info('Starting each stream from', streamStartTime);


### PR DESCRIPTION
It is nice to be able to set the playhead position on in-progress recordings, which use "live" manifests.

Interesting note:

We ran into this because we were setting the starting playback position by changing currentTime directly on the video node. Big, big, big mistake for in progress recordings! If we set the playhead too far into the past before beginPlayback gets called, the liveEdgeOffset gets very large, and users are unable to scrub into the future. It may be worth updating docs so that others don't run into this same trap.
