### PR TITLE
Add config option for using segment relative timestamps for VTT

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -338,7 +338,8 @@ shakaExtern.ManifestConfiguration;
  *   rebufferingGoal: number,
  *   bufferingGoal: number,
  *   bufferBehind: number,
- *   ignoreTextStreamFailures: boolean
+ *   ignoreTextStreamFailures: boolean,
+ *   useRelativeCueTimestamps: boolean
  * }}
  *
  * @description
@@ -362,6 +363,9 @@ shakaExtern.ManifestConfiguration;
  * @property {boolean} ignoreTextStreamFailures
  *   If true, the player will ignore text stream failures and proceed to play
  *   other streams.
+ * @property {boolean} useRelativeCueTimestamps
+ *   If true, WebVTT cue timestamps will be treated as relative to the start
+ *   time of the VTT segment. Defaults to false.
  * @exportDoc
  */
 shakaExtern.StreamingConfiguration;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -212,6 +212,7 @@ shaka.media.MediaSourceEngine.prototype.destroy = function() {
  *   MIME types.  For example: { 'audio': 'audio/webm; codecs="vorbis"',
  *   'video': 'video/webm; codecs="vp9"', 'text': 'text/vtt' }.
  *   All types given must be supported.
+ * @param {shakaExtern.StreamingConfiguration} config
  *
  * @throws InvalidAccessError if blank MIME types are given
  * @throws NotSupportedError if unsupported MIME types are given
@@ -219,7 +220,7 @@ shaka.media.MediaSourceEngine.prototype.destroy = function() {
  *
  * @suppress {unnecessaryCasts}
  */
-shaka.media.MediaSourceEngine.prototype.init = function(typeConfig) {
+shaka.media.MediaSourceEngine.prototype.init = function(typeConfig, config) {
   for (var contentType in typeConfig) {
     var mimeType = typeConfig[contentType];
     goog.asserts.assert(
@@ -227,7 +228,8 @@ shaka.media.MediaSourceEngine.prototype.init = function(typeConfig) {
         'Type negotiation should happen before MediaSourceEngine.init!');
 
     if (contentType == 'text') {
-      this.textEngine_ = new shaka.media.TextEngine(this.textTrack_, mimeType);
+      this.textEngine_ =
+          new shaka.media.TextEngine(this.textTrack_, mimeType, config);
     } else {
       var sourceBuffer = this.mediaSource_.addSourceBuffer(mimeType);
       this.eventManager_.listen(

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -212,7 +212,7 @@ shaka.media.MediaSourceEngine.prototype.destroy = function() {
  *   MIME types.  For example: { 'audio': 'audio/webm; codecs="vorbis"',
  *   'video': 'video/webm; codecs="vp9"', 'text': 'text/vtt' }.
  *   All types given must be supported.
- * @param {shakaExtern.StreamingConfiguration} config
+ * @param {boolean} useRelativeCueTimestamps
  *
  * @throws InvalidAccessError if blank MIME types are given
  * @throws NotSupportedError if unsupported MIME types are given
@@ -220,7 +220,9 @@ shaka.media.MediaSourceEngine.prototype.destroy = function() {
  *
  * @suppress {unnecessaryCasts}
  */
-shaka.media.MediaSourceEngine.prototype.init = function(typeConfig, config) {
+shaka.media.MediaSourceEngine.prototype.init =
+    function(typeConfig, useRelativeCueTimestamps) {
+
   for (var contentType in typeConfig) {
     var mimeType = typeConfig[contentType];
     goog.asserts.assert(
@@ -229,7 +231,9 @@ shaka.media.MediaSourceEngine.prototype.init = function(typeConfig, config) {
 
     if (contentType == 'text') {
       this.textEngine_ =
-          new shaka.media.TextEngine(this.textTrack_, mimeType, config);
+          new shaka.media.TextEngine(this.textTrack_,
+                                     mimeType,
+                                     useRelativeCueTimestamps);
     } else {
       var sourceBuffer = this.mediaSource_.addSourceBuffer(mimeType);
       this.eventManager_.listen(

--- a/lib/media/mp4_ttml_parser.js
+++ b/lib/media/mp4_ttml_parser.js
@@ -31,7 +31,7 @@ goog.require('shaka.util.Mp4Parser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
+ * @param {boolean} useRelativeCueTimestamps Only used by the VTT parser
  * @return {!Array.<!TextTrackCue>}
  */
 shaka.media.Mp4TtmlParser =
@@ -47,7 +47,7 @@ shaka.media.Mp4TtmlParser =
     // mdat box found, use TtmlTextParser to parse the content
     return shaka.media.TtmlTextParser(
         reader.readBytes(boxSize - 8).buffer, offset,
-        segmentStartTime, segmentEndTime, null);
+        segmentStartTime, segmentEndTime, false);
   }
   var stppBoxSize = shaka.util.Mp4Parser.findSampleDescriptionBox(
       data, shaka.media.Mp4TtmlParser.BOX_TYPE_STPP);

--- a/lib/media/mp4_ttml_parser.js
+++ b/lib/media/mp4_ttml_parser.js
@@ -31,10 +31,12 @@ goog.require('shaka.util.Mp4Parser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  */
 shaka.media.Mp4TtmlParser =
-    function(data, offset, segmentStartTime, segmentEndTime) {
+    function(data, offset, segmentStartTime,
+             segmentEndTime, useRelativeCueTimestamps) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
@@ -45,7 +47,7 @@ shaka.media.Mp4TtmlParser =
     // mdat box found, use TtmlTextParser to parse the content
     return shaka.media.TtmlTextParser(
         reader.readBytes(boxSize - 8).buffer, offset,
-        segmentStartTime, segmentEndTime);
+        segmentStartTime, segmentEndTime, null);
   }
   var stppBoxSize = shaka.util.Mp4Parser.findSampleDescriptionBox(
       data, shaka.media.Mp4TtmlParser.BOX_TYPE_STPP);

--- a/lib/media/mp4_vtt_parser.js
+++ b/lib/media/mp4_vtt_parser.js
@@ -34,7 +34,7 @@ goog.require('shaka.util.TextParser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
+ * @param {boolean} useRelativeCueTimestamps Only used by the VTT parser
  * @return {!Array.<!TextTrackCue>}
  */
 shaka.media.Mp4VttParser =
@@ -53,7 +53,7 @@ shaka.media.Mp4VttParser =
     goog.asserts.assert(segmentEndTime != null, 'end time should not be null');
     return shaka.media.Mp4VttParser.parseData_(
         reader.readBytes(boxSize - 8).buffer, offset,
-        segmentStartTime, segmentEndTime, null);
+        segmentStartTime, segmentEndTime);
   }
   var wvttBoxSize = shaka.util.Mp4Parser.findSampleDescriptionBox(
       data, shaka.media.Mp4VttParser.BOX_TYPE_WVTT);
@@ -75,12 +75,11 @@ shaka.media.Mp4VttParser =
  * @param {number} offset
  * @param {number} segmentStartTime
  * @param {number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  * @private
  */
 shaka.media.Mp4VttParser.parseData_ = function(
-    data, offset, segmentStartTime, segmentEndTime, useRelativeCueTimestamps) {
+    data, offset, segmentStartTime, segmentEndTime) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
@@ -99,7 +98,7 @@ shaka.media.Mp4VttParser.parseData_ = function(
     }
     var cue = shaka.media.Mp4VttParser.parseCue_(
         reader.readBytes(boxSize - 8).buffer,
-        segmentStartTime, segmentEndTime, null);
+        segmentStartTime, segmentEndTime);
     if (cue)
       result.push(cue);
   }
@@ -114,12 +113,11 @@ shaka.media.Mp4VttParser.parseData_ = function(
  * @param {ArrayBuffer} data
  * @param {number} segmentStartTime
  * @param {number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
  * @return {TextTrackCue}
  * @private
  */
 shaka.media.Mp4VttParser.parseCue_ = function(
-    data, segmentStartTime, segmentEndTime, useRelativeCueTimestamps) {
+    data, segmentStartTime, segmentEndTime) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);

--- a/lib/media/mp4_vtt_parser.js
+++ b/lib/media/mp4_vtt_parser.js
@@ -34,10 +34,12 @@ goog.require('shaka.util.TextParser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  */
 shaka.media.Mp4VttParser =
-    function(data, offset, segmentStartTime, segmentEndTime) {
+    function(data, offset, segmentStartTime,
+             segmentEndTime, useRelativeCueTimestamps) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
@@ -51,7 +53,7 @@ shaka.media.Mp4VttParser =
     goog.asserts.assert(segmentEndTime != null, 'end time should not be null');
     return shaka.media.Mp4VttParser.parseData_(
         reader.readBytes(boxSize - 8).buffer, offset,
-        segmentStartTime, segmentEndTime);
+        segmentStartTime, segmentEndTime, null);
   }
   var wvttBoxSize = shaka.util.Mp4Parser.findSampleDescriptionBox(
       data, shaka.media.Mp4VttParser.BOX_TYPE_WVTT);
@@ -73,11 +75,12 @@ shaka.media.Mp4VttParser =
  * @param {number} offset
  * @param {number} segmentStartTime
  * @param {number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  * @private
  */
 shaka.media.Mp4VttParser.parseData_ = function(
-    data, offset, segmentStartTime, segmentEndTime) {
+    data, offset, segmentStartTime, segmentEndTime, useRelativeCueTimestamps) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
@@ -96,7 +99,7 @@ shaka.media.Mp4VttParser.parseData_ = function(
     }
     var cue = shaka.media.Mp4VttParser.parseCue_(
         reader.readBytes(boxSize - 8).buffer,
-        segmentStartTime, segmentEndTime);
+        segmentStartTime, segmentEndTime, null);
     if (cue)
       result.push(cue);
   }
@@ -111,11 +114,12 @@ shaka.media.Mp4VttParser.parseData_ = function(
  * @param {ArrayBuffer} data
  * @param {number} segmentStartTime
  * @param {number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {TextTrackCue}
  * @private
  */
 shaka.media.Mp4VttParser.parseCue_ = function(
-    data, segmentStartTime, segmentEndTime) {
+    data, segmentStartTime, segmentEndTime, useRelativeCueTimestamps) {
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -615,7 +615,8 @@ shaka.media.StreamingEngine.prototype.initStreams_ = function(streamsByType) {
         (stream.codecs ? '; codecs="' + stream.codecs + '"' : '');
   });
 
-  this.mediaSourceEngine_.init(typeConfig, this.config_);
+  this.mediaSourceEngine_.init(typeConfig,
+                               this.config_.useRelativeCueTimestamps);
   this.setDuration_();
 
   // Setup the initial set of Streams and then begin each update cycle. After

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -615,7 +615,7 @@ shaka.media.StreamingEngine.prototype.initStreams_ = function(streamsByType) {
         (stream.codecs ? '; codecs="' + stream.codecs + '"' : '');
   });
 
-  this.mediaSourceEngine_.init(typeConfig);
+  this.mediaSourceEngine_.init(typeConfig, this.config_);
   this.setDuration_();
 
   // Setup the initial set of Streams and then begin each update cycle. After

--- a/lib/media/text_engine.js
+++ b/lib/media/text_engine.js
@@ -30,10 +30,10 @@ goog.require('shaka.util.IDestroyable');
  * @constructor
  * @param {TextTrack} track
  * @param {string} mimeType
- * @param {shakaExtern.StreamingConfiguration} config
+ * @param {boolean} useRelativeCueTimestamps
  * @implements {shaka.util.IDestroyable}
  */
-shaka.media.TextEngine = function(track, mimeType, config) {
+shaka.media.TextEngine = function(track, mimeType, useRelativeCueTimestamps) {
   /** @private {?shaka.media.TextEngine.TextParser} */
   this.parser_ = shaka.media.TextEngine.parserMap_[mimeType];
 
@@ -56,8 +56,8 @@ shaka.media.TextEngine = function(track, mimeType, config) {
   /** @private {?number} */
   this.bufferEnd_ = null;
 
-  /** @private {?shakaExtern.StreamingConfiguration} */
-  this.config_ = config;
+  /** @private {boolean} */
+  this.useRelativeCueTimestamps_ = useRelativeCueTimestamps;
 };
 
 
@@ -66,7 +66,7 @@ shaka.media.TextEngine = function(track, mimeType, config) {
  *
  * @typedef {
  *   function(ArrayBuffer, number, ?number,
- *            ?number, ?boolean):!Array.<!TextTrackCue>
+ *            ?number, boolean):!Array.<!TextTrackCue>
  * }
  * @exportDoc
  */
@@ -164,7 +164,7 @@ shaka.media.TextEngine.prototype.appendBuffer =
                             offset,
                             startTime,
                             endTime,
-                            this.config_.useRelativeCueTimestamps);
+                            this.useRelativeCueTimestamps_);
 
     if (startTime == null || endTime == null) {
       // Init segments will not have start/end times passed

--- a/lib/media/text_engine.js
+++ b/lib/media/text_engine.js
@@ -30,9 +30,10 @@ goog.require('shaka.util.IDestroyable');
  * @constructor
  * @param {TextTrack} track
  * @param {string} mimeType
+ * @param {shakaExtern.StreamingConfiguration} config
  * @implements {shaka.util.IDestroyable}
  */
-shaka.media.TextEngine = function(track, mimeType) {
+shaka.media.TextEngine = function(track, mimeType, config) {
   /** @private {?shaka.media.TextEngine.TextParser} */
   this.parser_ = shaka.media.TextEngine.parserMap_[mimeType];
 
@@ -54,6 +55,9 @@ shaka.media.TextEngine = function(track, mimeType) {
 
   /** @private {?number} */
   this.bufferEnd_ = null;
+
+  /** @private {?shakaExtern.StreamingConfiguration} */
+  this.config_ = config;
 };
 
 
@@ -61,7 +65,8 @@ shaka.media.TextEngine = function(track, mimeType) {
  * Parses a text buffer into an array of cues.
  *
  * @typedef {
- *   function(ArrayBuffer, number, ?number, ?number):!Array.<!TextTrackCue>
+ *   function(ArrayBuffer, number, ?number,
+ *            ?number, ?boolean):!Array.<!TextTrackCue>
  * }
  * @exportDoc
  */
@@ -155,7 +160,11 @@ shaka.media.TextEngine.prototype.appendBuffer =
     if (!this.track_) return;
 
     // Parse the buffer and add the new cues.
-    var cues = this.parser_(buffer, offset, startTime, endTime);
+    var cues = this.parser_(buffer,
+                            offset,
+                            startTime,
+                            endTime,
+                            this.config_.useRelativeCueTimestamps);
 
     if (startTime == null || endTime == null) {
       // Init segments will not have start/end times passed

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -30,11 +30,14 @@ goog.require('shaka.util.StringUtils');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  * @throws {shaka.util.Error}
  */
 shaka.media.TtmlTextParser =
-    function(data, offset, segmentStartTime, segmentEndTime) {
+    function(data, offset, segmentStartTime,
+             segmentEndTime, useRelativeCueTimestamps) {
+
   var str = shaka.util.StringUtils.fromUTF8(data);
   var ret = [];
   var parser = new DOMParser();
@@ -49,7 +52,7 @@ shaka.media.TtmlTextParser =
   }
 
   if (xml) {
-    // Try to get the framerate, subRameRate and frameRateMultiplier
+    // Try to get the framerate, subFrameRate and frameRateMultiplier
     // if applicable
     var frameRate = null;
     var subFrameRate = null;

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -30,7 +30,7 @@ goog.require('shaka.util.StringUtils');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
+ * @param {boolean} useRelativeCueTimestamps Only used by the VTT parser
  * @return {!Array.<!TextTrackCue>}
  * @throws {shaka.util.Error}
  */

--- a/lib/media/vtt_text_parser.js
+++ b/lib/media/vtt_text_parser.js
@@ -30,11 +30,14 @@ goog.require('shaka.util.TextParser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  * @throws {shaka.util.Error}
  */
 shaka.media.VttTextParser =
-    function(data, offset, segmentStartTime, segmentEndTime) {
+    function(data, offset, segmentStartTime,
+             segmentEndTime, useRelativeCueTimestamps) {
+
   // Get the input as a string.  Normalize newlines to \n.
   var str = shaka.util.StringUtils.fromUTF8(data);
   str = str.replace(/\r\n|\r(?=[^\n]|$)/gm, '\n');
@@ -49,7 +52,10 @@ shaka.media.VttTextParser =
   var ret = [];
   for (var i = 1; i < blocks.length; i++) {
     var lines = blocks[i].split('\n');
-    var cue = shaka.media.VttTextParser.parseCue_(lines, offset);
+    var cue = shaka.media.VttTextParser.parseCue_(lines,
+                                                  offset,
+                                                  segmentStartTime,
+                                                  useRelativeCueTimestamps);
     if (cue)
       ret.push(cue);
   }
@@ -63,10 +69,14 @@ shaka.media.VttTextParser =
  *
  * @param {!Array.<string>} text
  * @param {number} offset
+ * @param {?number} segmentStartTime
+ * @param {?boolean} useRelativeCueTimestamps
  * @return {?TextTrackCue}
  * @private
  */
-shaka.media.VttTextParser.parseCue_ = function(text, offset) {
+shaka.media.VttTextParser.parseCue_ =
+    function(text, offset, segmentStartTime, useRelativeCueTimestamps) {
+
   // Skip empty blocks.
   if (text.length == 1 && !text[0])
     return null;
@@ -96,6 +106,12 @@ shaka.media.VttTextParser.parseCue_ = function(text, offset) {
 
   start += offset;
   end += offset;
+
+  // See issue #480 for discussion on deprecation
+  if (useRelativeCueTimestamps) {
+    start += segmentStartTime;
+    end += segmentStartTime;
+  }
 
   // Get the payload.
   var payload = text.slice(1).join('\n').trim();

--- a/lib/media/vtt_text_parser.js
+++ b/lib/media/vtt_text_parser.js
@@ -30,7 +30,7 @@ goog.require('shaka.util.TextParser');
  * @param {number} offset
  * @param {?number} segmentStartTime
  * @param {?number} segmentEndTime
- * @param {?boolean} useRelativeCueTimestamps
+ * @param {boolean} useRelativeCueTimestamps
  * @return {!Array.<!TextTrackCue>}
  * @throws {shaka.util.Error}
  */
@@ -70,7 +70,7 @@ shaka.media.VttTextParser =
  * @param {!Array.<string>} text
  * @param {number} offset
  * @param {?number} segmentStartTime
- * @param {?boolean} useRelativeCueTimestamps
+ * @param {boolean} useRelativeCueTimestamps
  * @return {?TextTrackCue}
  * @private
  */

--- a/lib/media/vtt_text_parser.js
+++ b/lib/media/vtt_text_parser.js
@@ -39,7 +39,7 @@ shaka.media.VttTextParser =
     function(data, offset, segmentStartTime,
              segmentEndTime, useRelativeCueTimestamps) {
 
-  if (segmentStartTime > 0) {
+  if (segmentStartTime > 0 && !useRelativeCueTimestamps) {
     shaka.log.warning('Period-relative text cue timestamps have been ' +
                       'deprecated. Segment-relative timestamps will be used ' +
                       'in V2.1.0 and on.');

--- a/lib/media/vtt_text_parser.js
+++ b/lib/media/vtt_text_parser.js
@@ -39,6 +39,12 @@ shaka.media.VttTextParser =
     function(data, offset, segmentStartTime,
              segmentEndTime, useRelativeCueTimestamps) {
 
+  if (segmentStartTime > 0) {
+    shaka.log.warning('Period-relative text cue timestamps have been ' +
+                      'deprecated. Segment-relative timestamps will be used ' +
+                      'in V2.1.0 and on.');
+  }
+
   // Get the input as a string.  Normalize newlines to \n.
   var str = shaka.util.StringUtils.fromUTF8(data);
   str = str.replace(/\r\n|\r(?=[^\n]|$)/gm, '\n');

--- a/lib/player.js
+++ b/lib/player.js
@@ -581,6 +581,12 @@ shaka.Player.prototype.configure = function(config) {
  * @private
  */
 shaka.Player.prototype.applyConfig_ = function() {
+  if (!this.config_.streaming.useRelativeCueTimestamps) {
+    shaka.log.warning('Period-relative text cue timestamps have been ' +
+                      'deprecated. Segment-relative timestamps will be used ' +
+                      'in V2.1.0 and on.');
+  }
+
   if (this.parser_) {
     this.parser_.configure(this.config_.manifest);
   }
@@ -1247,7 +1253,8 @@ shaka.Player.prototype.defaultConfig_ = function() {
       rebufferingGoal: 2,
       bufferingGoal: 30,
       bufferBehind: 30,
-      ignoreTextStreamFailures: false
+      ignoreTextStreamFailures: false,
+      useRelativeCueTimestamps: false
     },
     abr: {
       manager: this.defaultAbrManager_,

--- a/lib/player.js
+++ b/lib/player.js
@@ -581,12 +581,6 @@ shaka.Player.prototype.configure = function(config) {
  * @private
  */
 shaka.Player.prototype.applyConfig_ = function() {
-  if (!this.config_.streaming.useRelativeCueTimestamps) {
-    shaka.log.warning('Period-relative text cue timestamps have been ' +
-                      'deprecated. Segment-relative timestamps will be used ' +
-                      'in V2.1.0 and on.');
-  }
-
   if (this.parser_) {
     this.parser_.configure(this.config_.manifest);
   }

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -168,16 +168,7 @@ describe('CastUtils', function() {
           mediaSourceEngine = new shaka.media.MediaSourceEngine(
               video, mediaSource, /* TextTrack */ null);
 
-          var retry = shaka.net.NetworkingEngine.defaultRetryParameters();
-          var config = {
-            rebufferingGoal: 2,
-            bufferingGoal: 5,
-            retryParameters: retry,
-            bufferBehind: Infinity,
-            ignoreTextStreamFailures: false,
-            useRelativeCueTimestamps: false
-          };
-          mediaSourceEngine.init({'video': mimeType}, config);
+          mediaSourceEngine.init({'video': mimeType}, false);
           shaka.test.Util.fetch(initSegmentUrl).then(function(data) {
             return mediaSourceEngine.appendBuffer('video', data, null, null);
           }).then(function() {

--- a/test/cast/cast_utils_unit.js
+++ b/test/cast/cast_utils_unit.js
@@ -167,7 +167,17 @@ describe('CastUtils', function() {
         function onSourceOpen() {
           mediaSourceEngine = new shaka.media.MediaSourceEngine(
               video, mediaSource, /* TextTrack */ null);
-          mediaSourceEngine.init({'video': mimeType});
+
+          var retry = shaka.net.NetworkingEngine.defaultRetryParameters();
+          var config = {
+            rebufferingGoal: 2,
+            bufferingGoal: 5,
+            retryParameters: retry,
+            bufferBehind: Infinity,
+            ignoreTextStreamFailures: false,
+            useRelativeCueTimestamps: false
+          };
+          mediaSourceEngine.init({'video': mimeType}, config);
           shaka.test.Util.fetch(initSegmentUrl).then(function(data) {
             return mediaSourceEngine.appendBuffer('video', data, null, null);
           }).then(function() {

--- a/test/media/cue_integration.js
+++ b/test/media/cue_integration.js
@@ -65,6 +65,6 @@ describe('Cue', function() {
    */
   function parseVtt(text, opt_offset) {
     var data = shaka.util.StringUtils.toUTF8(text);
-    return shaka.media.VttTextParser(data, opt_offset || 0, null, null, null);
+    return shaka.media.VttTextParser(data, opt_offset || 0, null, null, false);
   }
 });

--- a/test/media/cue_integration.js
+++ b/test/media/cue_integration.js
@@ -65,6 +65,6 @@ describe('Cue', function() {
    */
   function parseVtt(text, opt_offset) {
     var data = shaka.util.StringUtils.toUTF8(text);
-    return shaka.media.VttTextParser(data, opt_offset || 0, null, null);
+    return shaka.media.VttTextParser(data, opt_offset || 0, null, null, null);
   }
 });

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -119,10 +119,20 @@ describe('DrmEngine', function() {
       eventManager.unlisten(mediaSource, 'sourceopen');
       mediaSourceEngine = new shaka.media.MediaSourceEngine(
           video, mediaSource, null);
+
+      var streamingConfig = {
+        rebufferingGoal: 2,
+        bufferingGoal: 5,
+        retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+        bufferBehind: Infinity,
+        ignoreTextStreamFailures: false,
+        useRelativeCueTimestamps: false
+      };
+
       mediaSourceEngine.init({
         'video': 'video/mp4; codecs="avc1.640015"',
         'audio': 'audio/mp4; codecs="mp4a.40.2"'
-      });
+      }, streamingConfig);
       done();
     });
   });

--- a/test/media/drm_engine_integration.js
+++ b/test/media/drm_engine_integration.js
@@ -120,19 +120,10 @@ describe('DrmEngine', function() {
       mediaSourceEngine = new shaka.media.MediaSourceEngine(
           video, mediaSource, null);
 
-      var streamingConfig = {
-        rebufferingGoal: 2,
-        bufferingGoal: 5,
-        retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
-        bufferBehind: Infinity,
-        ignoreTextStreamFailures: false,
-        useRelativeCueTimestamps: false
-      };
-
       mediaSourceEngine.init({
         'video': 'video/mp4; codecs="avc1.640015"',
         'audio': 'audio/mp4; codecs="mp4a.40.2"'
-      }, streamingConfig);
+      }, false);
       done();
     });
   });

--- a/test/media/mp4_ttml_parser_unit.js
+++ b/test/media/mp4_ttml_parser_unit.js
@@ -40,21 +40,21 @@ describe('Mp4TtmlParser', function() {
 
   it('parses init segment', function() {
     // Last two parameters are only used by mp4 vtt parser.
-    var ret = shaka.media.Mp4TtmlParser(ttmlInitSegment, 0, null, null);
+    var ret = shaka.media.Mp4TtmlParser(ttmlInitSegment, 0, null, null, null);
     // init segment doesn't have the subtitles. The code should verify
     // their declaration and proceed to the next segment.
     expect(ret).toEqual([]);
   });
 
   it('parses media segment', function() {
-    var ret = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null);
+    var ret = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, null);
     expect(ret.length).toBeGreaterThan(0);
   });
 
   it('accounts for offset', function() {
-    var ret1 = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null);
+    var ret1 = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, null);
     expect(ret1.length).toBeGreaterThan(0);
-    var ret2 = shaka.media.Mp4TtmlParser(ttmlSegment, 7, null, null);
+    var ret2 = shaka.media.Mp4TtmlParser(ttmlSegment, 7, null, null, null);
     expect(ret2.length).toBeGreaterThan(0);
 
     expect(ret2[0].startTime).toEqual(ret1[0].startTime + 7);
@@ -65,7 +65,7 @@ describe('Mp4TtmlParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_TTML);
     try {
-      shaka.media.Mp4TtmlParser(audioInitSegment, 0, null, null);
+      shaka.media.Mp4TtmlParser(audioInitSegment, 0, null, null, null);
       fail('Mp4 file with no ttml supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/mp4_ttml_parser_unit.js
+++ b/test/media/mp4_ttml_parser_unit.js
@@ -40,21 +40,21 @@ describe('Mp4TtmlParser', function() {
 
   it('parses init segment', function() {
     // Last two parameters are only used by mp4 vtt parser.
-    var ret = shaka.media.Mp4TtmlParser(ttmlInitSegment, 0, null, null, null);
+    var ret = shaka.media.Mp4TtmlParser(ttmlInitSegment, 0, null, null, false);
     // init segment doesn't have the subtitles. The code should verify
     // their declaration and proceed to the next segment.
     expect(ret).toEqual([]);
   });
 
   it('parses media segment', function() {
-    var ret = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, null);
+    var ret = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, false);
     expect(ret.length).toBeGreaterThan(0);
   });
 
   it('accounts for offset', function() {
-    var ret1 = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, null);
+    var ret1 = shaka.media.Mp4TtmlParser(ttmlSegment, 0, null, null, false);
     expect(ret1.length).toBeGreaterThan(0);
-    var ret2 = shaka.media.Mp4TtmlParser(ttmlSegment, 7, null, null, null);
+    var ret2 = shaka.media.Mp4TtmlParser(ttmlSegment, 7, null, null, false);
     expect(ret2.length).toBeGreaterThan(0);
 
     expect(ret2[0].startTime).toEqual(ret1[0].startTime + 7);
@@ -65,7 +65,7 @@ describe('Mp4TtmlParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_TTML);
     try {
-      shaka.media.Mp4TtmlParser(audioInitSegment, 0, null, null, null);
+      shaka.media.Mp4TtmlParser(audioInitSegment, 0, null, null, false);
       fail('Mp4 file with no ttml supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/mp4_vtt_parser_unit.js
+++ b/test/media/mp4_vtt_parser_unit.js
@@ -65,7 +65,7 @@ describe('Mp4vttParser', function() {
   it('parses init segment', function() {
     // init segment doesn't have the subtitles. The code should verify
     // their declaration and proceed to the next segment.
-    var ret = shaka.media.Mp4VttParser(vttInitSegment, 0, null, null, null);
+    var ret = shaka.media.Mp4VttParser(vttInitSegment, 0, null, null, false);
     expect(ret).toEqual([]);
   });
 
@@ -76,7 +76,7 @@ describe('Mp4vttParser', function() {
          {start: 20, end: 40, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 0, 20, 40, null);
+    var result = shaka.media.Mp4VttParser(vttSegment, 0, 20, 40, false);
     verifyHelper(cues, result);
   });
 
@@ -89,7 +89,7 @@ describe('Mp4vttParser', function() {
            'You\'re a fool for traveling alone,\nso completely unprepared.\n',
            vertical: 'lr', line: 1}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 20, 40, null);
+    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 20, 40, false);
     verifyHelper(cues, result);
   });
 
@@ -100,7 +100,7 @@ describe('Mp4vttParser', function() {
          {start: 27, end: 47, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 7, 20, 40, null);
+    var result = shaka.media.Mp4VttParser(vttSegment, 7, 20, 40, false);
     verifyHelper(cues, result);
   });
 
@@ -108,7 +108,7 @@ describe('Mp4vttParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_VTT);
     try {
-      shaka.media.Mp4VttParser(audioInitSegment, 0, 20, 40, null);
+      shaka.media.Mp4VttParser(audioInitSegment, 0, 20, 40, false);
       fail('Mp4 file with no vtt supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/mp4_vtt_parser_unit.js
+++ b/test/media/mp4_vtt_parser_unit.js
@@ -65,7 +65,7 @@ describe('Mp4vttParser', function() {
   it('parses init segment', function() {
     // init segment doesn't have the subtitles. The code should verify
     // their declaration and proceed to the next segment.
-    var ret = shaka.media.Mp4VttParser(vttInitSegment, 0, null, null);
+    var ret = shaka.media.Mp4VttParser(vttInitSegment, 0, null, null, null);
     expect(ret).toEqual([]);
   });
 
@@ -76,7 +76,7 @@ describe('Mp4vttParser', function() {
          {start: 20, end: 40, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 0, 20, 40);
+    var result = shaka.media.Mp4VttParser(vttSegment, 0, 20, 40, null);
     verifyHelper(cues, result);
   });
 
@@ -89,7 +89,7 @@ describe('Mp4vttParser', function() {
            'You\'re a fool for traveling alone,\nso completely unprepared.\n',
            vertical: 'lr', line: 1}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 20, 40);
+    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 20, 40, null);
     verifyHelper(cues, result);
   });
 
@@ -100,7 +100,7 @@ describe('Mp4vttParser', function() {
          {start: 27, end: 47, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 7, 20, 40);
+    var result = shaka.media.Mp4VttParser(vttSegment, 7, 20, 40, null);
     verifyHelper(cues, result);
   });
 
@@ -108,7 +108,7 @@ describe('Mp4vttParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_VTT);
     try {
-      shaka.media.Mp4VttParser(audioInitSegment, 0, 20, 40);
+      shaka.media.Mp4VttParser(audioInitSegment, 0, 20, 40, null);
       fail('Mp4 file with no vtt supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -287,7 +287,8 @@ describe('StreamingEngine', function() {
       bufferingGoal: 5,
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
       bufferBehind: 15,
-      ignoreTextStreamFailures: false
+      ignoreTextStreamFailures: false,
+      useRelativeCueTimestamps: false
     };
     streamingEngine = new shaka.media.StreamingEngine(
         playhead,

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -458,7 +458,7 @@ describe('StreamingEngine', function() {
             'audio': 'audio/mp4; codecs="mp4a.40.2"',
             'video': 'video/mp4; codecs="avc1.42c01e"',
             'text': 'text/vtt'
-          });
+          }, false);
       expect(mediaSourceEngine.init.calls.count()).toBe(1);
       mediaSourceEngine.init.calls.reset();
 

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -341,7 +341,8 @@ describe('StreamingEngine', function() {
         bufferingGoal: 5,
         retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
         bufferBehind: Infinity,
-        ignoreTextStreamFailures: false
+        ignoreTextStreamFailures: false,
+        useRelativeCueTimestamps: false
       };
     }
 
@@ -1488,7 +1489,8 @@ describe('StreamingEngine', function() {
         bufferingGoal: 1,
         retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
         bufferBehind: 10,
-        ignoreTextStreamFailures: false
+        ignoreTextStreamFailures: false,
+        useRelativeCueTimestamps: false
       };
 
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
@@ -1568,7 +1570,8 @@ describe('StreamingEngine', function() {
         bufferingGoal: 1,
         retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
         bufferBehind: 10,
-        ignoreTextStreamFailures: false
+        ignoreTextStreamFailures: false,
+        useRelativeCueTimestamps: false
       };
 
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
@@ -1633,7 +1636,8 @@ describe('StreamingEngine', function() {
         bufferingGoal: 1,
         retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
         bufferBehind: 10,
-        ignoreTextStreamFailures: false
+        ignoreTextStreamFailures: false,
+        useRelativeCueTimestamps: false
       };
 
       mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);

--- a/test/media/text_engine_unit.js
+++ b/test/media/text_engine_unit.js
@@ -22,6 +22,7 @@ describe('TextEngine', function() {
 
   var mockParser;
   var mockTrack;
+  var mockConfig;
   var textEngine;
 
   beforeAll(function() {
@@ -31,8 +32,16 @@ describe('TextEngine', function() {
   beforeEach(function() {
     mockParser = jasmine.createSpy('mockParser');
     mockTrack = createMockTrack();
+    mockConfig = {
+      rebufferingGoal: 2,
+      bufferingGoal: 5,
+      retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+      bufferBehind: Infinity,
+      ignoreTextStreamFailures: false,
+      useRelativeCueTimestamps: false
+    };
     TextEngine.registerParser(dummyMimeType, mockParser);
-    textEngine = new TextEngine(mockTrack, dummyMimeType);
+    textEngine = new TextEngine(mockTrack, dummyMimeType, mockConfig);
   });
 
   afterEach(function() {

--- a/test/media/text_engine_unit.js
+++ b/test/media/text_engine_unit.js
@@ -64,7 +64,7 @@ describe('TextEngine', function() {
       mockParser.and.returnValue([]);
 
       textEngine.appendBuffer(dummyData, 0, 3).then(function() {
-        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3);
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3, false);
         expect(mockTrack.addCue).not.toHaveBeenCalled();
         expect(mockTrack.removeCue).not.toHaveBeenCalled();
 
@@ -80,7 +80,7 @@ describe('TextEngine', function() {
       mockParser.and.returnValue([1, 2, 3]);
 
       textEngine.appendBuffer(dummyData, 0, 3).then(function() {
-        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3);
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3, false);
         expect(mockTrack.addCue).toHaveBeenCalledWith(1);
         expect(mockTrack.addCue).toHaveBeenCalledWith(2);
         expect(mockTrack.addCue).toHaveBeenCalledWith(3);
@@ -92,7 +92,7 @@ describe('TextEngine', function() {
         mockParser.and.returnValue([4, 5]);
         return textEngine.appendBuffer(dummyData, 3, 5);
       }).then(function() {
-        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 3, 5);
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 3, 5, false);
         expect(mockTrack.addCue).toHaveBeenCalledWith(4);
         expect(mockTrack.addCue).toHaveBeenCalledWith(5);
       }).catch(fail).then(done);
@@ -170,7 +170,7 @@ describe('TextEngine', function() {
       });
 
       textEngine.appendBuffer(dummyData, 0, 3).then(function() {
-        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3);
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 0, 0, 3, false);
         expect(mockTrack.addCue).toHaveBeenCalledWith(createFakeCue(0, 1));
         expect(mockTrack.addCue).toHaveBeenCalledWith(createFakeCue(2, 3));
 
@@ -178,7 +178,7 @@ describe('TextEngine', function() {
         textEngine.setTimestampOffset(4);
         return textEngine.appendBuffer(dummyData, 0, 3);
       }).then(function() {
-        expect(mockParser).toHaveBeenCalledWith(dummyData, 4, 0, 3);
+        expect(mockParser).toHaveBeenCalledWith(dummyData, 4, 0, 3, false);
         expect(mockTrack.addCue).toHaveBeenCalledWith(createFakeCue(4, 5));
         expect(mockTrack.addCue).toHaveBeenCalledWith(createFakeCue(6, 7));
       }).catch(fail).then(done);

--- a/test/media/text_engine_unit.js
+++ b/test/media/text_engine_unit.js
@@ -22,7 +22,6 @@ describe('TextEngine', function() {
 
   var mockParser;
   var mockTrack;
-  var mockConfig;
   var textEngine;
 
   beforeAll(function() {
@@ -32,16 +31,8 @@ describe('TextEngine', function() {
   beforeEach(function() {
     mockParser = jasmine.createSpy('mockParser');
     mockTrack = createMockTrack();
-    mockConfig = {
-      rebufferingGoal: 2,
-      bufferingGoal: 5,
-      retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
-      bufferBehind: Infinity,
-      ignoreTextStreamFailures: false,
-      useRelativeCueTimestamps: false
-    };
     TextEngine.registerParser(dummyMimeType, mockParser);
-    textEngine = new TextEngine(mockTrack, dummyMimeType, mockConfig);
+    textEngine = new TextEngine(mockTrack, dummyMimeType, false);
   });
 
   afterEach(function() {

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -400,7 +400,7 @@ describe('TtmlTextParser', function() {
     var data = shaka.util.StringUtils.toUTF8(text);
     // Last two parameters are only used by mp4 vtt parser.
     var result =
-        shaka.media.TtmlTextParser(data, opt_offset || 0, null, null, null);
+        shaka.media.TtmlTextParser(data, opt_offset || 0, null, null, false);
     expect(result).toBeTruthy();
     expect(result.length).toBe(cues.length);
     for (var i = 0; i < cues.length; i++) {
@@ -429,7 +429,7 @@ describe('TtmlTextParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT, code);
     var data = shaka.util.StringUtils.toUTF8(text);
     try {
-      shaka.media.TtmlTextParser(data, 0, null, null, null);
+      shaka.media.TtmlTextParser(data, 0, null, null, false);
       fail('Invalid TTML file supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -399,7 +399,8 @@ describe('TtmlTextParser', function() {
   function verifyHelper(cues, text, opt_offset) {
     var data = shaka.util.StringUtils.toUTF8(text);
     // Last two parameters are only used by mp4 vtt parser.
-    var result = shaka.media.TtmlTextParser(data, opt_offset || 0, null, null);
+    var result =
+        shaka.media.TtmlTextParser(data, opt_offset || 0, null, null, null);
     expect(result).toBeTruthy();
     expect(result.length).toBe(cues.length);
     for (var i = 0; i < cues.length; i++) {
@@ -428,7 +429,7 @@ describe('TtmlTextParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT, code);
     var data = shaka.util.StringUtils.toUTF8(text);
     try {
-      shaka.media.TtmlTextParser(data, 0, null, null);
+      shaka.media.TtmlTextParser(data, 0, null, null, null);
       fail('Invalid TTML file supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/vtt_text_parser_unit.js
+++ b/test/media/vtt_text_parser_unit.js
@@ -340,6 +340,26 @@ describe('VttTextParser', function() {
         'Test');
   });
 
+  it('uses relative timestamps if configured to', function() {
+    verifyHelper(
+        [
+          {
+            start: 40, // Note these are 20s off of the cue
+            end: 60,   // because using relative timestamps
+            text: 'Test',
+            align: 'middle',
+            size: 56,
+            vertical: 'lr'
+          }
+        ],
+        'WEBVTT\n\n' +
+        '0:00:20.000 --> 0:00:40.000 align:middle size:56% vertical:lr\n' +
+        'Test',
+        undefined,
+        20,
+        true);
+  });
+
   it('rejects invalid settings', function() {
     errorHelper(shaka.util.Error.Code.INVALID_TEXT_SETTINGS,
                 'WEBVTT\n\n00:00.000 --> 00:00.010 vertical:es\nTest');
@@ -359,17 +379,22 @@ describe('VttTextParser', function() {
                 'WEBVTT\n\n00:00.000 --> 00:00.010 align:foo\nTest');
   });
 
-
   /**
    * @param {!Array} cues
    * @param {string} text
    * @param {number=} opt_offset
+   * @param {number=} opt_startTime
+   * @param {boolean=} opt_useRelativeCueTimestamps
    */
-  function verifyHelper(cues, text, opt_offset) {
+  function verifyHelper(cues, text, opt_offset,
+                        opt_startTime, opt_useRelativeCueTimestamps) {
     var data = shaka.util.StringUtils.toUTF8(text);
-    // Last two parameters are only used by mp4 vtt parser.
     var result =
-        shaka.media.VttTextParser(data, opt_offset || 0, null, null, false);
+        shaka.media.VttTextParser(data,
+                                  opt_offset || 0,
+                                  opt_startTime || 0,
+                                  null,
+                                  opt_useRelativeCueTimestamps || false);
     expect(result).toBeTruthy();
     expect(result.length).toBe(cues.length);
     for (var i = 0; i < cues.length; i++) {

--- a/test/media/vtt_text_parser_unit.js
+++ b/test/media/vtt_text_parser_unit.js
@@ -368,7 +368,8 @@ describe('VttTextParser', function() {
   function verifyHelper(cues, text, opt_offset) {
     var data = shaka.util.StringUtils.toUTF8(text);
     // Last two parameters are only used by mp4 vtt parser.
-    var result = shaka.media.VttTextParser(data, opt_offset || 0, null, null);
+    var result =
+        shaka.media.VttTextParser(data, opt_offset || 0, null, null, null);
     expect(result).toBeTruthy();
     expect(result.length).toBe(cues.length);
     for (var i = 0; i < cues.length; i++) {
@@ -399,7 +400,7 @@ describe('VttTextParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT, code);
     var data = shaka.util.StringUtils.toUTF8(text);
     try {
-      shaka.media.VttTextParser(data, 0, null, null);
+      shaka.media.VttTextParser(data, 0, null, null, null);
       fail('Invalid WebVTT file supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/vtt_text_parser_unit.js
+++ b/test/media/vtt_text_parser_unit.js
@@ -42,6 +42,10 @@ describe('VttTextParser', function() {
     }
   });
 
+  beforeEach(function() {
+    logWarningSpy.calls.reset();
+  });
+
   it('supports no cues', function() {
     verifyHelper([], 'WEBVTT');
   });
@@ -365,7 +369,7 @@ describe('VttTextParser', function() {
   });
 
   it('ignores and logs invalid settings', function() {
-    expect(logWarningSpy.calls.count()).toBe(1); // From test above
+    expect(logWarningSpy.calls.count()).toBe(0);
 
     verifyHelper(
         [
@@ -423,7 +427,7 @@ describe('VttTextParser', function() {
         '00:00:20.000 --> 00:00:40.000 align:foo\n' +
         'Test\n\n');
 
-    expect(logWarningSpy.calls.count()).toBe(8);
+    expect(logWarningSpy.calls.count()).toBe(7);
   });
 
   /**

--- a/test/media/vtt_text_parser_unit.js
+++ b/test/media/vtt_text_parser_unit.js
@@ -369,7 +369,7 @@ describe('VttTextParser', function() {
     var data = shaka.util.StringUtils.toUTF8(text);
     // Last two parameters are only used by mp4 vtt parser.
     var result =
-        shaka.media.VttTextParser(data, opt_offset || 0, null, null, null);
+        shaka.media.VttTextParser(data, opt_offset || 0, null, null, false);
     expect(result).toBeTruthy();
     expect(result.length).toBe(cues.length);
     for (var i = 0; i < cues.length; i++) {
@@ -400,7 +400,7 @@ describe('VttTextParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT, code);
     var data = shaka.util.StringUtils.toUTF8(text);
     try {
-      shaka.media.VttTextParser(data, 0, null, null, null);
+      shaka.media.VttTextParser(data, 0, null, null, false);
       fail('Invalid WebVTT file supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);

--- a/test/media/vtt_text_parser_unit.js
+++ b/test/media/vtt_text_parser_unit.js
@@ -365,7 +365,7 @@ describe('VttTextParser', function() {
   });
 
   it('ignores and logs invalid settings', function() {
-    expect(logWarningSpy.calls.count()).toBe(0);
+    expect(logWarningSpy.calls.count()).toBe(1); // From test above
 
     verifyHelper(
         [
@@ -423,7 +423,7 @@ describe('VttTextParser', function() {
         '00:00:20.000 --> 00:00:40.000 align:foo\n' +
         'Test\n\n');
 
-    expect(logWarningSpy.calls.count()).toBe(7);
+    expect(logWarningSpy.calls.count()).toBe(8);
   });
 
   /**


### PR DESCRIPTION
Fix for #480

This should be reviewed closely. Specifically I'm not thrilled that I had to modify all the other text parsers to receiver an argument that none of them are going to use. That seems confusing to me but I wasn't sure how to avoid that.