### PR TITLE
Add new lines in TTML cues with nested <br> tags

### DIFF
--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -181,15 +181,6 @@ shaka.media.TtmlTextParser.getLeafNodes_ = function(element) {
     return result;
 
   var childNodes = element.childNodes;
-  if (element.nodeName == 'p') {
-    // Replace <br> inside a <p> paragraph with a newline character.
-    // The <br> node is later on skipped
-    for (var j = 0; j < childNodes.length; j++) {
-      if (childNodes[j].nodeName == 'br' && j > 0) {
-        childNodes[j - 1].textContent += '\n';
-      }
-    }
-  }
   for (var i = 0; i < childNodes.length; i++) {
     // Currently we don't support styles applicable to span
     // elements, so they are ignored
@@ -217,6 +208,25 @@ shaka.media.TtmlTextParser.getLeafNodes_ = function(element) {
 
 
 /**
+ * Insert \n where <br> tags are found
+ *
+ * @param {!Node} element
+ * @private
+ */
+shaka.media.TtmlTextParser.addNewLines_ = function(element) {
+  var childNodes = element.childNodes;
+
+  for (var i = 0; i < childNodes.length; i++) {
+    if (childNodes[i].nodeName == 'br' && i > 0) {
+      childNodes[i - 1].textContent += '\n';
+    } else if (childNodes[i].childNodes.length !== 0) {
+      shaka.media.TtmlTextParser.addNewLines_(childNodes[i]);
+    }
+  }
+};
+
+
+/**
  * Parses an Element into a TextTrackCue or VTTCue.
  *
  * @param {!Element} cueElement
@@ -238,6 +248,8 @@ shaka.media.TtmlTextParser.parseCue_ = function(
       !cueElement.hasAttribute('end') &&
       cueElement.textContent == '')
     return null;
+
+  shaka.media.TtmlTextParser.addNewLines_(cueElement);
 
   // Get time
   var start = shaka.media.TtmlTextParser.parseTime_(

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -219,7 +219,7 @@ shaka.media.TtmlTextParser.addNewLines_ = function(element) {
   for (var i = 0; i < childNodes.length; i++) {
     if (childNodes[i].nodeName == 'br' && i > 0) {
       childNodes[i - 1].textContent += '\n';
-    } else if (childNodes[i].childNodes.length !== 0) {
+    } else if (childNodes[i].childNodes.length > 0) {
       shaka.media.TtmlTextParser.addNewLines_(childNodes[i]);
     }
   }

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -386,16 +386,13 @@ describe('TtmlTextParser', function() {
         '</tt>');
   });
 
-  it('inserts a newline on br in a p block', function() {
+  it('inserts newline characters into <br> tags', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Line1\nLine2'}
         ],
         '<tt><body><p begin="01:02.05" ' +
         'end="01:02:03.200">Line1<br/>Line2</p></body></tt>');
-  });
-
-  it('inserts a newline on br in elements nested in cue', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Line1\nLine2'}

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -395,6 +395,15 @@ describe('TtmlTextParser', function() {
         'end="01:02:03.200">Line1<br/>Line2</p></body></tt>');
   });
 
+  it('inserts a newline on br in elements nested in cue', function() {
+    verifyHelper(
+        [
+          {start: 62.05, end: 3723.2, text: 'Line1\nLine2'}
+        ],
+        '<tt><body><p begin="01:02.05" ' +
+        'end="01:02:03.200"><span>Line1<br/>Line2</span></p></body></tt>');
+  });
+
   it('parses cue alignment from textAlign attribute', function() {
     verifyHelper(
         [


### PR DESCRIPTION
This modifies the fix from #572. We have streams that also have `<br>` tags nested in `<span>` tags that were getting missed by #572 