### PR TITLE
Fix MSIE 11 fails to play video

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Oskar Arvidsson <oskar@irock.se>
 Philo Inc. <*@philo.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Roi Lipman <roilipman@gmail.com>
+Rostislav Hejduk <Ross-cz@users.noreply.github.com>
 SameGoal Inc. <*@samegoal.com>
 Sanborn Hilland <sanbornh@rogers.com>
 TalkTalk Plc <*@talktalkplc.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Oskar Arvidsson <oskar@irock.se>
 Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>
+Rostislav Hejduk <Ross-cz@users.noreply.github.com>
 Sam Dutton <dutton@google.com>
 Sanborn Hilland <sanbornh@rogers.com>
 Seth Madison <seth@philo.com>

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -66,10 +66,13 @@ shaka.util.XmlUtils.findChildren = function(elem, name) {
  */
 shaka.util.XmlUtils.getContents = function(elem) {
   var contents = elem.firstChild;
+
+  // check content
   if (!contents || contents.nodeType != Node.TEXT_NODE)
     return null;
 
-  return contents.nodeValue.trim();
+  // read merged text content from all text nodes (fixes MSIE 11 bug)
+  return elem.textContent.trim();
 };
 
 


### PR DESCRIPTION
This occurrs when hyphen is contained inside manifest Location/BaseUri element and new MutationObserver(...).observe(...) called before #608