### PR TITLE
Update end time of last segment in a period when new periods are added

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -298,9 +298,6 @@ shaka.dash.MpdUtils.fitSegmentReferences = function(
   /** @const {number} */
   var tolerance = shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS;
 
-  // TODO: Update this function if we modify the SegmentReference to account
-  // for @presentationTimeOffset.
-
   var firstReference = references[0];
   if (firstReference.startTime <= tolerance) {
     references[0] =

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -133,7 +133,7 @@ shaka.media.SegmentIndex.prototype.merge = function(references) {
       // expand last segment to the start of the next the period
       // so, it is valid to have end time updated to the
       // last segment reference in a period
-      if(r1.endTime != r2.endTime)
+      if (r1.endTime != r2.endTime)
       {
         goog.asserts.assert(r2.endTime - r1.endTime <=
             shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS &&

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -130,19 +130,19 @@ shaka.media.SegmentIndex.prototype.merge = function(references) {
       j++;
     } else {
       // when period is changed, fitSegmentReference will
-      // expand last segment to the start of the next the period
+      // expand last segment to the start of the next period
       // so, it is valid to have end time updated to the
       // last segment reference in a period
       if (r1.endTime != r2.endTime)
       {
-        goog.asserts.assert(r2.endTime - r1.endTime <=
+        goog.asserts.assert(r2.endTime > r1.endTime &&
+            r2.endTime - r1.endTime <=
             shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS &&
             i == this.references_.length - 1 &&
             j == references.length - 1,
-            'This should be un update of the last segment in a period');
+            'This should be an update of the last segment in a period');
         newReferences.push(r2);
-      }
-      else {
+      } else {
         // Drop the new reference if there's an old reference with the
         // same time.
         newReferences.push(r1);

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -129,9 +129,24 @@ shaka.media.SegmentIndex.prototype.merge = function(references) {
       shaka.log.warning('Refusing to rewrite original references on update!');
       j++;
     } else {
-      // Drop the new reference if there's an old reference with the same
-      // time.
-      newReferences.push(r1);
+      // when period is changed, fitSegmentReference will
+      // expand last segment to the start of the next the period
+      // so, it is valid to have end time updated to the
+      // last segment reference in a period
+      if(r1.endTime != r2.endTime)
+      {
+        goog.asserts.assert(r2.endTime - r1.endTime <=
+            shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS &&
+            i == this.references_.length - 1 &&
+            j == references.length - 1,
+            'This should be un update of the last segment in a period');
+        newReferences.push(r2);
+      }
+      else {
+        // Drop the new reference if there's an old reference with the
+        // same time.
+        newReferences.push(r1);
+      }
       i++;
       j++;
     }

--- a/test/segment_index_unit.js
+++ b/test/segment_index_unit.js
@@ -238,7 +238,7 @@ describe('SegmentIndex', /** @suppress {accessControls} */ function() {
       var references1 = [
         makeReference(1, 10, 20, uri(10)),
         makeReference(2, 20, 30, uri(20)),
-        makeReference(3, 30, 49.987, uri(30)),
+        makeReference(3, 30, 49.987, uri(30))
       ];
       var index1 = new shaka.media.SegmentIndex(references1);
 

--- a/test/segment_index_unit.js
+++ b/test/segment_index_unit.js
@@ -233,6 +233,28 @@ describe('SegmentIndex', /** @suppress {accessControls} */ function() {
       expect(index1.references_[1]).toEqual(references2[0]);
       expect(index1.references_[2]).toEqual(references2[1]);
     });
+
+    it('last live stream reference when period change', function() {
+      var references1 = [
+        makeReference(1, 10, 20, uri(10)),
+        makeReference(2, 20, 30, uri(20)),
+        makeReference(3, 30, 49.987, uri(30)),
+      ];
+      var index1 = new shaka.media.SegmentIndex(references1);
+
+      // when period is changed, fitSegmentReference will
+      // expand last segment to the start of the next the period
+      var references2 = [
+        makeReference(2, 20, 30, uri(20)),
+        makeReference(3, 30, 50, uri(30))
+      ];
+
+      index1.merge(references2);
+      expect(index1.references_.length).toBe(3);
+      expect(index1.references_[0]).toEqual(references1[0]);
+      expect(index1.references_[1]).toEqual(references2[0]);
+      expect(index1.references_[2]).toEqual(references2[1]);
+    });
   });
 
   describe('evict', function() {


### PR DESCRIPTION
Hi,
I have a multi period live stream and, at some time shaka was stopping with an INVALID_SEGMENT_INDEX error.

I discovered that the issue was caused by the fact that when segment references are merged at the manifest change, some of the segments are skipped, considered to be duplicates of the previous received segments. This is true in general, but when the period changes, last segment is expanded to end of the period (in MpdUtils.fitSegmentReferences). This updated segment was not merged into the final segment list which was causing a gap.

I added a unit test that reproduce the issue and I also made a fix for it. 
