### PR TITLE
Fix for TTML text alignment

### DIFF
--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -261,6 +261,25 @@ shaka.media.TtmlTextParser.parseCue_ = function(
 
 
 /**
+ * Converts TTML align attribute to VTT Cue lineAlign
+ *
+ * @param {!string} align
+ * @return {string}
+ * @private
+ */
+shaka.media.TtmlTextParser.ttmlToLineAlign_ = function(align) {
+  var convTable = {
+    'left': 'start',
+    'middle': 'center',
+    'right': 'end',
+    'start': 'start',
+    'end': 'end'
+  };
+  return convTable[align];
+};
+
+
+/**
  * Adds applicable style properties to a cue.
  *
  * @param {!TextTrackCue} cue
@@ -276,8 +295,10 @@ shaka.media.TtmlTextParser.addStyle_ = function(
 
   var align = TtmlTextParser.getStyleAttribute_(
       cueElement, region, styles, 'tts:textAlign');
-  if (align)
-    cue.lineAlign = align;
+  if (align) {
+    cue.align = align;
+    cue.lineAlign = TtmlTextParser.ttmlToLineAlign_(align);
+  }
 
   var extent = TtmlTextParser.getStyleAttribute_(
       cueElement, region, styles, 'tts:extent');

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -160,11 +160,12 @@ shaka.media.TtmlTextParser.percentValues_ = /^(\d{1,2}|100)% (\d{1,2}|100)%$/;
  */
 shaka.media.TtmlTextParser.lineAlignConvTable_ = {
   'left': 'start',
-  'middle': 'center',
+  'center': 'center',
   'right': 'end',
   'start': 'start',
   'end': 'end'
 };
+
 
 /**
  * Gets leaf nodes of the xml node tree. Ignores the text, br elements
@@ -286,12 +287,6 @@ shaka.media.TtmlTextParser.addStyle_ = function(
   var TtmlTextParser = shaka.media.TtmlTextParser;
   var results = null;
 
-  var align = TtmlTextParser.getStyleAttribute_(
-      cueElement, region, styles, 'tts:textAlign');
-  if (align) {
-    cue.align = align;
-    cue.lineAlign = TtmlTextParser.lineAlignConvTable_[align];
-  }
 
   var extent = TtmlTextParser.getStyleAttribute_(
       cueElement, region, styles, 'tts:extent');
@@ -330,6 +325,20 @@ shaka.media.TtmlTextParser.addStyle_ = function(
         cue.line = Number(results[2]);
       }
     }
+  }
+
+  var align = TtmlTextParser.getStyleAttribute_(
+      cueElement, region, styles, 'tts:textAlign');
+  if (align) {
+    if (align == 'center') {
+      // Need to set cue.position to auto to get centered
+      // subtitles
+      cue.align = 'middle';
+      cue.position = 'auto';
+    } else {
+      cue.align = align;
+    }
+    cue.lineAlign = TtmlTextParser.lineAlignConvTable_[align];
   }
 };
 

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -155,6 +155,18 @@ shaka.media.TtmlTextParser.percentValues_ = /^(\d{1,2}|100)% (\d{1,2}|100)%$/;
 
 
 /**
+ * @const
+ * @private {!string}
+ */
+shaka.media.TtmlTextParser.lineAlignConvTable_ = {
+  'left': 'start',
+  'middle': 'center',
+  'right': 'end',
+  'start': 'start',
+  'end': 'end'
+};
+
+/**
  * Gets leaf nodes of the xml node tree. Ignores the text, br elements
  * and the spans positioned inside paragraphs
  *
@@ -261,25 +273,6 @@ shaka.media.TtmlTextParser.parseCue_ = function(
 
 
 /**
- * Converts TTML align attribute to VTT Cue lineAlign
- *
- * @param {!string} align
- * @return {string}
- * @private
- */
-shaka.media.TtmlTextParser.ttmlToLineAlign_ = function(align) {
-  var convTable = {
-    'left': 'start',
-    'middle': 'center',
-    'right': 'end',
-    'start': 'start',
-    'end': 'end'
-  };
-  return convTable[align];
-};
-
-
-/**
  * Adds applicable style properties to a cue.
  *
  * @param {!TextTrackCue} cue
@@ -295,9 +288,9 @@ shaka.media.TtmlTextParser.addStyle_ = function(
 
   var align = TtmlTextParser.getStyleAttribute_(
       cueElement, region, styles, 'tts:textAlign');
-  if (align) {
+  if (align) {
     cue.align = align;
-    cue.lineAlign = TtmlTextParser.ttmlToLineAlign_(align);
+    cue.lineAlign = TtmlTextParser.lineAlignConvTable_[align];
   }
 
   var extent = TtmlTextParser.getStyleAttribute_(

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -156,7 +156,7 @@ shaka.media.TtmlTextParser.percentValues_ = /^(\d{1,2}|100)% (\d{1,2}|100)%$/;
 
 /**
  * @const
- * @private {!string}
+ * @private {!Object}
  */
 shaka.media.TtmlTextParser.lineAlignConvTable_ = {
   'left': 'start',

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -158,7 +158,7 @@ shaka.media.TtmlTextParser.percentValues_ = /^(\d{1,2}|100)% (\d{1,2}|100)%$/;
  * @const
  * @private {!Object}
  */
-shaka.media.TtmlTextParser.lineAlignConvTable_ = {
+shaka.media.TtmlTextParser.textAlignToLineAlign_ = {
   'left': 'start',
   'center': 'center',
   'right': 'end',
@@ -338,7 +338,7 @@ shaka.media.TtmlTextParser.addStyle_ = function(
     } else {
       cue.align = align;
     }
-    cue.lineAlign = TtmlTextParser.lineAlignConvTable_[align];
+    cue.lineAlign = TtmlTextParser.textAlignToLineAlign_[align];
   }
 };
 

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -399,6 +399,25 @@ describe('TtmlTextParser', function() {
         'end="01:02:03.200">Line1<br/>Line2</p></body></tt>');
   });
 
+  it('aligns left when textAlign is left', function() {
+    verifyHelper(
+        [
+          {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'start',
+            align: 'left'}
+        ],
+        '<tt xmlns:tts="ttml#styling">' +
+        '<styling>' +
+        '<style xml:id="s1" tts:textAlign="left"/>' +
+        '</styling>' +
+        '<layout xmlns:tts="ttml#styling">' +
+        '<region xml:id="subtitleArea" />' +
+        '</layout>' +
+        '<body region="subtitleArea">' +
+        '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
+        '</body>' +
+        '</tt>');
+  });
+
   /**
    * @param {!Array} cues
    * @param {string} text
@@ -416,6 +435,8 @@ describe('TtmlTextParser', function() {
       expect(result[i].endTime).toBeCloseTo(cues[i].end, 3);
       expect(result[i].text).toBe(cues[i].text);
 
+      if (cues[i].align)
+        expect(result[i].align).toBe(cues[i].align);
       if (cues[i].lineAlign)
         expect(result[i].lineAlign).toBe(cues[i].lineAlign);
       if (cues[i].size)

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -418,6 +418,25 @@ describe('TtmlTextParser', function() {
         '</tt>');
   });
 
+  it('aligns center when textAlign is center', function() {
+    verifyHelper(
+        [
+          {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'center',
+            align: 'middle', position: 'auto'}
+        ],
+        '<tt xmlns:tts="ttml#styling">' +
+        '<styling>' +
+        '<style xml:id="s1" tts:textAlign="center"/>' +
+        '</styling>' +
+        '<layout xmlns:tts="ttml#styling">' +
+        '<region xml:id="subtitleArea" />' +
+        '</layout>' +
+        '<body region="subtitleArea">' +
+        '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
+        '</body>' +
+        '</tt>');
+  });
+
   /**
    * @param {!Array} cues
    * @param {string} text

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -399,7 +399,7 @@ describe('TtmlTextParser', function() {
         'end="01:02:03.200">Line1<br/>Line2</p></body></tt>');
   });
 
-  it('aligns left when textAlign is left', function() {
+  it('parses cue alignment from textAlign attribute', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'start',
@@ -416,9 +416,6 @@ describe('TtmlTextParser', function() {
         '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
         '</body>' +
         '</tt>');
-  });
-
-  it('aligns center when textAlign is center', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'center',
@@ -436,6 +433,7 @@ describe('TtmlTextParser', function() {
         '</body>' +
         '</tt>');
   });
+
 
   /**
    * @param {!Array} cues


### PR DESCRIPTION
This pull request solves the problem with TTML text alignment. We have TTML subtitles that has tts:textAlign=left and the subtitle was placed on the left side of the player but the text was centered. If I am reading the VTTCue specification correctly [1] the cue.align also needs to be set. This was not done and is solved by this PR.

[1] https://w3c.github.io/webvtt/#dom-vttcue-align 