### PR TITLE
Incorrect TTML positioning

### DIFF
--- a/externs/texttrack.js
+++ b/externs/texttrack.js
@@ -33,3 +33,15 @@ TextTrackCue.prototype.positionAlign;
 
 /** @type {string} */
 TextTrackCue.prototype.lineAlign;
+
+
+/** @type {number|null|string} */
+TextTrackCue.prototype.line;
+
+
+/** @type {string} */
+TextTrackCue.prototype.vertical;
+
+
+/** @type {boolean} */
+TextTrackCue.prototype.snapToLines;

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -336,6 +336,12 @@ shaka.media.TtmlTextParser.addStyle_ = function(
         cue.position = Number(results[1]);
         cue.line = Number(results[2]);
       }
+      // A boolean indicating whether the line is an integer
+      // number of lines (using the line dimensions of the first
+      // line of the cue), or whether it is a percentage of the
+      // dimension of the video. The flag is set to true when lines
+      // are counted, and false otherwise.
+      cue.snapToLines = false;
     }
   }
 


### PR DESCRIPTION
This PR contains a fix with incorrect TTML positioning. When converting tts:origin for example "10% 10%" we need to set the VTTCue.snapToLines to false as according to spec:

> A boolean indicating whether the line is an integer number of lines (using the line dimensions of the first line of the cue), or whether it is a percentage of the dimension of the video. The flag is set to true when lines are counted, and false otherwise.

This PR also contains the required Externs for VTTCue / TextTrackCue properties that otherwise was not included in the compiled version and default values was used instead.

_(This PR replaces the git mess I made in #591, sorry about that)_