### PR TITLE
Do not initiate a new seek while a seek for flushing is in progress.

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -382,21 +382,26 @@ shaka.media.MediaSourceEngine.prototype.remove =
  * @param {string} contentType
  * @return {!Promise}
  */
-shaka.media.MediaSourceEngine.prototype.clear = function(contentType) {
+shaka.media.MediaSourceEngine.prototype.clear = function(contentType, flush = true) {
   if (contentType == 'text') {
     return this.textEngine_.remove(0, Infinity);
   }
-  return Promise.all([
+  var p = [
     // Note that not all platforms allow clearing to Infinity.
     this.enqueueOperation_(
         contentType,
-        this.remove_.bind(this, contentType, 0, this.mediaSource_.duration)),
+        this.remove_.bind(this, contentType, 0, this.mediaSource_.duration))
+  ];
+  if (flush) {
     // Flush the pipeline.  Necessary on Chromecast, even though we have removed
     // everything.
-    this.enqueueOperation_(
-        contentType,
-        this.flush_.bind(this, contentType))
-  ]);
+    p.push(
+        this.enqueueOperation_(
+            contentType,
+            this.flush_.bind(this, contentType)));
+  }
+
+  return Promise.all(p);
 };
 
 

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -178,6 +178,11 @@ shaka.media.StreamingEngine = function(
   this.destroyed_ = false;
 };
 
+shaka.media.StreamingEngine.prototype.ClearBufferType = {
+  NONE : 0,
+  FLUSH : 1,
+  NOFLUSH : 2
+};
 
 /**
  * @typedef {{
@@ -190,7 +195,7 @@ shaka.media.StreamingEngine = function(
  *   endOfStream: boolean,
  *   performingUpdate: boolean,
  *   updateTimer: ?number,
- *   waitingToClearBuffer: boolean,
+ *   waitingToClearBuffer: ClearBufferType,
  *   clearingBuffer: boolean,
  *   recovering: boolean
  * }}
@@ -220,7 +225,7 @@ shaka.media.StreamingEngine = function(
  *   True indicates that an update is in progress.
  * @property {?number} updateTimer
  *   A non-null value indicates that an update is scheduled.
- * @property {boolean} waitingToClearBuffer
+ * @property {ClearBufferType} waitingToClearBuffer
  *   True indicates that the buffer must be cleared after the current update
  *   finishes.
  * @property {boolean} clearingBuffer
@@ -451,7 +456,7 @@ shaka.media.StreamingEngine.prototype.switch = function(
  * @param {shaka.media.StreamingEngine.MediaState_} mediaState
  * @private
  */
-shaka.media.StreamingEngine.prototype.clear_ = function(mediaState) {
+shaka.media.StreamingEngine.prototype.clear_ = function(mediaState, flush = true) {
   // Ignore if we are already clearing the buffer.
   if (mediaState.clearingBuffer) {
     return;
@@ -461,12 +466,13 @@ shaka.media.StreamingEngine.prototype.clear_ = function(mediaState) {
     // We are performing an update, so we have to wait until it's finished.
     // onUpdate_() will call clearBuffer_() when the update has
     // finished.
-    mediaState.waitingToClearBuffer = true;
+    mediaState.waitingToClearBuffer = flush ? shaka.media.StreamingEngine.prototype.ClearBufferType.FLUSH
+                                            : shaka.media.StreamingEngine.prototype.ClearBufferType.NOFLUSH;
   } else {
     // Cancel the update timer, if any.
     this.cancelUpdate_(mediaState);
     // Clear right away.
-    this.clearBuffer_(mediaState);
+    this.clearBuffer_(mediaState, flush);
   }
 };
 
@@ -512,7 +518,7 @@ shaka.media.StreamingEngine.prototype.seeked = function() {
       // onUpdate_() will call clearBuffer_() when the update has
       // finished.
       shaka.log.debug(logPrefix, 'seeked: unbuffered seek: currently updating');
-      mediaState.waitingToClearBuffer = true;
+      mediaState.waitingToClearBuffer = shaka.media.StreamingEngine.prototype.ClearBufferType.NOFLUSH;
       continue;
     }
 
@@ -531,7 +537,7 @@ shaka.media.StreamingEngine.prototype.seeked = function() {
     // buffer right away. Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'seeked: unbuffered seek: handling right now');
     this.cancelUpdate_(mediaState);
-    this.clearBuffer_(mediaState);
+    this.clearBuffer_(mediaState, /* flush */ false);
   }
 };
 
@@ -582,7 +588,7 @@ shaka.media.StreamingEngine.prototype.initStreams_ = function(streamsByType) {
           endOfStream: false,
           performingUpdate: false,
           updateTimer: null,
-          waitingToClearBuffer: false,
+          waitingToClearBuffer: shaka.media.StreamingEngine.prototype.ClearBufferType.NONE,
           clearingBuffer: false,
           recovering: false
         };
@@ -740,7 +746,8 @@ shaka.media.StreamingEngine.prototype.onUpdate_ = function(mediaState) {
   if (mediaState.waitingToClearBuffer) {
     // Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'skipping update and clearing the buffer');
-    this.clearBuffer_(mediaState);
+    this.clearBuffer_(mediaState, mediaState.waitingToClearBuffer
+                                  == shaka.media.StreamingEngine.prototype.ClearBufferType.FLUSH);
     return;
   }
 
@@ -1664,18 +1671,18 @@ shaka.media.StreamingEngine.prototype.fetch_ = function(reference) {
  * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
  * @private
  */
-shaka.media.StreamingEngine.prototype.clearBuffer_ = function(mediaState) {
+shaka.media.StreamingEngine.prototype.clearBuffer_ = function(mediaState, flush = true) {
   var logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
 
   goog.asserts.assert(
       !mediaState.performingUpdate && (mediaState.updateTimer == null),
       logPrefix + ' unexpected call to clearBuffer_()');
 
-  mediaState.waitingToClearBuffer = false;
+  mediaState.waitingToClearBuffer = shaka.media.StreamingEngine.prototype.ClearBufferType.NONE;
   mediaState.clearingBuffer = true;
 
   shaka.log.debug(logPrefix, 'clearing buffer');
-  var p = this.mediaSourceEngine_.clear(mediaState.type);
+  var p = this.mediaSourceEngine_.clear(mediaState.type, flush);
   p.then(function() {
     if (this.destroyed_) return;
     shaka.log.debug(logPrefix, 'cleared buffer');


### PR DESCRIPTION
In commit 2ecd8bba19c, as workaround for a chromecast bug, whenever the sourcebuffer is cleared, a new seek is initiated in order to flush the media pipeline.
However, this can cause an infinite loop if a seek is already pending.

Fixes #569.
---- additional comments
Here is a quick fix. I'm not familiar with shaka code so it may not be how you would have done it.
The issue at hand here is that the media pipeline is flushed when a seek is initiated. However, this flushing is done by seeking again. So you get something like seek -> clear -> flush (seek) -> seek -> clear -> flush (seek) -> repeat

The current code is racy in such that it relies on an event (seeking/seeked) be fired in a specific order, order with others.

So the work around is to not attempt to clear the media pipeline while we're seeking. It's more efficient that way anyway as when you're seeking there's no need to flush the pipeline (it's already been flushed). This will speed up seeking on all user agents.