### PR TITLE
Fix when using Data URIs for the manifest

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Johan Sundström <oyasumi@gmail.com>
 JW Player <*@jwplayer.com>
+Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Joey Parrish <joeyparrish@google.com>
 Johan Sundström <oyasumi@gmail.com>
 Jono Ward <jonoward@gmail.com>
+Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>

--- a/lib/net/data_uri_plugin.js
+++ b/lib/net/data_uri_plugin.js
@@ -79,7 +79,14 @@ shaka.net.DataUriPlugin = function(uri, request) {
     }
 
     /** @type {shakaExtern.Response} */
-    var response = {uri: uri, data: data, headers: {}};
+    var response = {
+      uri: uri,
+      data: data,
+      headers: {
+        'content-type': typeAndEncoding[0]
+      }
+    };
+
     resolve(response);
   });
 };

--- a/test/net/data_uri_plugin_unit.js
+++ b/test/net/data_uri_plugin_unit.js
@@ -23,31 +23,32 @@ describe('DataUriPlugin', function() {
   });
 
   it('supports MIME types', function(done) {
-    testSucceeds('data:text/plain,Hello', 'Hello', done);
+    testSucceeds('data:text/plain,Hello', 'text/plain', 'Hello', done);
   });
 
   it('supports URI encoded text', function(done) {
     testSucceeds(
         'data:text/html,%3Ch1%3EHello%2C%20World!%3C%2Fh1%3E',
+        'text/html',
         '<h1>Hello, World!</h1>',
         done);
   });
 
   it('supports base64 encoded text', function(done) {
     testSucceeds(
-        'data:;base64,SGVsbG8sIFdvcmxkIQ%3D%3D', 'Hello, World!', done);
+        'data:;base64,SGVsbG8sIFdvcmxkIQ%3D%3D', '', 'Hello, World!', done);
   });
 
   it('supports extra colin', function(done) {
-    testSucceeds('data:,Hello:', 'Hello:', done);
+    testSucceeds('data:,Hello:', '', 'Hello:', done);
   });
 
   it('supports extra semi-colin', function(done) {
-    testSucceeds('data:,Hello;', 'Hello;', done);
+    testSucceeds('data:,Hello;', '', 'Hello;', done);
   });
 
   it('supports extra comma', function(done) {
-    testSucceeds('data:,Hello,', 'Hello,', done);
+    testSucceeds('data:,Hello,', '', 'Hello,', done);
   });
 
   it('fails for empty URI', function(done) {
@@ -67,7 +68,7 @@ describe('DataUriPlugin', function() {
     testFails('data:Bad', done, shaka.util.Error.Code.MALFORMED_DATA_URI);
   });
 
-  function testSucceeds(uri, text, done) {
+  function testSucceeds(uri, contentType, text, done) {
     var request =
         shaka.net.NetworkingEngine.makeRequest([uri], retryParameters);
     shaka.net.DataUriPlugin(uri, request)
@@ -75,6 +76,7 @@ describe('DataUriPlugin', function() {
           expect(response).toBeTruthy();
           expect(response.uri).toBe(uri);
           expect(response.data).toBeTruthy();
+          expect(response.headers['content-type']).toBe(contentType);
           var data = shaka.util.StringUtils.fromBytesAutoDetect(response.data);
           expect(data).toBe(text);
         })


### PR DESCRIPTION
When using Data URIs for the manifest an `UNABLE_TO_GUESS_MANIFEST_TYPE` is thrown. The mimeType is used to look up the manifesst parser but mimeType is `undefined ` because `shaka.net.DataUriPlugin` does not return the correct 'content-type' in the header.

With this change `shaka.media.ManifestParser` (lib/media/manifest_parser.js, line167) can select the manifest parser correctly.

Data URIs used:

> data:application/dash+xml,[encoded xml]

and

> data:application/dash+xml;base64,[base64 encoded xml] 