### PR TITLE
Extern xhr error property

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Roi Lipman <roilipman@gmail.com>
 Sanborn Hilland <sanbornh@rogers.com>
 TalkTalk Plc <*@talktalkplc.com>
 uStudio Inc. <*@ustudio.com>
+Mattias Wadman <mattias.wadman@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -40,3 +40,4 @@ Thomas Stephens <thomas@ustudio.com>
 Timothy Drews <tdrews@google.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>
+Mattias Wadman <mattias.wadman@gmail.com>

--- a/externs/errors.js
+++ b/externs/errors.js
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2016 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @fileoverview Externs for additional Error properties.
+ *
+ * @externs
+ */
+
+
+/** @type {XMLHttpRequest} */
+Error.xhr;


### PR DESCRIPTION
Make it possible to access the response when requests fails.

I tried to change to `['xhr'] = ` but then the tests failed because of type error

Hope it's correct to target v1.6.x branch.