### PR TITLE
Consider empty text cues buffered

### DIFF
--- a/lib/media/text_engine.js
+++ b/lib/media/text_engine.js
@@ -125,13 +125,10 @@ shaka.media.TextEngine.prototype.appendBuffer =
     // Parse the buffer and add the new cues.
     var cues = this.parser_(buffer, startTime, endTime);
 
-    if (!cues.length) {
-      // Init segments have no cues and no times.
+    if (startTime == null || endTime == null) {
+      // Init segments will not have start/end times passed
       return;
     }
-    // If cues were parsed, startTime and endTime should be non-null.
-    goog.asserts.assert(startTime != null && endTime != null,
-                        'start and end times should be non-null!');
 
     for (var i = 0; i < cues.length; ++i) {
       cues[i].startTime += offset;

--- a/test/media/text_engine_unit.js
+++ b/test/media/text_engine_unit.js
@@ -60,6 +60,22 @@ describe('TextEngine', function() {
       expect(mockTrack.addCue).not.toHaveBeenCalled();
     });
 
+    it('considers empty cues buffered', function(done) {
+      mockParser.and.returnValue([]);
+
+      textEngine.appendBuffer(dummyData, 0, 3).then(function() {
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 3);
+        expect(mockTrack.addCue).not.toHaveBeenCalled();
+        expect(mockTrack.removeCue).not.toHaveBeenCalled();
+
+        expect(textEngine.bufferStart()).toBe(0);
+        expect(textEngine.bufferEnd()).toBe(3);
+
+        mockTrack.addCue.calls.reset();
+        mockParser.calls.reset();
+      }).catch(fail).then(done);
+    });
+
     it('adds cues to the track', function(done) {
       mockParser.and.returnValue([1, 2, 3]);
 


### PR DESCRIPTION
Empty WebVTT cues are valid, and should still be considered buffered. 

By using a cues object with 0 length as a proxy to the init segment, we lose valid empty WebVTT segments. Instead, use existence of start/end as a proxy to init segments.

This regression was introduced in ab64c76ee90eafe6f8813c400a54eedfdf22bf81