### PR TITLE
Use type as a proxy to isLive in dash_parser

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -420,6 +420,8 @@ shaka.dash.DashParser.prototype.parseManifest_ =
       mpd, 'suggestedPresentationDelay', XmlUtils.parseDuration);
   var maxSegmentDuration = XmlUtils.parseAttr(
       mpd, 'maxSegmentDuration', XmlUtils.parseDuration);
+  var type = XmlUtils.parseAttr(
+      mpd, 'type', function(a) { return a; });
 
   var presentationTimeline;
   if (this.manifest_) {
@@ -432,8 +434,7 @@ shaka.dash.DashParser.prototype.parseManifest_ =
         presentationStartTime, presentationDelay);
   }
 
-  var isLive = presentationDuration == null ||
-      segmentAvailabilityDuration != null;
+  var isLive = (type == 'dynamic');
 
   /** @type {shaka.dash.DashParser.Context} */
   var context = {


### PR DESCRIPTION
Static assets do not necessarily specify a `mediaPresentationDuration`, so we cannot use `presentationDuration == null` as a proxy to `isLive`.

Confirmed that this fixes #463 