### PR TITLE
Deferring filling URI templates

### DIFF
--- a/lib/dash/mpd_processor.js
+++ b/lib/dash/mpd_processor.js
@@ -1144,12 +1144,12 @@ shaka.dash.MpdProcessor.prototype.makeSegmentIndexSourceViaIndexUrlTemplate_ =
   }
 
   // Generate the media URL.
-  var mediaUrl = shaka.dash.MpdUtils.createFromTemplate(
-      networkCallback, representation, 1, 0, 0, null);
-  if (!mediaUrl) {
+//  var mediaUrl = shaka.dash.MpdUtils.createFromTemplate(
+//      networkCallback, representation, 1, 0, 0, null);
+//  if (!mediaUrl) {
     // An error has already been logged.
-    return null;
-  }
+  //  return null;
+  //}
 
   // Generate a RepresentationIndex.
   var representationIndex = this.generateRepresentationIndex_(representation);

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -78,10 +78,10 @@ shaka.dash.MpdUtils.generateSegmentReferences = function(
     var timeReplacement = startTime;
 
     // Generate the media URL.
-    var mediaUrl = shaka.dash.MpdUtils.createFromTemplate(
+    var mediaUrlFunction = shaka.dash.MpdUtils.createFromTemplate(
         networkCallback, representation, segmentReplacement, timeReplacement,
         0 /* startByte */, null /* endByte */);
-    if (!mediaUrl) {
+    if (!mediaUrlFunction) {
       // An error has already been logged.
       return null;
     }
@@ -90,11 +90,13 @@ shaka.dash.MpdUtils.generateSegmentReferences = function(
         new shaka.media.SegmentReference(
             scaledStartTime,
             scaledEndTime,
-            mediaUrl));
+            mediaUrlFunction));
   }
 
   return references;
 };
+
+
 
 
 /**
@@ -106,7 +108,7 @@ shaka.dash.MpdUtils.generateSegmentReferences = function(
  * @param {number} time
  * @param {number} startByte
  * @param {?number} endByte
- * @return {shaka.util.FailoverUri}
+ * @return {shaka.util.FailoverUri} or pointer to function which return shaka.util.FailoverUri in case deferring filling URI templates
  */
 shaka.dash.MpdUtils.createFromTemplate = function(
     networkCallback, representation, number, time, startByte, endByte) {
@@ -125,22 +127,26 @@ shaka.dash.MpdUtils.createFromTemplate = function(
         null;
   }
 
+ 
+  var fillUrlTemplateFunction= function() {
   var filledUrlTemplate = shaka.dash.MpdUtils.fillUrlTemplate(
       urlTemplate,
       representation.id,
       number,
       representation.bandwidth,
       time);
-
   if (!filledUrlTemplate) {
     // An error has already been logged.
     return null;
   }
-
   var mediaUrl = shaka.util.FailoverUri.resolve(
       representation.baseUrl, filledUrlTemplate);
   return new shaka.util.FailoverUri(
       networkCallback, mediaUrl, startByte, endByte);
+      
+  }
+
+  return fillUrlTemplateFunction;
 };
 
 

--- a/lib/dash/timeline_segment_index_source.js
+++ b/lib/dash/timeline_segment_index_source.js
@@ -124,10 +124,10 @@ shaka.dash.TimelineSegmentIndexSource.prototype.create = function() {
     var timeReplacement = startTime;
 
     // Generate the media URL.
-    var mediaUrl = shaka.dash.MpdUtils.createFromTemplate(
+    var mediaUrlFunction = shaka.dash.MpdUtils.createFromTemplate(
         this.networkCallback_, this.representation_, segmentReplacement,
         timeReplacement, 0, null);
-    if (!mediaUrl) {
+    if (!mediaUrlFunction) {
       var error = new Error('Failed to generate media URL.');
       error.type = 'dash';
       return Promise.reject(error);
@@ -143,7 +143,7 @@ shaka.dash.TimelineSegmentIndexSource.prototype.create = function() {
         new shaka.media.SegmentReference(
             scaledStartTime - scaledPto,
             scaledEndTime - scaledPto,
-            mediaUrl));
+            mediaUrlFunction));
   }
 
   if (shaka.features.Live && this.mpd_.type == 'dynamic') {

--- a/lib/media/source_buffer_manager.js
+++ b/lib/media/source_buffer_manager.js
@@ -247,8 +247,16 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
     this.sourceBuffer_.timestampOffset = timestampOffset;
   }
 
+  var mediaUrl;
+  if (typeof(reference.url)=='function') { //deffered initialization
+      mediaUrl=reference.url.call();
+  }
+  else {
+      mediaUrl=reference.url;
+  }
+
   if (shaka.features.Offline &&
-      reference.url.isOfflineUri() && !this.contentDatabase_) {
+      mediaUrl.isOfflineUri() && !this.contentDatabase_) {
     this.contentDatabase_ = new shaka.util.ContentDatabaseReader();
     this.task_.append(
         function() {
@@ -274,8 +282,8 @@ shaka.media.SourceBufferManager.prototype.fetch = function(
         params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
         params.contentDatabase = this.contentDatabase_;
         return [
-          reference.url.fetch(params, this.estimator_),
-          shaka.util.FailoverUri.prototype.abortFetch.bind(reference.url)];
+          mediaUrl.fetch(params, this.estimator_),
+          shaka.util.FailoverUri.prototype.abortFetch.bind(mediaUrl)];
       }.bind(this));
 
   // Sanity check: appendBuffer() should not modify the MediaSource's duration

--- a/lib/util/content_database_writer.js
+++ b/lib/util/content_database_writer.js
@@ -426,8 +426,15 @@ shaka.util.ContentDatabaseWriter.prototype.requestSegment_ = function(
     reference) {
   var params = new shaka.util.AjaxRequest.Parameters();
   params.requestTimeoutMs = this.segmentRequestTimeout_ * 1000;
+  var mediaUrl;
+  if (typeof(reference.url)=='function') { //deffered initialization
+      mediaUrl=reference.url.call();
+  }
+  else {
+      mediaUrl=reference.url;
+  }  
   return /** @type {!Promise.<!ArrayBuffer>} */ (
-      reference.url.fetch(params, this.estimator_));
+      mediaUrl.fetch(params, this.estimator_));
 };
 
 


### PR DESCRIPTION
In version 1.6.x we noticed juggering playback on contents with over 2h of manifest.
This patch will solve the issue, we tried with manifest 4-6h long and we didn't spot further issues.

These are the issues related to this bug
https://github.com/google/shaka-player/issues/408
https://github.com/google/shaka-player/issues/405
https://github.com/google/shaka-player/issues/449