### PR TITLE
Fix for TTML alignment (non-centered) in Firefox

### DIFF
--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -16,7 +16,7 @@
  */
 
 /**
- * @fileoverview Externs for TextTrack which are missing from the closure
+ * @fileoverview Externs for TextTrack and TextTrackCue which are missing from the closure
  * compiler.
  *
  * @externs
@@ -25,3 +25,9 @@
 
 /** @type {string} */
 TextTrack.prototype.label;
+
+/** @type {string} */
+TextTrackCue.prototype.positionAlign;
+
+/** @type {string} */
+TextTrackCue.prototype.lineAlign;

--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -16,8 +16,8 @@
  */
 
 /**
- * @fileoverview Externs for TextTrack and TextTrackCue which are missing from the closure
- * compiler.
+ * @fileoverview Externs for TextTrack and TextTrackCue which are
+ * missing from the closure compiler.
  *
  * @externs
  */
@@ -26,8 +26,10 @@
 /** @type {string} */
 TextTrack.prototype.label;
 
+
 /** @type {string} */
 TextTrackCue.prototype.positionAlign;
+
 
 /** @type {string} */
 TextTrackCue.prototype.lineAlign;

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -169,6 +169,17 @@ shaka.media.TtmlTextParser.textAlignToLineAlign_ = {
 
 
 /**
+ * @const
+ * @private {!Object}
+ */
+shaka.media.TtmlTextParser.textAlignToPositionAlign_ = {
+  'left': 'line-left',
+  'center': 'center',
+  'right': 'line-right'
+};
+
+
+/**
  * Gets leaf nodes of the xml node tree. Ignores the text, br elements
  * and the spans positioned inside paragraphs
  *
@@ -332,12 +343,15 @@ shaka.media.TtmlTextParser.addStyle_ = function(
       cueElement, region, styles, 'tts:textAlign');
   if (align) {
     cue.align = align;
-    if (align == 'center' && cue.align != 'center') {
-      // Workaround for a Chrome bug http://crbug.com/663797
-      // Chrome does not support align = 'center'
+    if (align == 'center') {
+      if (cue.align != 'center') {
+        // Workaround for a Chrome bug http://crbug.com/663797
+        // Chrome does not support align = 'center'
+        cue.align = 'middle';
+      }
       cue.position = 'auto';
-      cue.align = 'middle';
     }
+    cue.positionAlign = TtmlTextParser.textAlignToPositionAlign_[align];
     cue.lineAlign = TtmlTextParser.textAlignToLineAlign_[align];
   }
 };

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -399,7 +399,7 @@ describe('TtmlTextParser', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'start',
-            align: 'left'}
+            align: 'left', positionAlign: 'line-left'}
         ],
         '<tt xmlns:tts="ttml#styling">' +
         '<styling>' +
@@ -432,7 +432,7 @@ describe('TtmlTextParser', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'center',
-            align: 'middle', position: 'auto'}
+            align: 'middle', position: 'auto', positionAlign: 'center'}
         ],
         '<tt xmlns:tts="ttml#styling">' +
         '<styling>' +
@@ -469,6 +469,8 @@ describe('TtmlTextParser', function() {
         expect(result[i].align).toBe(cues[i].align);
       if (cues[i].lineAlign)
         expect(result[i].lineAlign).toBe(cues[i].lineAlign);
+      if (cues[i].positionAlign)
+        expect(result[i].positionAlign).toBe(cues[i].positionAlign);
       if (cues[i].size)
         expect(result[i].size).toBe(cues[i].size);
       if (cues[i].line)


### PR DESCRIPTION
It was discovered that TTML alignments that is not centered (e.g. left) was shown incorrectly in Firefox. The reason I discovered was that the cue.positionAlign was not set and defaulted to "center". This caused the subtitles to be positioned on the left (when tts:textAlign=left) but with the text center aligned.

Note that for Firefox v48 or lower the implementation of cue.positionAlign did not fully follow the spec and was corrected in v49 and above.