### PR TITLE
Add support for 302 redirect

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
 Philo Inc. <*@philo.com>
+Robert Colantuoni <rgc@colantuoni.com>
 Roi Lipman <roilipman@gmail.com>
 Sanborn Hilland <sanbornh@rogers.com>
 TalkTalk Plc <*@talktalkplc.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,6 +31,7 @@ Jono Ward <jonoward@gmail.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
+Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>
 Sanborn Hilland <sanbornh@rogers.com>

--- a/lib/dash/mpd_parser.js
+++ b/lib/dash/mpd_parser.js
@@ -36,12 +36,13 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * Numbers, times, and byte ranges are set to null if they cannot be parsed.
  *
  * @param {string} source The MPD XML text.
- * @param {!Array.<!goog.Uri>} url The MPD URL for relative BaseURL resolution.
+ * @param {!Array.<!goog.Uri>} origUrl MPD URL for original download location.
+ * @param {!Array.<!goog.Uri>} baseUrl MPD URL for relative BaseURL resolution.
  * @return {shaka.dash.mpd.Mpd}
  *
  * @see ISO/IEC 23009-1
  */
-shaka.dash.mpd.parseMpd = function(source, url) {
+shaka.dash.mpd.parseMpd = function(source, origUrl, baseUrl) {
   var parser = new DOMParser();
   var xml = parser.parseFromString(source, 'text/xml');
 
@@ -51,7 +52,7 @@ shaka.dash.mpd.parseMpd = function(source, url) {
   }
 
   // Construct a virtual parent for the MPD to use in resolving relative URLs.
-  var parent = { baseUrl: url };
+  var parent = { origUrl: origUrl, baseUrl: baseUrl };
 
   return shaka.dash.mpd.parseChild_(parent, xml, shaka.dash.mpd.Mpd);
 };
@@ -88,6 +89,9 @@ shaka.dash.mpd.Mpd = function() {
 
   /** @type {string} */
   this.type = 'static';
+
+  /** @type {Array.<!goog.Uri>} */
+  this.origUrl = null;
 
   /** @type {Array.<!goog.Uri>} */
   this.baseUrl = null;
@@ -869,7 +873,7 @@ shaka.dash.mpd.Mpd.prototype.parse = function(parent, elem) {
   var mpd = shaka.dash.mpd;
 
   // Parse attributes.
-  this.url = parent.baseUrl;
+  this.url = parent.origUrl;
   this.id = mpd.parseAttr_(elem, 'id', mpd.parseString_);
   this.type = mpd.parseAttr_(elem, 'type', mpd.parseString_) || 'static';
   this.mediaPresentationDuration = mpd.parseAttr_(

--- a/lib/dash/mpd_request.js
+++ b/lib/dash/mpd_request.js
@@ -65,7 +65,7 @@ shaka.dash.MpdRequest.prototype.send = function() {
       /** @param {!ArrayBuffer|string} data */
       function(data) {
         var mpd = shaka.dash.mpd.parseMpd(
-            /** @type {string} */ (data), url.urls);
+            /** @type {string} */ (data), url.urls, [url.currentUrl]);
         if (mpd) {
           return Promise.resolve(mpd);
         }

--- a/lib/util/failover_uri.js
+++ b/lib/util/failover_uri.js
@@ -56,6 +56,9 @@ shaka.util.FailoverUri = function(callback, urls, opt_startByte, opt_endByte) {
 
   /** @private {shaka.util.FailoverUri.NetworkCallback} */
   this.callback_ = callback;
+
+  /** @type {goog.Uri} */
+  this.currentUrl = null;
 };
 
 
@@ -134,6 +137,7 @@ shaka.util.FailoverUri.prototype.abortFetch = function() {
     this.requestPromise_ = null;
     this.request_.abort();
     this.request_ = null;
+    this.currentUrl = null;
   }
 };
 
@@ -168,8 +172,11 @@ shaka.util.FailoverUri.prototype.createRequest_ =
         // effectively cache every response.
         this.requestPromise_ = null;
         this.request_ = null;
+        this.currentUrl = null;
         if (xhr.responseURL) {
-          this.urls[i] = new goog.Uri(xhr.responseURL);
+          this.currentUrl = new goog.Uri(xhr.responseURL);
+        } else {
+          this.currentUrl = this.urls[i];
         }
         return Promise.resolve(xhr.response);
       }));

--- a/lib/util/failover_uri.js
+++ b/lib/util/failover_uri.js
@@ -168,6 +168,9 @@ shaka.util.FailoverUri.prototype.createRequest_ =
         // effectively cache every response.
         this.requestPromise_ = null;
         this.request_ = null;
+        if (xhr.responseURL) {
+          this.urls[i] = new goog.Uri(xhr.responseURL);
+        }
         return Promise.resolve(xhr.response);
       }));
 

--- a/spec/mpd_parser_base_url_spec.js
+++ b/spec/mpd_parser_base_url_spec.js
@@ -147,7 +147,9 @@ describe('mpd.BaseUrl', function() {
       '</MPD>'].join('\n');
     var mpdUrl = 'http://example.com/dash/test.mpd';
 
-    var mpd = shaka.dash.mpd.parseMpd(source, createFailover(mpdUrl).urls);
+    var mpd = shaka.dash.mpd.parseMpd(source,
+        createFailover(mpdUrl).urls,
+        createFailover(mpdUrl).urls);
     expect(mpd).toBeTruthy();
     expect(mpd.baseUrl.toString()).toBe(mpdUrl);
     expect(mpd.periods.length).toBe(1);

--- a/spec/mpd_spec.js
+++ b/spec/mpd_spec.js
@@ -550,8 +550,9 @@ describe('mpd', function() {
       '  <Location>updated_mpd</Location>',
       '</MPD>'].join('\n');
 
-    var mpd = shaka.dash.mpd.parseMpd(source, createFailover(
-        'http://example.com/mpd').urls);
+    var mpd = shaka.dash.mpd.parseMpd(source,
+        createFailover('http://example.com/mpd').urls,
+        createFailover('http://example.com/mpd').urls);
     expect(mpd.updateLocation.toString()).toBe(
         'http://example.com/updated_mpd');
   });


### PR DESCRIPTION
Add support for responseURL where supported.

XMLHttpRequest spec 4.6.1 adds the responseUrl attribute:
https://xhr.spec.whatwg.org/#the-responseurl-attribute

**Browser Support**
Chromium: https://code.google.com/p/chromium/issues/detail?id=377583
Webkit: https://bugs.webkit.org/show_bug.cgi?id=136938
Mozilla: https://bugzilla.mozilla.org/show_bug.cgi?id=998076

A current use case is when the DASH manifest is located at a URL that is redirected via 302 to another location. Currently, the mpdParser will then pull the chunks from the original URI rather than the URl from which the manifest was ultimately downloaded.

**Example - Current Flow**
http://some.host.org/path/manifest.mpd returns 302 to http://other.host.org/path/manifest.mpd.

Subsequent requests for mp4 chunks will be:
http://some.host.org/path/chunk1.mp4
http://some.host.org/path/chunk2.mp4

If the server has been configured to 302 redirect for everything, this will result in each of the above chunks also having a 302 redirect. If the server hasn't been configured, then they will fail.

**Example - Proposed Flow**
http://some.host.org/path/manifest.mpd returns 302 to http://other.host.org/path/manifest.mpd.

Subsequent requests for mp4 chunks will be:
http://other.host.org/path/chunk1.mp4
http://other.host.org/path/chunk2.mp4

As the base_url should be the URI from which the manifest was downloaded.

In browsers without responseUrl support, flow will fallback to current.

