### PR TITLE
Add bFrameAdjustment configuration option to address PTS/DTS bug

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -41,12 +41,15 @@ goog.require('shaka.util.PublicPromise');
  * @param {MediaSource} mediaSource The MediaSource, which must be in the
  *   'open' state.
  * @param {TextTrack} textTrack The TextTrack to use for subtitles/captions.
+ * @param {shakaExtern.BFrameAdjustment} bFrameAdjustment Configuration options
+ *   for adjusting the timestampOffset and windowEnd to account for bframes.
  *
  * @struct
  * @constructor
  * @implements {shaka.util.IDestroyable}
  */
-shaka.media.MediaSourceEngine = function(video, mediaSource, textTrack) {
+shaka.media.MediaSourceEngine =
+    function(video, mediaSource, textTrack, bFrameAdjustment) {
   goog.asserts.assert(mediaSource.readyState == 'open',
                       'The MediaSource should be in the \'open\' state.');
 
@@ -59,9 +62,15 @@ shaka.media.MediaSourceEngine = function(video, mediaSource, textTrack) {
   /** @private {TextTrack} */
   this.textTrack_ = textTrack;
 
+  /** @private {shakaExtern.BFrameAdjustment} */
+  this.bFrameAdjustment_ = bFrameAdjustment;
+
   /** @private {!Object.<shaka.util.ManifestParserUtils.ContentType,
                          SourceBuffer>} */
   this.sourceBuffers_ = {};
+
+  /** @private {?number} */
+  this.videoFrameRate_ = null;
 
   /** @private {shaka.media.TextEngine} */
   this.textEngine_ = null;
@@ -460,16 +469,21 @@ shaka.media.MediaSourceEngine.prototype.flush = function(contentType) {
  *   value does not affect segments which have already been inserted.
  * @param {?number} appendWindowEnd The timestamp to set the append window end
  *   to. Media beyond this value will be truncated.
+ * @param {?number} frameRate The framerate; only provided by video tracks
  * @return {!Promise}
  */
 shaka.media.MediaSourceEngine.prototype.setStreamProperties = function(
-    contentType, timestampOffset, appendWindowEnd) {
+    contentType, timestampOffset, appendWindowEnd, frameRate) {
   var ContentType = shaka.util.ManifestParserUtils.ContentType;
   if (contentType == ContentType.TEXT) {
     this.textEngine_.setTimestampOffset(timestampOffset);
     if (appendWindowEnd != null)
       this.textEngine_.setAppendWindowEnd(appendWindowEnd);
     return Promise.resolve();
+  }
+
+  if (contentType == ContentType.VIDEO) {
+    this.videoFrameRate_ = frameRate;
   }
 
   if (appendWindowEnd == null)
@@ -637,7 +651,17 @@ shaka.media.MediaSourceEngine.prototype.flush_ = function(contentType) {
  */
 shaka.media.MediaSourceEngine.prototype.setTimestampOffset_ =
     function(contentType, timestampOffset) {
-  this.sourceBuffers_[contentType].timestampOffset = timestampOffset;
+  var ContentType = shaka.util.ManifestParserUtils.ContentType;
+  var fudge = 0;
+
+  if (contentType == ContentType.VIDEO &&
+        this.bFrameAdjustment_.adjustOffset) {
+    goog.asserts.assert(this.videoFrameRate_,
+        'Must provide frameRate for offset bframe adjustment');
+    fudge = this.bFrameAdjustment_.bFrameCount / this.videoFrameRate_;
+  }
+
+  this.sourceBuffers_[contentType].timestampOffset = timestampOffset + fudge;
 
   // Fake 'updateend' event to resolve the operation.
   this.onUpdateEnd_(contentType);
@@ -652,7 +676,16 @@ shaka.media.MediaSourceEngine.prototype.setTimestampOffset_ =
  */
 shaka.media.MediaSourceEngine.prototype.setAppendWindowEnd_ =
     function(contentType, appendWindowEnd) {
-  var fudge = 1 / 25;  // one frame, assuming a low framerate
+  var ContentType = shaka.util.ManifestParserUtils.ContentType;
+  var fudge = 1 / 25; // one frame, assuming a low framerate
+  if (contentType == ContentType.VIDEO &&
+        this.bFrameAdjustment_.adjustWindowEnd) {
+    goog.asserts.assert(this.videoFrameRate_,
+        'Must provide frameRate for windowEnd bframe adjustment');
+    // windowEnd is exclusive, so we need one extra frame on the end
+    fudge = (this.bFrameAdjustment_.bFrameCount + 1) / this.videoFrameRate_;
+  }
+
   this.sourceBuffers_[contentType].appendWindowEnd = appendWindowEnd + fudge;
 
   // Fake 'updateend' event to resolve the operation.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1398,7 +1398,8 @@ shaka.media.StreamingEngine.prototype.initSourceBuffer_ = function(
   shaka.log.v1(logPrefix, 'setting append window end to ' + appendWindowEnd);
   var setStreamProperties =
       this.playerInterface_.mediaSourceEngine.setStreamProperties(
-          mediaState.type, timestampOffset, appendWindowEnd);
+        mediaState.type, timestampOffset, appendWindowEnd,
+        mediaState.stream.frameRate || null);
 
   if (!mediaState.stream.initSegmentReference) {
     // The Stream is self initializing.

--- a/lib/player.js
+++ b/lib/player.js
@@ -652,7 +652,8 @@ shaka.Player.prototype.createMediaSource = function() {
  */
 shaka.Player.prototype.createMediaSourceEngine = function() {
   return new shaka.media.MediaSourceEngine(
-      this.video_, this.mediaSource_, this.textTrack_);
+      this.video_, this.mediaSource_, this.textTrack_,
+      this.config_.streaming.bFrameAdjustment);
 };
 
 
@@ -1641,7 +1642,12 @@ shaka.Player.prototype.defaultConfig_ = function() {
       bufferBehind: 30,
       ignoreTextStreamFailures: false,
       useRelativeCueTimestamps: false,
-      startAtSegmentBoundary: false
+      startAtSegmentBoundary: false,
+      bFrameAdjustment: {
+        adjustOffset: true,
+        adjustWindowEnd: true,
+        bFrameCount: 2
+      }
     },
     abr: {
       manager: this.defaultAbrManager_,


### PR DESCRIPTION
I know you guys have been working on gap jumping as a workaround for the PTS/DTS bug, which should go a long way for many use cases. We have our own gap jumping implementation, but it has some limitations. Specifically: transitions to new periods are not smooth, and content with a correctly set base_media_decode_time (DTS) will not start because it ends up with a negative presentation start time.

This approach fixes the underlying problem, but requires uniform and predictable frame rates and bframe counts.

I think it is a relatively unobtrusive solution that goes a long way towards achieving smooth multi-period playback for most use cases.

Take a look and let me know what you think. If it is something you'd consider I can clean it up and fix tests.

----

WIP: pending discussion, will add/fix tests

This change introduces a configuration option that adjusts the timestampOffset and appendWindowEnd to address the PTS/DTS bug in Chrome. It assumes that the number of bframes is known, and constant. It also assumes that the manifest provides an accurate framerate.

Full explanation at: https://github.com/baconz/shaka-player/blob/bframe-adjustment-for-chrome/externs/shaka/player.js#L474