### PR TITLE
Disable cache busting when URL starts with 'blob:'

### DIFF
--- a/lib/util/ajax_request.js
+++ b/lib/util/ajax_request.js
@@ -250,7 +250,8 @@ shaka.util.AjaxRequest.prototype.send = function() {
   this.xhr_ = new XMLHttpRequest();
 
   var url = this.url;
-  if (shaka.util.AjaxRequest.enableCacheBusting) {
+  if (shaka.util.AjaxRequest.enableCacheBusting &&
+      url.indexOf('blob:') != 0) {
     if ((this.estimator && !this.estimator.supportsCaching()) ||
         this.parameters.synchronizeClock) {
       // We cannot detect that a response was cached after the fact, so add a


### PR DESCRIPTION
This one is for issue https://github.com/google/shaka-player/issues/395.
