### PR TITLE
Correct instantiation of HttpVideoSource with no content protection.

### DIFF
--- a/app.js
+++ b/app.js
@@ -699,7 +699,7 @@ app.loadHttpStream = function() {
   var subtitlesUrl = document.getElementById('subtitlesUrlInput').value;
   var config = keySystem ?
                {'keySystem': keySystem, 'licenseServerUrl': licenseServerUrl} :
-               {};
+               {'keySystem': ''};
   app.load_(new shaka.player.HttpVideoSource(mediaUrl, subtitlesUrl, config));
 };
 

--- a/lib/player/http_video_source.js
+++ b/lib/player/http_video_source.js
@@ -33,8 +33,7 @@ goog.require('shaka.util.StringUtils');
  * Creates an HttpVideoSource.
  * @param {string} mediaUrl The media URL.
  * @param {string} textUrl The text URL, or empty string if no subtitles.
- * @param {shaka.player.DrmInfo.Config} drmInfoConfig A DrmInfo Config object,
- *     an empty object indicates unencrypted content.
+ * @param {shaka.player.DrmInfo.Config} drmInfoConfig A DrmInfo Config object.
  * @struct
  * @constructor
  * @implements {shaka.player.IVideoSource}


### PR DESCRIPTION
Passing an empty config object is no longer acceptable because the
keySystem property is mandatory on drmConfig objects.

Also modified HttpVideoSource constructor comment so that the drmConfig
comments are the single source of truth regarding well-formed drmConfig
objects.