### PR TITLE
Add support for 302 redirect

### DIFF
--- a/lib/util/failover_uri.js
+++ b/lib/util/failover_uri.js
@@ -168,6 +168,9 @@ shaka.util.FailoverUri.prototype.createRequest_ =
         // effectively cache every response.
         this.requestPromise_ = null;
         this.request_ = null;
+	if(xhr.responseURL) {
+		this.urls.unshift(new goog.Uri(xhr.responseURL));
+	}
         return Promise.resolve(xhr.response);
       }));
 


### PR DESCRIPTION
Add support for 302 redirect in browsers that have responseURL implemented for XHR per:
https://xhr.spec.whatwg.org/#the-responseurl-attribute

See also:
https://github.com/google/shaka-player/issues/225
