### PR TITLE
text_engine: fix remove when TextTrack is in disabled mode

### DIFF
--- a/lib/media/text_engine.js
+++ b/lib/media/text_engine.js
@@ -160,6 +160,11 @@ shaka.media.TextEngine.prototype.appendBuffer =
 shaka.media.TextEngine.prototype.remove = function(start, end) {
   // Start the operation asynchronously to avoid blocking the caller.
   return Promise.resolve().then(function() {
+    if (!this.track_.cues) {
+      // This TextTrack was disabled before we started work. When TextTracks
+      // move to disabled state their cues property is set to null
+      return
+    }
     this.removeWhere_(function(cue) {
       if (cue.startTime >= end || cue.endTime <= start) {
         // Outside the remove range.  Hang on to it.


### PR DESCRIPTION
If you disable CC the TextTrack ends up with cues set to null, which
breaks the async remove call on TextEngine. We should bail if there
are no cues.