### PR TITLE
TTML Positioning issues

### DIFF
--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -33,3 +33,15 @@ TextTrackCue.prototype.positionAlign;
 
 /** @type {string} */
 TextTrackCue.prototype.lineAlign;
+
+
+/** @type {number|null|string} */
+TextTrackCue.prototype.line;
+
+
+/** @type {string} */
+TextTrackCue.prototype.vertical;
+
+
+/** @type {boolean} */
+TextTrackCue.prototype.snapToLines;

--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -16,8 +16,8 @@
  */
 
 /**
- * @fileoverview Externs for TextTrack which are missing from the closure
- * compiler.
+ * @fileoverview Externs for TextTrack and TextTrackCue which are
+ * missing from the closure compiler.
  *
  * @externs
  */
@@ -25,3 +25,11 @@
 
 /** @type {string} */
 TextTrack.prototype.label;
+
+
+/** @type {string} */
+TextTrackCue.prototype.positionAlign;
+
+
+/** @type {string} */
+TextTrackCue.prototype.lineAlign;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -272,6 +272,12 @@ module.exports = function(config) {
     // Run Player integration tests with uncompiled code for debugging.
     setClientArg(config, 'uncompiled', true);
   }
+
+  var hostname = getFlagValue('hostname');
+  if (hostname !== null) {
+    // Point the browsers to a hostname other than localhost.
+    config.set({hostname: hostname});
+  }
 };
 
 // Sets the value of an argument passed to the client.

--- a/lib/abr/ewma.js
+++ b/lib/abr/ewma.js
@@ -54,8 +54,12 @@ shaka.abr.Ewma = function(halfLife) {
  */
 shaka.abr.Ewma.prototype.sample = function(weight, value) {
   var adjAlpha = Math.pow(this.alpha_, weight);
-  this.estimate_ = value * (1 - adjAlpha) + adjAlpha * this.estimate_;
-  this.totalWeight_ += weight;
+  var newEstimate = value * (1 - adjAlpha) + adjAlpha * this.estimate_;
+
+  if (!isNaN(newEstimate)) {
+    this.estimate_ = newEstimate;
+    this.totalWeight_ += weight;
+  }
 };
 
 

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -169,6 +169,17 @@ shaka.media.TtmlTextParser.textAlignToLineAlign_ = {
 
 
 /**
+ * @const
+ * @private {!Object}
+ */
+shaka.media.TtmlTextParser.textAlignToPositionAlign_ = {
+  'left': 'line-left',
+  'center': 'center',
+  'right': 'line-right'
+};
+
+
+/**
  * Gets leaf nodes of the xml node tree. Ignores the text, br elements
  * and the spans positioned inside paragraphs
  *
@@ -332,12 +343,15 @@ shaka.media.TtmlTextParser.addStyle_ = function(
       cueElement, region, styles, 'tts:textAlign');
   if (align) {
     cue.align = align;
-    if (align == 'center' && cue.align != 'center') {
-      // Workaround for a Chrome bug http://crbug.com/663797
-      // Chrome does not support align = 'center'
+    if (align == 'center') {
+      if (cue.align != 'center') {
+        // Workaround for a Chrome bug http://crbug.com/663797
+        // Chrome does not support align = 'center'
+        cue.align = 'middle';
+      }
       cue.position = 'auto';
-      cue.align = 'middle';
     }
+    cue.positionAlign = TtmlTextParser.textAlignToPositionAlign_[align];
     cue.lineAlign = TtmlTextParser.textAlignToLineAlign_[align];
   }
 };

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -336,6 +336,12 @@ shaka.media.TtmlTextParser.addStyle_ = function(
         cue.position = Number(results[1]);
         cue.line = Number(results[2]);
       }
+      // A boolean indicating whether the line is an integer
+      // number of lines (using the line dimensions of the first
+      // line of the cue), or whether it is a percentage of the
+      // dimension of the video. The flag is set to true when lines
+      // are counted, and false otherwise.
+      cue.snapToLines = false;
     }
   }
 

--- a/test/abr/simple_abr_manager_unit.js
+++ b/test/abr/simple_abr_manager_unit.js
@@ -182,6 +182,29 @@ describe('SimpleAbrManager', function() {
     });
   });
 
+  it('can handle 0 duration segments', function() {
+    var audioBandwidth = 5e5;
+    var videoBandwidth = 2e6;
+    var bytesPerSecond =
+        sufficientBWMultiplier * (audioBandwidth + videoBandwidth) / 8.0;
+
+    abrManager.chooseStreams(streamSetsByType);
+
+    // 0 duration segment shouldn't cause us to get stuck on the lowest variant
+    abrManager.segmentDownloaded(1000, 1000, bytesPerSecond);
+    abrManager.segmentDownloaded(2000, 3000, bytesPerSecond);
+
+    abrManager.enable();
+
+    abrManager.segmentDownloaded(4000, 5000, bytesPerSecond);
+
+    expect(switchCallback).toHaveBeenCalled();
+    expect(switchCallback.calls.argsFor(0)[0]).toEqual({
+      'audio': jasmine.objectContaining({bandwidth: audioBandwidth}),
+      'video': jasmine.objectContaining({bandwidth: videoBandwidth})
+    });
+  });
+
   it('picks lowest audio Stream when there is insufficient bandwidth',
       function() {
         // The lowest audio track will only be chosen if needed to fit the

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -399,7 +399,7 @@ describe('TtmlTextParser', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'start',
-            align: 'left'}
+            align: 'left', positionAlign: 'line-left'}
         ],
         '<tt xmlns:tts="ttml#styling">' +
         '<styling>' +
@@ -432,7 +432,7 @@ describe('TtmlTextParser', function() {
     verifyHelper(
         [
           {start: 62.05, end: 3723.2, text: 'Test', lineAlign: 'center',
-            align: 'middle', position: 'auto'}
+            align: 'middle', position: 'auto', positionAlign: 'center'}
         ],
         '<tt xmlns:tts="ttml#styling">' +
         '<styling>' +
@@ -469,6 +469,8 @@ describe('TtmlTextParser', function() {
         expect(result[i].align).toBe(cues[i].align);
       if (cues[i].lineAlign)
         expect(result[i].lineAlign).toBe(cues[i].lineAlign);
+      if (cues[i].positionAlign)
+        expect(result[i].positionAlign).toBe(cues[i].positionAlign);
       if (cues[i].size)
         expect(result[i].size).toBe(cues[i].size);
       if (cues[i].line)


### PR DESCRIPTION
This PR contains a fix with incorrect TTML positioning. When converting tts:origin for example "10% 10%" we need to set the VTTCue.snapToLines to false as according to spec:

> A boolean indicating whether the line is an integer number of lines (using the line dimensions of the first line of the cue), or whether it is a percentage of the dimension of the video. The flag is set to true when lines are counted, and false otherwise.

This PR also contains the required Externs for VTTCue / TextTrackCue properties that otherwise was not included in the compiled version and default values was used instead.