### PR TITLE
Add official method for accessing HTML media element

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -776,6 +776,16 @@ shaka.Player.prototype.resetConfiguration = function() {
 
 
 /**
+ * @return {HTMLMediaElement} A reference to the HTML Media Element passed
+ *     in during initialization.
+ * @export
+ */
+shaka.Player.prototype.getMediaElement = function() {
+  return this.video_;
+};
+
+
+/**
  * @return {shaka.net.NetworkingEngine} A reference to the Player's networking
  *     engine.  Applications may use this to make requests through Shaka's
  *     networking plugins.


### PR DESCRIPTION
In some cases it may be necessary to get access to the HTML Media Element (the one that is passed in during initialization of a player) from a player instance when you no longer have a reference to what it was initialized with. In this case it would be helpful to have a method to do so (and not have to access player.video_ directly, which could change at any point not reflected by semver as it's not an official API). 
