### PR TITLE
Add missing goog.require() dependencies

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -18,9 +18,11 @@
 goog.provide('shaka.dash.ContentProtection');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.MapUtils');
+goog.require('shaka.util.Uint8ArrayUtils');
 goog.require('shaka.util.XmlUtils');
 
 

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -31,6 +31,7 @@ goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.LanguageUtils');
+goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.MultiMap');
 goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.XmlUtils');

--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -20,6 +20,7 @@ goog.provide('shaka.dash.SegmentList');
 goog.require('goog.asserts');
 goog.require('shaka.dash.MpdUtils');
 goog.require('shaka.dash.SegmentBase');
+goog.require('shaka.log');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');
 goog.require('shaka.util.Error');

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -19,6 +19,8 @@ goog.provide('shaka.dash.SegmentTemplate');
 
 goog.require('goog.asserts');
 goog.require('shaka.dash.MpdUtils');
+goog.require('shaka.dash.SegmentBase');
+goog.require('shaka.log');
 goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -19,6 +19,7 @@ goog.provide('shaka.media.DrmEngine');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.EventManager');

--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -18,6 +18,7 @@
 goog.provide('shaka.media.ManifestParser');
 
 goog.require('goog.Uri');
+goog.require('shaka.log');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.Error');
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -18,6 +18,7 @@
 goog.provide('shaka.media.MediaSourceEngine');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.media.TextEngine');
 goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.util.Error');

--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -18,6 +18,7 @@
 goog.provide('shaka.media.Playhead');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.media.PresentationTimeline');
 goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.util.EventManager');

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -17,6 +17,9 @@
 
 goog.provide('shaka.media.PresentationTimeline');
 
+goog.require('goog.asserts');
+goog.require('shaka.log');
+
 
 
 /**

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -18,6 +18,7 @@
 goog.provide('shaka.media.StreamingEngine');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.media.MediaSourceEngine');
 goog.require('shaka.media.Playhead');
 goog.require('shaka.net.NetworkingEngine');

--- a/lib/net/data_uri_plugin.js
+++ b/lib/net/data_uri_plugin.js
@@ -17,6 +17,7 @@
 
 goog.provide('shaka.net.DataUriPlugin');
 
+goog.require('shaka.log');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');

--- a/lib/offline/db_engine.js
+++ b/lib/offline/db_engine.js
@@ -17,6 +17,7 @@
 
 goog.provide('shaka.offline.DBEngine');
 
+goog.require('goog.asserts');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.IDestroyable');

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -17,6 +17,7 @@
 
 goog.provide('shaka.offline.DownloadManager');
 
+goog.require('goog.asserts');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IDestroyable');

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -17,11 +17,13 @@
 
 goog.provide('shaka.offline.Storage');
 
+goog.require('goog.asserts');
 goog.require('shaka.Player');
 goog.require('shaka.media.DrmEngine');
 goog.require('shaka.media.ManifestParser');
 goog.require('shaka.offline.DBEngine');
 goog.require('shaka.offline.DownloadManager');
+goog.require('shaka.offline.OfflineManifestParser');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Functional');

--- a/lib/player.js
+++ b/lib/player.js
@@ -34,6 +34,7 @@ goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
 goog.require('shaka.util.IDestroyable');
+goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.PublicPromise');
 goog.require('shaka.util.StreamUtils');
 

--- a/lib/polyfill/patchedmediakeys_20140218.js
+++ b/lib/polyfill/patchedmediakeys_20140218.js
@@ -19,11 +19,13 @@ goog.provide('shaka.polyfill.PatchedMediaKeys.v20140218');
 
 goog.require('goog.asserts');
 goog.require('shaka.log');
+goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
 goog.require('shaka.util.Pssh');
 goog.require('shaka.util.PublicPromise');
+goog.require('shaka.util.Uint8ArrayUtils');
 
 
 /**

--- a/lib/util/config_utils.js
+++ b/lib/util/config_utils.js
@@ -17,6 +17,9 @@
 
 goog.provide('shaka.util.ConfigUtils');
 
+goog.require('goog.asserts');
+goog.require('shaka.log');
+
 
 /**
  * @param {!Object} destination

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -17,6 +17,7 @@
 
 goog.provide('shaka.util.StreamUtils');
 
+goog.require('shaka.log');
 goog.require('shaka.media.DrmEngine');
 goog.require('shaka.media.MediaSourceEngine');
 goog.require('shaka.util.Functional');

--- a/lib/util/string_utils.js
+++ b/lib/util/string_utils.js
@@ -17,6 +17,7 @@
 
 goog.provide('shaka.util.StringUtils');
 
+goog.require('shaka.log');
 goog.require('shaka.util.Error');
 
 


### PR DESCRIPTION
This change adds missing dependencies to shaka-player with the exception of adding 'shaka.offline.Storage' to 'shaka.offline.DownloadManager'. Doing so creates a circular dependency.

```
Checking the tests for type errors...
ERROR - Circular dependency detected: shaka.offline.Storage -> shaka.offline.DownloadManager -> shaka.offline.Storage

1 error(s), 0 warning(s)
```

I will look into resolving that circular dep in a dedicated change.