### PR TITLE
TTML subtitles: Support for <br> inside a paragraph

### DIFF
--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -168,6 +168,15 @@ shaka.media.TtmlTextParser.getLeafNodes_ = function(element) {
     return result;
 
   var childNodes = element.childNodes;
+  if (element.nodeName == 'p') {
+    // Replace <br> inside a <p> paragraph with a newline character.
+    // The <br> node is later on skipped
+    for (var j = 0; j < childNodes.length; j++) {
+      if (childNodes[j].nodeName == 'br' && j > 0) {
+        childNodes[j - 1].textContent += '\n';
+      }
+    }
+  }
   for (var i = 0; i < childNodes.length; i++) {
     // Currently we don't support styles applicable to span
     // elements, so they are ignored

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -390,6 +390,14 @@ describe('TtmlTextParser', function() {
         '</tt>');
   });
 
+  it('inserts a newline on br in a p block', function() {
+    verifyHelper(
+        [
+          {start: 62.05, end: 3723.2, text: 'Line1\nLine2'}
+        ],
+        '<tt><body><p begin="01:02.05" ' +
+        'end="01:02:03.200">Line1<br/>Line2</p></body></tt>');
+  });
 
   /**
    * @param {!Array} cues


### PR DESCRIPTION
We currently have TTML subtitles that contains `<br>` elements inside a paragraph for linebreaking. This pull request replaces the `<br>` elements with a newline character. Having `<br>` inside a paragraph is valid in TTML as far as I have understood by looking at the examples in https://www.w3.org/TR/ttaf1-dfxp/

