### PR TITLE
Added new method to CastProxy called simpleCast()

### DIFF
--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -176,8 +176,8 @@ shaka.cast.CastProxy.prototype.receiverName = function() {
  */
 shaka.cast.CastProxy.prototype.cast = function() {
   return this.simpleCast().then(function() {
-      // Unload the local manifest when casting succeeds.
-      return this.localPlayer_.unload();
+    // Unload the local manifest when casting succeeds.
+    return this.localPlayer_.unload();
   }.bind(this));
 };
 

--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -175,15 +175,26 @@ shaka.cast.CastProxy.prototype.receiverName = function() {
  * @export
  */
 shaka.cast.CastProxy.prototype.cast = function() {
+  return this.simpleCast().then(function() {
+      // Unload the local manifest when casting succeeds.
+      return this.localPlayer_.unload();
+  }.bind(this));
+};
+
+
+/**
+ * @return {!Promise} Resolved when connected to a receiver.  Rejected if the
+ *   connection fails or is canceled by the user.
+ * @suppress {unnecessaryCasts} to cast Player to Object to access with []
+ * @export
+ */
+shaka.cast.CastProxy.prototype.simpleCast = function() {
   var initState = this.getInitState_();
 
   // TODO: transfer manually-selected tracks?
   // TODO: transfer side-loaded text tracks?
 
-  return this.sender_.cast(initState).then(function() {
-    // Unload the local manifest when casting succeeds.
-    return this.localPlayer_.unload();
-  }.bind(this));
+  return this.sender_.cast(initState);
 };
 
 


### PR DESCRIPTION
Right now `CastProxy.prototype.cast` invokes `this.sender_.cast` to start casting and on success just unloads the local player calling `this.localPlayer_.unload()`

I needed a way to start casting without unloading the local player.

One possible solution was to pass an optional parameter to `CastProxy.prototype.cast` like this:

```
/**
 * @param {boolean=} opt_keepLocal True to not unload local player on succesfull casting.
 * @return {!Promise} Resolved when connected to a receiver.  Rejected if the
 *   connection fails or is canceled by the user.
 * @suppress {unnecessaryCasts} to cast Player to Object to access with []
 * @export
*/
shaka.cast.CastProxy.prototype.cast = function(opt_keepLocal) {
   var initState = this.getInitState_();
 
   // TODO: transfer manually-selected tracks?
   // TODO: transfer side-loaded text tracks?
 
  return this.sender_.cast(initState)
      if (!opt_keepLocal) {
        // Unload the local manifest when casting succeeds.
        return this.localPlayer_.unload();
      }
  }.bind(this));
}
```
and call it like this:
```
this.castProxy_.cast(true);
```
But I didn't like the boolean parameter, so I made another method and call it like this:
```
this.castProxy_.simpleCast();
```
I'm not happy with the name, but I don't have a better one for now.