### PR TITLE
Do not prematurely evict segments from multi-period manifests

### DIFF
--- a/lib/dash/segment_list.js
+++ b/lib/dash/segment_list.js
@@ -62,14 +62,14 @@ shaka.dash.SegmentList.createStream = function(context, segmentIndexMap) {
   }
 
   var references = SegmentList.createSegmentReferences_(
-      context.periodInfo.start, context.periodInfo.duration, info.startNumber,
+      context.periodInfo.duration, info.startNumber,
       context.representation.baseUris, info);
   shaka.dash.MpdUtils.fitSegmentReferences(
       context.periodInfo.duration, references);
   if (segmentIndex) {
     segmentIndex.merge(references);
-    segmentIndex.evict(
-        context.presentationTimeline.getSegmentAvailabilityStart());
+    var start = context.presentationTimeline.getSegmentAvailabilityStart();
+    segmentIndex.evict(start - context.periodInfo.start);
   } else {
     context.presentationTimeline.notifySegments(
         context.periodInfo.start, references);
@@ -236,7 +236,6 @@ shaka.dash.SegmentList.checkSegmentListInfo_ = function(context, info) {
 /**
  * Creates an array of segment references for the given data.
  *
- * @param {number} periodStart in seconds.
  * @param {?number} periodDuration in seconds.
  * @param {number} startNumber
  * @param {!Array.<string>} baseUris
@@ -245,7 +244,7 @@ shaka.dash.SegmentList.checkSegmentListInfo_ = function(context, info) {
  * @private
  */
 shaka.dash.SegmentList.createSegmentReferences_ = function(
-    periodStart, periodDuration, startNumber, baseUris, info) {
+    periodDuration, startNumber, baseUris, info) {
   var MpdUtils = shaka.dash.MpdUtils;
 
   var max = info.mediaSegments.length;

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -80,8 +80,8 @@ shaka.dash.SegmentTemplate.createStream = function(
         context.periodInfo.duration, references);
     if (segmentIndex) {
       segmentIndex.merge(references);
-      segmentIndex.evict(
-          context.presentationTimeline.getSegmentAvailabilityStart());
+      var start = context.presentationTimeline.getSegmentAvailabilityStart();
+      segmentIndex.evict(start - context.periodInfo.start);
     } else {
       context.presentationTimeline.notifySegments(
           context.periodInfo.start, references);

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -41,13 +41,20 @@ shaka.test.Dash.makeDashParser = function() {
  *
  * @param {shakaExtern.Manifest} manifest
  * @param {!Array.<shaka.media.SegmentReference>} references
+ * @param {number} periodIndex
  */
-shaka.test.Dash.verifySegmentIndex = function(manifest, references) {
+shaka.test.Dash.verifySegmentIndex = function(
+    manifest, references, periodIndex) {
   expect(manifest).toBeTruthy();
-  var stream = manifest.periods[0].streamSets[0].streams[0];
+  var stream = manifest.periods[periodIndex].streamSets[0].streams[0];
   expect(stream).toBeTruthy();
   expect(stream.findSegmentPosition).toBeTruthy();
   expect(stream.getSegmentReference).toBeTruthy();
+
+  if (references.length == 0) {
+    expect(stream.findSegmentPosition(0)).toBe(null);
+    return;
+  }
 
   var positionBeforeFirst =
       stream.findSegmentPosition(references[0].startTime - 1);
@@ -84,7 +91,7 @@ shaka.test.Dash.testSegmentIndex = function(done, manifestText, references) {
   var filterPeriod = function() {};
   dashParser.start('dummy://foo', fakeNetEngine, filterPeriod, fail, fail)
       .then(function(manifest) {
-        shaka.test.Dash.verifySegmentIndex(manifest, references);
+        shaka.test.Dash.verifySegmentIndex(manifest, references, 0);
       })
       .catch(fail)
       .then(done);


### PR DESCRIPTION
`presentationTimeline.getSegmentAvailabilityStart()` yields a start time relative to the AST, but all of the reference start/end times are relative to their PTOs. We need to normalize the start time to the period before we evict any segments.