### PR TITLE
Always build the same input files to a stable output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,6 +17,7 @@ Google Inc. <*@google.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
+Johan Sundström <oyasumi@gmail.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
 Philo Inc. <*@philo.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@ Jacob Trimble <modmaker@google.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Joey Parrish <joeyparrish@google.com>
+Johan Sundström <oyasumi@gmail.com>
 Jono Ward <jonoward@gmail.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>

--- a/build/lib.sh
+++ b/build/lib.sh
@@ -101,7 +101,8 @@ function closure_sources_0() {
 }
 
 function compile_0() {
-  xargs -0 java -jar "$dir"/third_party/closure/compiler.jar $closure_opts "$@"
+  sort -z | xargs -0 \
+    java -jar "$dir"/third_party/closure/compiler.jar $closure_opts "$@"
 }
 
 function lint_0() {


### PR DESCRIPTION
Leaning just on `find` for order, two different checkouts will produce different file list orders for different people building it, at the moment, on some OS:es / file systems. Sorting the input file list prior to compiling makes sure that built output will produce the same result no matter who builds it where, which is all sorts of helpful when the built file is also under version control.