### PR TITLE
Issue where certain types of text streams were incorrectly dropped

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -101,7 +101,11 @@ shaka.util.StreamUtils.filterPeriod = function(
   // Filter text streams
   for (var i = 0; i < period.textStreams.length; ++i) {
     var stream = period.textStreams[i];
-    if (!shaka.media.TextEngine.isTypeSupported(stream.mimeType)) {
+    var fullMimeType = stream.mimeType;
+    if (stream.codecs) {
+      fullMimeType += '; codecs="' + stream.codecs + '"';
+    }
+    if (!shaka.media.TextEngine.isTypeSupported(fullMimeType)) {
       shaka.log.debug('Dropping text stream. Is not supported by the' +
                       'platform.', stream);
       period.textStreams.splice(i, 1);


### PR DESCRIPTION
This PR solves an issue in latest build from Master where text streams of type "application/mp4" and codecs="stpp" were incorrectly filtered out.