### PR TITLE
apply periodStart instead of timestampOffset to text reference times

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -346,14 +346,17 @@ shaka.media.MediaSourceEngine.prototype.getBuffered_ = function(contentType) {
  * @param {!ArrayBuffer|!ArrayBufferView} data
  * @param {?number} startTime
  * @param {?number} endTime
+ * @param {?number} periodStart
  * @return {!Promise}
  */
 shaka.media.MediaSourceEngine.prototype.appendBuffer =
-    function(contentType, data, startTime, endTime) {
+    function(contentType, data, startTime, endTime, periodStart) {
   if (contentType == 'text') {
     goog.asserts.assert(startTime != null && endTime != null,
                         'text streams do not have init segments!');
-    return this.textEngine_.appendBuffer(data, startTime, endTime);
+    goog.asserts.assert(periodStart != null,
+                        'must pass periodStart for text streams');
+    return this.textEngine_.appendBuffer(data, startTime, endTime, periodStart);
   }
   return this.enqueueOperation_(
       contentType,

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1312,8 +1312,8 @@ shaka.media.StreamingEngine.prototype.initSourceBuffer_ = function(
     if (this.destroyed_) return;
     shaka.log.v1(logPrefix, 'appending init segment');
 
-    return this.mediaSourceEngine_.appendBuffer(
-        mediaState.type, initSegment, null /* startTime */, null /* endTime */);
+    return this.mediaSourceEngine_.appendBuffer(mediaState.type, initSegment,
+        null /* startTime */, null /* endTime */, null /* periodStart */);
   }.bind(this)).catch(function(error) {
     mediaState.needInitSegment = true;
     return Promise.reject(error);
@@ -1337,13 +1337,15 @@ shaka.media.StreamingEngine.prototype.initSourceBuffer_ = function(
 shaka.media.StreamingEngine.prototype.append_ = function(
     mediaState, playheadTime, stream, reference, segment) {
   var logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+  var currentPeriodIndex = this.findPeriodContainingStream_(stream);
+  var currentPeriod = this.manifest_.periods[currentPeriodIndex];
 
   return this.evict_(mediaState, playheadTime).then(function() {
     if (this.destroyed_) return;
     shaka.log.v1(logPrefix, 'appending media segment');
 
-    return this.mediaSourceEngine_.appendBuffer(
-        mediaState.type, segment, reference.startTime, reference.endTime);
+    return this.mediaSourceEngine_.appendBuffer(mediaState.type, segment,
+        reference.startTime, reference.endTime, currentPeriod.startTime);
   }.bind(this)).then(function() {
     if (this.destroyed_) return;
     shaka.log.v2(logPrefix, 'appended media segment');

--- a/lib/media/text_engine.js
+++ b/lib/media/text_engine.js
@@ -114,14 +114,18 @@ shaka.media.TextEngine.prototype.destroy = function() {
  * @param {ArrayBuffer|ArrayBufferView} buffer
  * @param {number} startTime
  * @param {number} endTime
+ * @param {number} periodStart
  * @return {!Promise}
  */
 shaka.media.TextEngine.prototype.appendBuffer =
-    function(buffer, startTime, endTime) {
+    function(buffer, startTime, endTime, periodStart) {
   var offset = this.timestampOffset_;
 
-  startTime += offset;
-  endTime += offset;
+  // These times are derived from reference start and end times which are
+  // relative to the start of the period. The buffer should be relative to
+  // the presentation start time (AST), so we add the period start to adjust.
+  startTime += periodStart;
+  endTime += periodStart;
 
   // Start the operation asynchronously to avoid blocking the caller.
   return Promise.resolve().then(function() {


### PR DESCRIPTION
The start/end times are derived from reference times which have
already had the offsets applied. Without this patch, when there
is an offset present we buffer all available text segments at
stream start.