### PR TITLE
Fix when Content-Type includes character encoding.

### DIFF
--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -163,6 +163,8 @@ shaka.media.ManifestParser.getFactory = function(
         // but just to be safe:
         if (mimeType) {
           mimeType = mimeType.toLowerCase();
+          var i = mimeType.indexOf(';');
+          if (i > -1) mimeType = mimeType.substring(0, i);
         }
         factory = shaka.media.ManifestParser.parsersByMime[mimeType];
         if (!factory) {


### PR DESCRIPTION
When the Content-Type header includes the character encoding (ex: application/dash+xml;charset=UTF-8), an UNABLE_TO_GUESS_MANIFEST_TYPE is thrown. This change gets the actual mimeType from the header string and uses that to look up the manifest parser.