### PR TITLE
Add guard to stop getAudioLanguages and getTextLanguages from failing

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1111,6 +1111,10 @@ shaka.Player.prototype.selectVariantTrack = function(track, opt_clearBuffer) {
  * @export
  */
 shaka.Player.prototype.getAudioLanguages = function() {
+  if (!this.streamingEngine_) {
+    return [];
+  }
+
   var StreamUtils = shaka.util.StreamUtils;
   var period = this.streamingEngine_.getCurrentPeriod();
   var variants = StreamUtils.getPlayableVariants(period.variants);
@@ -1128,6 +1132,10 @@ shaka.Player.prototype.getAudioLanguages = function() {
  * @export
  */
 shaka.Player.prototype.getTextLanguages = function() {
+  if (!this.streamingEngine_) {
+    return [];
+  }
+
   var period = this.streamingEngine_.getCurrentPeriod();
   return period.textStreams.map(function(stream) {
     return stream.language;


### PR DESCRIPTION
If no content has been loaded and therefore there is no streamingEngine
then these two functions will fail. Add a guard to check and return an
empty array if there is no streamingEngine.

Close #677