### PR TITLE
TextTrackCue properties never used in compiled version

### DIFF
--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -16,8 +16,8 @@
  */
 
 /**
- * @fileoverview Externs for TextTrack which are missing from the closure
- * compiler.
+ * @fileoverview Externs for TextTrack and TextTrackCue which are
+ * missing from the closure compiler.
  *
  * @externs
  */
@@ -25,3 +25,23 @@
 
 /** @type {string} */
 TextTrack.prototype.label;
+
+
+/** @type {string} */
+TextTrackCue.prototype.positionAlign;
+
+
+/** @type {string} */
+TextTrackCue.prototype.lineAlign;
+
+
+/** @type {number|null|string} */
+TextTrackCue.prototype.line;
+
+
+/** @type {string} */
+TextTrackCue.prototype.vertical;
+
+
+/** @type {boolean} */
+TextTrackCue.prototype.snapToLines;


### PR DESCRIPTION
I discovered that a number of VTTCue / TextTrackCue properties actually was never used as the Closure compiler "removed" these properties. This PR adds these Externs.