### PR TITLE
Attempt to fetch one chunk prior on seeking

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -121,6 +121,22 @@ shaka.media.SegmentIndex.prototype.find = function(time) {
 
 
 /**
+ * Finds a SegmentReference immediately prior to the requested time.
+ *
+ * This function can trigger an update, which may add or remove
+ * SegmentReferences.
+ *
+ * @param {number} time The time in seconds.
+ * @return {shaka.media.SegmentReference} The SegmentReference prior to the
+ *     specified time, or null if no such SegmentReference exists.
+ */
+shaka.media.SegmentIndex.prototype.findBefore = function(time) {
+  var i = shaka.media.SegmentReference.find(this.references, time);
+  return i <= 0 ? null : this.references[i - 1];
+};
+
+
+/**
  * Integrates |segmentIndex| into this SegmentIndex. "Integration" is
  * implementation dependent, but can be assumed to combine the two
  * SegmentIndexes somehow. Assumes that both SegmentIndexes correspond to the

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -132,7 +132,7 @@ shaka.media.SegmentIndex.prototype.find = function(time) {
  */
 shaka.media.SegmentIndex.prototype.findBefore = function(time) {
   var i = shaka.media.SegmentReference.find(this.references, time);
-  return i <= 0 ? null : this.references[i - 1];
+  return i > 0 ? this.references[i - 1] : null;
 };
 
 

--- a/lib/media/stream.js
+++ b/lib/media/stream.js
@@ -648,9 +648,13 @@ shaka.media.Stream.prototype.getNext_ = function(
   if (last != null) {
     return last.endTime != null ? segmentIndex.find(last.endTime) : null;
   } else {
+    // Try to get the segment prior to currentTime in order to gracefully handle
+    // cases where the manifest description of segment durations is different
+    // than the actual duration of segments as per #330.
     // Return the last SegmentReference if no segments have been inserted so
     // that we will always compute a timestamp correction and resolve started().
-    return segmentIndex.find(currentTime) ||
+    return segmentIndex.findBefore(currentTime) ||
+           segmentIndex.find(currentTime) ||
            (segmentIndex.length() ? segmentIndex.last() : null);
   }
 };


### PR DESCRIPTION
As per issue #330, manifests are only required to be approx.
correct with respect to their description of the media segments.
In order to avoid stalling when seeking through content like this,
fetch the chunk prior to the one that supposedly contains the
current time.

This is an attempt to apply a similar fix to Ia7bb74d0120.