### PR TITLE
playhead reposition: treat anything with a duration as vod

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -324,7 +324,7 @@ shaka.media.Playhead.prototype.reposition_ = function(currentTime) {
   var start = timeline.getEarliestStart();
   var end = timeline.getSegmentAvailabilityEnd();
 
-  if (!timeline.isLive() ||
+  if (timeline.getDuration() < Number.POSITIVE_INFINITY ||
       timeline.getSegmentAvailabilityDuration() == Number.POSITIVE_INFINITY) {
     // If the presentation is live but has an infinite segment availability
     // duration then we can treat it as VOD since the start of the window is

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -63,14 +63,14 @@ describe('Playhead', function() {
       }
     });
 
-    timeline.isLive.and.returnValue(false);
+    timeline.getDuration.and.returnValue(60);
     timeline.getEarliestStart.and.returnValue(5);
     timeline.getSegmentAvailabilityStart.and.returnValue(5);
     timeline.getSegmentAvailabilityEnd.and.returnValue(60);
 
     // These tests should not cause these methods to be invoked.
+    timeline.isLive.and.throwError(new Error());
     timeline.getSegmentAvailabilityDuration.and.throwError(new Error());
-    timeline.getDuration.and.throwError(new Error());
     timeline.setDuration.and.throwError(new Error());
   });
 
@@ -181,7 +181,7 @@ describe('Playhead', function() {
       }
     };
 
-    timeline.isLive.and.returnValue(true);
+    timeline.getDuration.and.returnValue(Number.POSITIVE_INFINITY);
     timeline.getEarliestStart.and.returnValue(5);
     timeline.getSegmentAvailabilityStart.and.returnValue(5);
     timeline.getSegmentAvailabilityEnd.and.returnValue(60);
@@ -335,7 +335,7 @@ describe('Playhead', function() {
       }
     };
 
-    timeline.isLive.and.returnValue(false);
+    timeline.getDuration.and.returnValue(30);
     timeline.getEarliestStart.and.returnValue(5);
     timeline.getSegmentAvailabilityStart.and.returnValue(5);
     timeline.getSegmentAvailabilityEnd.and.returnValue(60);
@@ -389,7 +389,7 @@ describe('Playhead', function() {
     };
 
     // Live case:
-    timeline.isLive.and.returnValue(true);
+    timeline.getDuration.and.returnValue(Number.POSITIVE_INFINITY);
     timeline.getEarliestStart.and.returnValue(5);
     timeline.getSegmentAvailabilityStart.and.returnValue(5);
     timeline.getSegmentAvailabilityEnd.and.returnValue(60);
@@ -424,7 +424,7 @@ describe('Playhead', function() {
     expect(onSeek).toHaveBeenCalled();
 
     // VOD case:
-    timeline.isLive.and.returnValue(false);
+    timeline.getDuration.and.returnValue(30);
     timeline.getEarliestStart.and.returnValue(5);
     timeline.getSegmentAvailabilityStart.and.returnValue(5);
     timeline.getSegmentAvailabilityEnd.and.returnValue(60);


### PR DESCRIPTION
If there is a duration set the start of the window will not move.

We've been including a `timeShiftBufferDepth` equal to the duration for in-progress recordings. Otherwise the `presentationTimeline.isLive()` check fails.