### PR TITLE
VTT on digit hour fix.

### DIFF
--- a/lib/media/vtt_text_parser.js
+++ b/lib/media/vtt_text_parser.js
@@ -182,8 +182,8 @@ shaka.media.VttTextParser.parseSetting = function(cue, word) {
  * @private
  */
 shaka.media.VttTextParser.parseTime_ = function(parser) {
-  // 00:00.000 or 00:00:00.000
-  var results = parser.readRegex(/(?:(\d{2,}):)?(\d{2}):(\d{2})\.(\d{3})/g);
+  // 00:00.000 or 00:00:00.000 or 0:00:00.000
+  var results = parser.readRegex(/(?:(\d{1,}):)?(\d{2}):(\d{2})\.(\d{3})/g);
   if (results == null)
     return null;
   // This capture is optional, but will still be in the array as undefined,


### PR DESCRIPTION
This fixes an issue that happens because ffmpeg, when converting from .srt to .vtt, strips the zero in '0n', where 0 < n < 10, from the times with hour < 10.

Thanks.
