### PR TITLE
fitSegmentReferences: Check isLive() using presentationTimeline

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -409,6 +409,8 @@ shaka.dash.DashParser.prototype.parseManifest_ =
   this.updatePeriod_ = /** @type {number} */ (XmlUtils.parseAttr(
       mpd, 'minimumUpdatePeriod', XmlUtils.parseDuration, -1));
 
+  var presentationDuration = XmlUtils.parseAttr(
+      mpd, 'mediaPresentationDuration', XmlUtils.parseDuration);
   var presentationStartTime = XmlUtils.parseAttr(
       mpd, 'availabilityStartTime', XmlUtils.parseDate);
   var segmentAvailabilityDuration = XmlUtils.parseAttr(
@@ -429,9 +431,13 @@ shaka.dash.DashParser.prototype.parseManifest_ =
         presentationStartTime, presentationDelay);
   }
 
+  var isLive = presentationDuration == null ||
+      segmentAvailabilityDuration != null;
+
   /** @type {shaka.dash.DashParser.Context} */
   var context = {
     presentationTimeline: presentationTimeline,
+    isLive: isLive,
     period: null,
     periodInfo: null,
     adaptationSet: null,
@@ -439,7 +445,8 @@ shaka.dash.DashParser.prototype.parseManifest_ =
     bandwidth: undefined
   };
 
-  var periodsAndDuration = this.parsePeriods_(context, baseUris, mpd);
+  var periodsAndDuration = this.parsePeriods_(context, baseUris,
+      presentationDuration, mpd);
   var duration = periodsAndDuration.duration;
   var periods = periodsAndDuration.periods;
 
@@ -459,7 +466,6 @@ shaka.dash.DashParser.prototype.parseManifest_ =
   // This is the first manifest parse, so we cannot return until we calculate
   // the clock offset.
   var timingElements = XmlUtils.findChildren(mpd, 'UTCTiming');
-  var isLive = presentationTimeline.isLive();
   return this.parseUtcTiming_(
       baseUris, timingElements, isLive).then(function(offset) {
     // Detect calls to stop().
@@ -484,16 +490,15 @@ shaka.dash.DashParser.prototype.parseManifest_ =
  *
  * @param {shaka.dash.DashParser.Context} context
  * @param {!Array.<string>} baseUris
+ * @param {?number} presentationDuration
  * @param {!Element} mpd
  * @return {{periods: !Array.<shakaExtern.Period>, duration: ?number}}
  * @private
  */
 shaka.dash.DashParser.prototype.parsePeriods_ = function(
-    context, baseUris, mpd) {
+    context, baseUris, presentationDuration, mpd) {
   var Functional = shaka.util.Functional;
   var XmlUtils = shaka.util.XmlUtils;
-  var presentationDuration = XmlUtils.parseAttr(
-      mpd, 'mediaPresentationDuration', XmlUtils.parseDuration);
 
   var periods = [];
   var prevEnd = 0;

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -290,9 +290,10 @@ shaka.dash.MpdUtils.createTimeline = function(
  *
  * @param {?number} periodDuration
  * @param {!Array.<!shaka.media.SegmentReference>} references
+ * @param {!boolean} isLive
  */
 shaka.dash.MpdUtils.fitSegmentReferences = function(
-    periodDuration, references) {
+    periodDuration, references, isLive) {
   if (references.length == 0)
     return;
 
@@ -311,8 +312,11 @@ shaka.dash.MpdUtils.fitSegmentReferences = function(
             firstReference.startByte, firstReference.endByte);
   }
 
-  if (periodDuration == null || periodDuration == Number.POSITIVE_INFINITY)
+  if (isLive)
     return;
+
+  goog.asserts.assert(periodDuration != null,
+      'cannot have a null periodDuration for a non-live presentation');
 
   var lastReference = references[references.length - 1];
 

--- a/lib/dash/segment_base.js
+++ b/lib/dash/segment_base.js
@@ -152,7 +152,8 @@ shaka.dash.SegmentBase.createSegmentIndexFromUris = function(
             presentationTimeOffset);
       }
 
-      shaka.dash.MpdUtils.fitSegmentReferences(periodDuration, references);
+      shaka.dash.MpdUtils.fitSegmentReferences(periodDuration, references,
+          context.isLive);
       presentationTimeline.notifySegments(periodStartTime, references);
 
       // Since containers are never updated, we don't need to store the

--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -65,7 +65,7 @@ shaka.dash.SegmentList.createStream = function(context, segmentIndexMap) {
       context.periodInfo.start, context.periodInfo.duration, info.startNumber,
       context.representation.baseUris, info);
   shaka.dash.MpdUtils.fitSegmentReferences(
-      context.periodInfo.duration, references);
+      context.periodInfo.duration, references, context.isLive);
   if (segmentIndex) {
     segmentIndex.merge(references);
     segmentIndex.evict(

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -77,7 +77,7 @@ shaka.dash.SegmentTemplate.createStream = function(
 
     var references = SegmentTemplate.createFromTimeline_(context, info);
     shaka.dash.MpdUtils.fitSegmentReferences(
-        context.periodInfo.duration, references);
+        context.periodInfo.duration, references, context.isLive);
     if (segmentIndex) {
       segmentIndex.merge(references);
       segmentIndex.evict(


### PR DESCRIPTION
If we rely on duration != null in-progress recordings get their last segment stretched to the end.

Fix for #423 