### PR TITLE
Improvement of segment timeline $Time$ accuracy

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Andy Hochhaus <ahochhaus@samegoal.com>
 Chad Assareh <assareh@google.com>
 Costel Madalin Grecu <madalin.grecu@adswizz.com>
 Donato Borrello <donato@jwplayer.com>
+Duc Pham <duc.pham@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>
 Itay Kinnrot <itay.kinnrot@kaltura.com>
 Jacob Trimble <modmaker@google.com>

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -269,8 +269,12 @@ shaka.dash.MpdUtils.createTimeline = function(
 
     for (var j = 0; j <= repeat; ++j) {
       var endTime = startTime + d;
-      timeline.push(
-          {start: (startTime / timescale), end: (endTime / timescale)});
+      var item = {
+        start: startTime / timescale,
+        end: endTime / timescale,
+        unscaledStart: startTime
+      };
+      timeline.push(item);
 
       startTime = endTime;
       lastEndTime = endTime;
@@ -398,6 +402,7 @@ shaka.dash.MpdUtils.parseSegmentInfo = function(context, callback) {
     segmentDuration: segmentDuration,
     startNumber: startNumber,
     presentationTimeOffset: pto,
+    unscaledPresentationTimeOffset: Number(presentationTimeOffset),
     timeline: timeline
   };
 };

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -44,6 +44,7 @@ shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS = 1 / 15;
 /**
  * @typedef {{
  *   start: number,
+ *   unscaledStart: number,
  *   end: number
  * }}
  *
@@ -52,6 +53,8 @@ shaka.dash.MpdUtils.GAP_OVERLAP_TOLERANCE_SECONDS = 1 / 15;
  *
  * @property {number} start
  *   The start time of the range.
+ * @property {number} unscaledStart
+ *   The start time of the range in representation timescale units.
  * @property {number} end
  *   The end time (exclusive) of the range.
  */
@@ -64,6 +67,7 @@ shaka.dash.MpdUtils.TimeRange;
  *   segmentDuration: ?number,
  *   startNumber: number,
  *   presentationTimeOffset: number,
+ *   unscaledPresentationTimeOffset: number,
  *   timeline: Array.<shaka.dash.MpdUtils.TimeRange>
  * }}
  *
@@ -78,6 +82,8 @@ shaka.dash.MpdUtils.TimeRange;
  *   The start number of the segments; 1 or greater.
  * @property {number} presentationTimeOffset
  *   The presentationTimeOffset of the representation, in seconds.
+ * @property {number} unscaledPresentationTimeOffset
+ *   The presentationTimeOffset of the representation, in timescale units.
  * @property {Array.<shaka.dash.MpdUtils.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
  */

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -174,6 +174,7 @@ shaka.dash.SegmentTemplate.parseSegmentTemplateInfo_ = function(context) {
     timescale: segmentInfo.timescale,
     startNumber: segmentInfo.startNumber,
     presentationTimeOffset: segmentInfo.presentationTimeOffset,
+    unscaledPresentationTimeOffset: segmentInfo.unscaledPresentationTimeOffset,
     timeline: segmentInfo.timeline,
     mediaTemplate: media,
     indexTemplate: index
@@ -357,6 +358,7 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
   var references = [];
   for (var i = 0; i < info.timeline.length; i++) {
     var start = info.timeline[i].start;
+    var unscaledStart = info.timeline[i].unscaledStart;
     var end = info.timeline[i].end;
 
     // Note: i = k - 1, where k indicates the k'th segment listed in the MPD.
@@ -364,9 +366,8 @@ shaka.dash.SegmentTemplate.createFromTimeline_ = function(context, info) {
     var segmentReplacement = i + info.startNumber;
 
     // Consider the presentation time offset in segment uri computation
-    var timeReplacement = (start + info.presentationTimeOffset) *
-        info.timescale;
-
+    var timeReplacement = unscaledStart +
+        info.unscaledPresentationTimeOffset;
     var createUris = (function(
             template, repId, bandwidth, baseUris, segmentId, time) {
           var mediaUri = MpdUtils.fillUriTemplate(

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -114,6 +114,7 @@ shaka.dash.SegmentTemplate.createStream = function(
  *   segmentDuration: ?number,
  *   startNumber: number,
  *   presentationTimeOffset: number,
+ *   unscaledPresentationTimeOffset: number,
  *   timeline: Array.<shaka.dash.MpdUtils.TimeRange>,
  *   mediaTemplate: ?string,
  *   indexTemplate: ?string
@@ -131,6 +132,8 @@ shaka.dash.SegmentTemplate.createStream = function(
  *   The start number of the segments; 1 or greater.
  * @property {number} presentationTimeOffset
  *   The presentationTimeOffset of the representation, in seconds.
+ * @property {number} unscaledPresentationTimeOffset
+ *   The presentationTimeOffset of the representation, in timescale units.
  * @property {Array.<shaka.dash.MpdUtils.TimeRange>} timeline
  *   The timeline of the representation, if given.  Times in seconds.
  * @property {?string} mediaTemplate


### PR DESCRIPTION
This PR solves #690 (and replaces PR #702)

With the following SegmentTimeline snippet

    <SegmentTemplate timescale="10000000"  media="$Time$.mp4">
      <SegmentTimeline>
        <S t="5369174623790086" d="40000000/>
      <S d="40000000" />
    </SegmentTimeline>
the second segment erroneously gets the wrong timestamp 5369174663790087 due to rounding errors.

This is because the calculation is done using values scaled to seconds as follows:

 (5369174623790086 / 10000000 + 40000000 / 10000000) * 10000000 = 5369174663790087

The problem with this rounding error is that the timestamp is used in the $Time$.mp4 URL template, and results in an HTTP 404 error when requesting the segment from the server.

Somewhat higher precision (roughly 1 more bit) can be achieved by avoiding the scaling and just do an integer addition like:

5369174623790086 + 40000000 = 5369174663790086

This is fixed in this PR by storing the unscaled values unscaledStart and unscaledPresentationOffset and using them for generating the timeReplacement for the segment request URL.

A lot of other calculations use times scaled to seconds as before, but since they don't need to be fully accurate, no change is needed.

Unfortunately, we haven't found a good way to add a unit or functional test for this PR, but no existing tests are broken. The fix solves the issue we have seen and makes our streams play in shaka player as they do in dash.js. We don't have reliable public URL, though.