### PR TITLE
use trun durations for synchronizing mp4 wrapped VTT cues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ Sanborn Hilland <sanbornh@rogers.com>
 TalkTalk Plc <*@talktalkplc.com>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 uStudio Inc. <*@ustudio.com>
+Verizon Digital Media Services <*@verizondigitalmedia.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -37,6 +37,7 @@ Johan Sundström <oyasumi@gmail.com>
 Jonas Birmé <jonas.birme@eyevinn.se>
 Jono Ward <jonoward@gmail.com>
 Jozef Chúťka <jozefchutka@gmail.com>
+Krisz Varro <krisz.varro@verizondigitalmedia.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Natalie Harris <natalieharris@google.com>

--- a/lib/media/mp4_vtt_parser.js
+++ b/lib/media/mp4_vtt_parser.js
@@ -106,13 +106,13 @@ shaka.media.Mp4VttParser =
     moovBoxSize = shaka.util.Mp4Parser.findBox(
         shaka.util.Mp4Parser.BOX_TYPE_MOOV, mdhdReader);
     if (moovBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
-      trakBoxSize = shaka.util.Mp4Parser.findBox(
+      var trakBoxSize = shaka.util.Mp4Parser.findBox(
           shaka.util.Mp4Parser.BOX_TYPE_TRAK, mdhdReader);
       if (trakBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
-        mdiaBoxSize = shaka.util.Mp4Parser.findBox(
+        var mdiaBoxSize = shaka.util.Mp4Parser.findBox(
             shaka.util.Mp4Parser.BOX_TYPE_MDIA, mdhdReader);
         if (mdiaBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
-          mdhdBoxSize = shaka.util.Mp4Parser.findBox(
+          var mdhdBoxSize = shaka.util.Mp4Parser.findBox(
               shaka.util.Mp4Parser.BOX_TYPE_MDHD, mdhdReader);
           if (mdhdBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
             var version = mdhdReader.readUint8();
@@ -298,7 +298,7 @@ shaka.media.Mp4VttParser.parseDataWithTrunDurations_ = function(
         where no subtitles are present (ISO 14496-30, 7.6) */
       case shaka.media.Mp4VttParser.BOX_TYPE_VTTE:
         emptyCuePadding += (trunDurations[idx].sample_duration / mdhdToMvhd);
-        reader.readBytes(size - 8);
+        reader.skip(size - 8);
         break;
       default:
         //no more cues

--- a/lib/media/mp4_vtt_parser.js
+++ b/lib/media/mp4_vtt_parser.js
@@ -45,6 +45,9 @@ shaka.media.Mp4VttParser =
   var reader = new shaka.util.DataViewReader(
       new DataView(data),
       shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
+
+  var trunDurations = shaka.media.Mp4VttParser.parseTrun_(reader);
+
   var boxSize = shaka.util.Mp4Parser.findBox(
       shaka.util.Mp4Parser.BOX_TYPE_MDAT, reader);
   if (boxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
@@ -53,20 +56,161 @@ shaka.media.Mp4VttParser =
     goog.asserts.assert(
         segmentStartTime != null, 'start time should not be null');
     goog.asserts.assert(segmentEndTime != null, 'end time should not be null');
-    return shaka.media.Mp4VttParser.parseData_(
-        reader.readBytes(boxSize - 8).buffer, offset,
-        segmentStartTime, segmentEndTime);
+    if (trunDurations.length != 0) {
+      return shaka.media.Mp4VttParser.parseDataWithTrunDurations_(
+          reader.readBytes(boxSize - 8).buffer, offset, segmentStartTime,
+          shaka.media.Mp4VttParser.movie_timescale,
+          shaka.media.Mp4VttParser.media_timescale,
+          trunDurations);
+    }
+    else {
+      return shaka.media.Mp4VttParser.parseData_(
+          reader.readBytes(boxSize - 8).buffer, offset,
+          segmentStartTime, segmentEndTime);
+    }
   }
   var wvttBoxSize = shaka.util.Mp4Parser.findSampleDescriptionBox(
       data, shaka.media.Mp4VttParser.BOX_TYPE_WVTT);
   if (wvttBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
     // a valid vtt init segment, no actual subtitles yet
+
+    shaka.media.Mp4VttParser.movie_timescale = 1;
+    shaka.media.Mp4VttParser.media_timescale = 1;
+    //grab movie timescale from moov->mvhd
+    var mvhdReader = new shaka.util.DataViewReader(
+        new DataView(data),
+        shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
+
+    var moovBoxSize = shaka.util.Mp4Parser.findBox(
+        shaka.util.Mp4Parser.BOX_TYPE_MOOV, mvhdReader);
+    if (moovBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+      var mvhdBoxSize = shaka.util.Mp4Parser.findBox(
+          shaka.util.Mp4Parser.BOX_TYPE_MVHD, mvhdReader);
+      if (mvhdBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+        var version = mvhdReader.readUint8();
+        mvhdReader.skip(3); //skip flags
+        if (version == 1)
+          mvhdReader.skip(16);
+        else //assume 0
+          mvhdReader.skip(8);
+
+        shaka.media.Mp4VttParser.movie_timescale = mvhdReader.readUint32();
+      }
+    }
+
+    //grab media timescale from moov->trak->mdia->mdhd
+    var mdhdReader = new shaka.util.DataViewReader(
+        new DataView(data),
+        shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
+
+    moovBoxSize = shaka.util.Mp4Parser.findBox(
+        shaka.util.Mp4Parser.BOX_TYPE_MOOV, mdhdReader);
+    if (moovBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+      trakBoxSize = shaka.util.Mp4Parser.findBox(
+          shaka.util.Mp4Parser.BOX_TYPE_TRAK, mdhdReader);
+      if (trakBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+        mdiaBoxSize = shaka.util.Mp4Parser.findBox(
+            shaka.util.Mp4Parser.BOX_TYPE_MDIA, mdhdReader);
+        if (mdiaBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+          mdhdBoxSize = shaka.util.Mp4Parser.findBox(
+              shaka.util.Mp4Parser.BOX_TYPE_MDHD, mdhdReader);
+          if (mdhdBoxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+            var version = mdhdReader.readUint8();
+            mdhdReader.skip(3); //skip flags
+            if (version == 1)
+              mdhdReader.skip(16);
+            else //assume 0
+              mdhdReader.skip(8);
+            shaka.media.Mp4VttParser.media_timescale = mdhdReader.readUint32();
+          }
+        }
+      }
+    }
+
     return [];
   } else {
     throw new shaka.util.Error(
         shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_VTT);
   }
+};
+
+
+/**
+ * parses the trun table of the segment and returns durations
+ *
+ * @param {!shaka.util.DataViewReader} reader
+ * @return {!Array.<!Object>}
+ * @private
+ */
+shaka.media.Mp4VttParser.parseTrun_ = function(reader) {
+  var trunDurations = [];
+  var boxSize = shaka.util.Mp4Parser.findBox(
+      shaka.util.Mp4Parser.BOX_TYPE_MOOF, reader);
+  if (boxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+    // trun box found, parse the content
+    boxSize = shaka.util.Mp4Parser.findBox(
+        shaka.util.Mp4Parser.BOX_TYPE_TRAF, reader);
+    if (boxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+      boxSize = shaka.util.Mp4Parser.findBox(
+          shaka.util.Mp4Parser.BOX_TYPE_TRUN, reader);
+      if (boxSize != shaka.util.Mp4Parser.BOX_NOT_FOUND) {
+        var version = reader.readUint8();
+        var tmp = new Uint8Array(4);
+        tmp[0] = 0;
+        tmp[1] = reader.readUint8();
+        tmp[2] = reader.readUint8();
+        tmp[3] = reader.readUint8();
+        var sample_flags = new DataView(tmp.buffer).getUint32(0);
+
+        var data_offset_present = sample_flags & 0x00000001;
+        var first_sample_flags_present = sample_flags & 0x00000004;
+        var sample_entry_durations_present = sample_flags & 0x000100;
+        var sample_entry_sizes_present = sample_flags & 0x000200;
+        var sample_entry_flags_present = sample_flags & 0x000400;
+        var sample_entry_comp_time_present = sample_flags & 0x000800;
+
+        var sample_count = reader.readUint32();
+        if (data_offset_present) {
+          reader.skip(4); //skip unused field 'data_offset'
+        }
+        if (first_sample_flags_present) {
+          reader.skip(4); //skip unused field 'first_sample_flags'
+        }
+
+        for (var i = 0; i < sample_count; i++)
+        {
+          var entry = {};
+          if (sample_entry_durations_present) {
+            entry.sample_duration = reader.readUint32();
+          }
+          if (sample_entry_sizes_present) {
+            entry.sample_size = reader.readUint32();
+          }
+          if (sample_entry_flags_present) {
+            entry.sample_flags = reader.readUint32();
+          }
+          if (sample_entry_comp_time_present) {
+            var scto = reader.readUint32();
+            if (version == 0) {
+              entry.sample_composition_time_offset = scto;
+            }
+            if (version == 1) {
+              var dv = new DataView(new Uint32Array([scto]).buffer, 0);
+              entry.sample_composition_time_offset = dv.getInt32(0);
+            }
+            else if (version != 0) {
+              shaka.log.warning('unexpected trun version: ', version,
+                  ' defaulting to unsigned int for composition offsets');
+              entry.sample_composition_time_offset = scto;
+            }
+          }
+          trunDurations.push(entry);
+        }
+      }
+    }
+  }
+  return trunDurations;
 };
 
 
@@ -103,6 +247,64 @@ shaka.media.Mp4VttParser.parseData_ = function(
         segmentStartTime, segmentEndTime);
     if (cue)
       result.push(cue);
+  }
+
+  return result;
+};
+
+
+/**
+ * Parses the content of the mdat MP4 box into cue objects.
+ *
+ * @param {ArrayBuffer} data
+ * @param {number} offset
+ * @param {number} segmentStartTime
+ * @param {number} movieTimeScale
+ * @param {number} mediaTimeScale
+ * @param {Array} trunDurations
+ * @return {!Array.<!TextTrackCue>}
+ * @private
+ */
+shaka.media.Mp4VttParser.parseDataWithTrunDurations_ = function(
+    data, offset, segmentStartTime, movieTimeScale,
+    mediaTimeScale, trunDurations) {
+  var reader = new shaka.util.DataViewReader(
+      new DataView(data),
+      shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
+
+  var result = [];
+  // Cues are represented as vttc boxes. Each box corresponds to a cue.
+  var idx = 0;
+  var emptyCuePadding = 0;
+  var mdhdToMvhd = mediaTimeScale / movieTimeScale;
+  while (reader.hasMoreData()) {
+    var size = reader.readUint32();
+    var type = reader.readUint32();
+    var lastCueEndTime = segmentStartTime;
+    switch (type) {
+      case shaka.media.Mp4VttParser.BOX_TYPE_VTTC:
+        var thisCueDuration = trunDurations[idx].sample_duration / mdhdToMvhd;
+        var thisCueStartTime = lastCueEndTime + emptyCuePadding;
+        var thisCueEndTime = lastCueEndTime + thisCueDuration;
+        var cue = shaka.media.Mp4VttParser.parseCue_(
+            reader.readBytes(size - 8).buffer,
+            thisCueStartTime, thisCueEndTime);
+        if (cue)
+          result.push(cue);
+        lastCueEndTime = thisCueEndTime;
+        emptyCuePadding = 0;
+        break;
+      /*we may run into empty cues which span time periods
+        where no subtitles are present (ISO 14496-30, 7.6) */
+      case shaka.media.Mp4VttParser.BOX_TYPE_VTTE:
+        emptyCuePadding += (trunDurations[idx].sample_duration / mdhdToMvhd);
+        reader.readBytes(size - 8);
+        break;
+      default:
+        //no more cues
+        break;
+    }
+    idx += 1;
   }
 
   return result;
@@ -205,6 +407,9 @@ shaka.media.Mp4VttParser.BOX_TYPE_IDEN = 0x6964656F;
 /** @const {number} */
 shaka.media.Mp4VttParser.BOX_TYPE_STTG = 0x73747467;
 
+
+/** @const {number} */
+shaka.media.Mp4VttParser.BOX_TYPE_VTTE = 0x76747465;
 
 shaka.media.TextEngine.registerParser(
     'application/mp4; codecs="wvtt"', shaka.media.Mp4VttParser);

--- a/lib/media/mp4_vtt_parser.js
+++ b/lib/media/mp4_vtt_parser.js
@@ -275,29 +275,28 @@ shaka.media.Mp4VttParser.parseDataWithTrunDurations_ = function(
   var result = [];
   // Cues are represented as vttc boxes. Each box corresponds to a cue.
   var idx = 0;
-  var emptyCuePadding = 0;
+  //convert track timescale to movie timescale
   var mdhdToMvhd = mediaTimeScale / movieTimeScale;
+  var lastCueEndTime = segmentStartTime;
   while (reader.hasMoreData()) {
     var size = reader.readUint32();
     var type = reader.readUint32();
-    var lastCueEndTime = segmentStartTime;
     switch (type) {
       case shaka.media.Mp4VttParser.BOX_TYPE_VTTC:
         var thisCueDuration = trunDurations[idx].sample_duration / mdhdToMvhd;
-        var thisCueStartTime = lastCueEndTime + emptyCuePadding;
-        var thisCueEndTime = lastCueEndTime + thisCueDuration;
+        var thisCueStartTime = lastCueEndTime;
+        var thisCueEndTime = thisCueStartTime + thisCueDuration;
         var cue = shaka.media.Mp4VttParser.parseCue_(
             reader.readBytes(size - 8).buffer,
             thisCueStartTime, thisCueEndTime);
         if (cue)
           result.push(cue);
         lastCueEndTime = thisCueEndTime;
-        emptyCuePadding = 0;
         break;
       /*we may run into empty cues which span time periods
         where no subtitles are present (ISO 14496-30, 7.6) */
       case shaka.media.Mp4VttParser.BOX_TYPE_VTTE:
-        emptyCuePadding += (trunDurations[idx].sample_duration / mdhdToMvhd);
+        lastCueEndTime += (trunDurations[idx].sample_duration / mdhdToMvhd);
         reader.skip(size - 8);
         break;
       default:

--- a/lib/util/mp4_parser.js
+++ b/lib/util/mp4_parser.js
@@ -128,4 +128,24 @@ shaka.util.Mp4Parser.BOX_TYPE_STSD = 0x73747364;
 
 
 /** @const {number} */
+shaka.util.Mp4Parser.BOX_TYPE_MOOF = 0x6D6F6F66;
+
+
+/** @const {number} */
+shaka.util.Mp4Parser.BOX_TYPE_TRAF = 0x74726166;
+
+
+/** @const {number} */
+shaka.util.Mp4Parser.BOX_TYPE_TRUN = 0x7472756E;
+
+
+/** @const {number} */
+shaka.util.Mp4Parser.BOX_TYPE_MVHD = 0x6d766864;
+
+
+/** @const {number} */
+shaka.util.Mp4Parser.BOX_TYPE_MDHD = 0x6d646864;
+
+
+/** @const {number} */
 shaka.util.Mp4Parser.BOX_TYPE_EMSG = 0x656D7367;

--- a/test/media/mp4_vtt_parser_unit.js
+++ b/test/media/mp4_vtt_parser_unit.js
@@ -72,35 +72,35 @@ describe('Mp4vttParser', function() {
   it('parses media segment', function() {
     var cues =
         [
-         {start: 20, end: 40, text: 'It has shed much innocent blood.\n'},
-         {start: 20, end: 40, text:
+         {start: 1080, end: 3480, text: 'It has shed much innocent blood.\n'},
+         {start: 4800, end: 6000, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 0, 20, 40, false);
+    var result = shaka.media.Mp4VttParser(vttSegment, 0, 0, 10000, false);
     verifyHelper(cues, result);
   });
 
   it('parses media segment containing settings', function() {
     var cues =
         [
-         {start: 20, end: 40, text: 'It has shed much innocent blood.\n',
+         {start: 1080, end: 3480, text: 'It has shed much innocent blood.\n',
            align: 'right', size: 50, position: 10},
-         {start: 20, end: 40, text:
+         {start: 4800, end: 6000, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n',
            vertical: 'lr', line: 1}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 20, 40, false);
+    var result = shaka.media.Mp4VttParser(vttSegSettings, 0, 0, 10000, false);
     verifyHelper(cues, result);
   });
 
   it('accounts for offset', function() {
     var cues =
         [
-         {start: 27, end: 47, text: 'It has shed much innocent blood.\n'},
-         {start: 27, end: 47, text:
+         {start: 1080, end: 3480, text: 'It has shed much innocent blood.\n'},
+         {start: 4800, end: 6000, text:
            'You\'re a fool for traveling alone,\nso completely unprepared.\n'}
         ];
-    var result = shaka.media.Mp4VttParser(vttSegment, 7, 20, 40, false);
+    var result = shaka.media.Mp4VttParser(vttSegment, 7, 0, 10000, false);
     verifyHelper(cues, result);
   });
 
@@ -108,7 +108,7 @@ describe('Mp4vttParser', function() {
     var error = new shaka.util.Error(shaka.util.Error.Category.TEXT,
         shaka.util.Error.Code.INVALID_MP4_VTT);
     try {
-      shaka.media.Mp4VttParser(audioInitSegment, 0, 20, 40, false);
+      shaka.media.Mp4VttParser(audioInitSegment, 0, 0, 10000, false);
       fail('Mp4 file with no vtt supported');
     } catch (e) {
       shaka.test.Util.expectToEqualError(e, error);


### PR DESCRIPTION
This pull request will use sample duration values in the TRUN box to calculate the start/end times for MP4 wrapped VTT cues. 

I believe this should also address issue #699 
https://github.com/google/shaka-player/issues/699 

I've gone through the CONTRIBUTING.md file, and I believe I have met all the criteria. Our corporate CLA was signed and accepted as of 3/9/2017