### PR TITLE
Fix of TTML bug for white-space div with no content

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@
 AdsWizz <*@adswizz.com>
 Esteban Dosztal <edosztal@gmail.com>
 Google Inc. <*@google.com>
+Edgeware AB <*@edgeware.tv>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Sanborn Hilland <sanbornh@rogers.com>
 Seth Madison <seth@philo.com>
 Thomas Stephens <thomas@ustudio.com>
 Timothy Drews <tdrews@google.com>
+Torbjörn Einarsson <torbjorn.einarsson@edgeware.tv>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>

--- a/lib/media/ttml_text_parser.js
+++ b/lib/media/ttml_text_parser.js
@@ -254,11 +254,11 @@ shaka.media.TtmlTextParser.parseCue_ = function(
 
   // Disregard empty elements:
   // TTML allows for empty elements like <div></div>.
-  // If cueElement has neither time attributes, nor text,
-  // don't try to make a cue out of it.
+  // If cueElement has neither time attributes, nor
+  // non-whitespace text, don't try to make a cue out of it.
   if (!cueElement.hasAttribute('begin') &&
       !cueElement.hasAttribute('end') &&
-      cueElement.textContent == '')
+      /^\s*$/.test(cueElement.textContent))
     return null;
 
   shaka.media.TtmlTextParser.addNewLines_(cueElement);

--- a/test/media/ttml_text_parser_unit.js
+++ b/test/media/ttml_text_parser_unit.js
@@ -38,6 +38,10 @@ describe('TtmlTextParser', function() {
     verifyHelper([], '<tt></tt>');
   });
 
+  it('supports div with no cues but whitespace', function() {
+    verifyHelper([], '<tt><body><div>  \r\n </div></body></tt>');
+  });
+
   it('rejects invalid ttml', function() {
     errorHelper(shaka.util.Error.Code.INVALID_TTML, '<test></test>');
     errorHelper(shaka.util.Error.Code.INVALID_TTML, '');


### PR DESCRIPTION
Fix for issue #646.

A div element with no timing and only whitespace should be considered empty.
Added a test that checks this.

