### PR TITLE
Improvement of segment timeline $Time$ accuracy

### DIFF
--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -269,8 +269,12 @@ shaka.dash.MpdUtils.createTimeline = function(
 
     for (var j = 0; j <= repeat; ++j) {
       var endTime = startTime + d;
-      timeline.push(
-          {start: (startTime / timescale), end: (endTime / timescale)});
+      var item = {
+        start: startTime / timescale,
+        end: endTime / timescale,
+        unscaledStart: startTime
+      };
+      timeline.push(item);
 
       startTime = endTime;
       lastEndTime = endTime;
@@ -398,6 +402,7 @@ shaka.dash.MpdUtils.parseSegmentInfo = function(context, callback) {
     segmentDuration: segmentDuration,
     startNumber: startNumber,
     presentationTimeOffset: pto,
+    unscaledPresentationTimeOffset: Number(presentationTimeOffset),
     timeline: timeline
   };
 };

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -174,6 +174,7 @@ shaka.dash.SegmentTemplate.parseSegmentTemplateInfo_ = function(context) {
     timescale: segmentInfo.timescale,
     startNumber: segmentInfo.startNumber,
     presentationTimeOffset: segmentInfo.presentationTimeOffset,
+    unscaledPresentationTimeOffset: segmentInfo.unscaledPresentationTimeOffset,
     timeline: segmentInfo.timeline,
     mediaTemplate: media,
     indexTemplate: index
@@ -357,6 +358,7 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
   var references = [];
   for (var i = 0; i < info.timeline.length; i++) {
     var start = info.timeline[i].start;
+    var unscaledStart = info.timeline[i].unscaledStart;
     var end = info.timeline[i].end;
 
     // Note: i = k - 1, where k indicates the k'th segment listed in the MPD.
@@ -364,9 +366,8 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
     var segmentReplacement = i + info.startNumber;
 
     // Consider the presentation time offset in segment uri computation
-    var timeReplacement = (start + info.presentationTimeOffset) *
-        info.timescale;
-
+    var timeReplacement = unscaledStart +
+        info.unscaledPresentationTimeOffset;
     var createUris = (function(
             template, repId, bandwidth, baseUris, segmentId, time) {
           var mediaUri = MpdUtils.fillUriTemplate(


### PR DESCRIPTION
This PR solves #690.

With the following SegmentTimeline snippet

      <SegmentTemplate timescale="10000000"  media="t$Time$.mp4">
      <SegmentTimeline>
      <S t="5369174623790086" d="40000000/>
      <S d="40000000" />
      </SegmentTimeline>

the second segment erroneously gets the wrong timestamp

5369174663790087 because it is calculated as

     (5369174623790086 / 10000000 + 40000000 / 10000000) * 10000000 = 5369174663790087

and results in an HTTP 404 error when requesting the segment using the $Time$.mp4 segment.

By avoiding, the division by 10000000 a more accurate calculation can be done:

5369174623790086 + 40000000 = 5369174663790086

This is fixed in the PR by storing the unscaled values `unscaledStart` and `unscaledPresentationOffset` and using them for generating the `timeReplacement` for the segment request URL.

A lot of other calculations use times scaled to seconds as before, but since they don't need to be fully accurate, no change is needed.

Unfortunately, we haven't found a good way to add a unit or functional test for this PR, but no existing tests are broken.  The fix solves the issue we have seen and makes our streams play in shaka player as they do in dash.js. We don't have reliable public URL, though.


