### PR TITLE
Removed compiled conditional for logPrefix in stream.js.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -42,3 +42,4 @@ Timothy Drews <tdrews@google.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>
 Mattias Wadman <mattias.wadman@gmail.com>
+John Turner <john@ustudio.com>

--- a/lib/media/stream.js
+++ b/lib/media/stream.js
@@ -753,17 +753,16 @@ shaka.media.Stream.prototype.cancelUpdateTimer_ = function() {
 };
 
 
-if (!COMPILED) {
-  /**
-   * Returns a string with the form 'Stream MIME_TYPE:' for logging purposes.
-   *
-   * @return {string}
-   * @private
-   */
-  shaka.media.Stream.prototype.logPrefix_ = function() {
-    return 'Stream ' + this.mimeType_ + ':';
-  };
-}
+/**
+ * Returns a string with the form 'Stream MIME_TYPE:' for logging purposes.
+ *
+ * @return {string}
+ * @private
+ */
+shaka.media.Stream.prototype.logPrefix_ = function() {
+  return 'Stream ' + this.mimeType_ + ':';
+};
+
 
 
 /**


### PR DESCRIPTION
When using the closure compiler and shaka-player as a lib I'm seeing the following error: 
`Uncaught TypeError: this.O` is not a function associated with the `this.logPrefix_()` call in the following code block in `stream.js`:

```
shaka.media.Stream.prototype.onUpdate_ = function() {
  shaka.log.v2(this.logPrefix_(), 'onUpdate_');
  shaka.asserts.assert(this.streamInfo_);
  shaka.asserts.assert(this.segmentIndex_);
  shaka.asserts.assert((this.updateTimer_ != null) && !this.resyncing_);
  shaka.asserts.assert(!this.fetching_);

  if (this.started_ && !this.proceeded_) {
    shaka.log.v1(this.logPrefix_(), 'waiting to proceed...');
    this.updateTimer_ = null;
    return;
  }
```
`this.logPrefix_()` seems to only be defined when not compiled at line

```
if (!COMPILED) {
  /**
   * Returns a string with the form 'Stream MIME_TYPE:' for logging purposes.
   *
   * @return {string}
   * @private
   */
  shaka.media.Stream.prototype.logPrefix_ = function() {
    return 'Stream ' + this.mimeType_ + ':';
  };
}
```
This change occurred from the following commit: 49e34bc

Versions before this show no error while versions after do.

Setting COMPILED to false as well as removing the compiled check both resolve this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/shaka-player/362)
<!-- Reviewable:end -->
