### PR TITLE
Add ProgressEvent on NetworkingEngine. Allows for tracking progress of network transactions.

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -148,6 +148,10 @@ summary {
   max-width: 80%;
 }
 
+#bufferingProgressBar {
+  width: 80%;
+}
+
 #container {
   margin: 0 auto 0 auto;
   max-width: 40em;

--- a/demo/index.html
+++ b/demo/index.html
@@ -82,6 +82,7 @@
 
         <div>
           <button id="loadButton">Load</button>
+          <progress id="bufferingProgressBar" value="0" max="100"></progress>
         </div>
       </div>
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -63,6 +63,10 @@ shakaDemo.hashCanChange_ = false;
 shakaDemo.suppressHashChangeEvent_ = false;
 
 
+/** @private {Object} */
+shakaDemo.pendingNetworkTransactions_ = {};
+
+
 /**
  * @private
  * @const {string}
@@ -155,7 +159,14 @@ shakaDemo.init = function() {
 
       shakaDemo.video_ = shakaDemo.castProxy_.getVideo();
       shakaDemo.player_ = shakaDemo.castProxy_.getPlayer();
+
+      // add error handling
       shakaDemo.player_.addEventListener('error', shakaDemo.onErrorEvent_);
+
+      // add network transactions progress events listener
+      shakaDemo.player_.getNetworkingEngine().addEventListener('progress',
+          shakaDemo.onNetworkProgressEvent_);
+
       shakaDemo.localVideo_ = localVideo;
       shakaDemo.localPlayer_ = localPlayer;
 
@@ -472,6 +483,61 @@ shakaDemo.hashShouldChange_ = function() {
 shakaDemo.onErrorEvent_ = function(event) {
   var error = event.detail;
   shakaDemo.onError_(error);
+};
+
+
+/**
+ * @param {Object} event
+ * @private
+ */
+shakaDemo.onNetworkProgressEvent_ = function(event) {
+
+  var responseURL;
+  var aggregatedLoaded = 0;
+  var aggregatedTotal = 0;
+  var progressBar;
+  var contentType;
+  var pendingNetworkTransactions = shakaDemo.pendingNetworkTransactions_;
+
+  // only track progress of segment requests
+  if (event.requestType !== shaka.net.NetworkingEngine.RequestType.SEGMENT) {
+    return;
+  }
+
+  // make sure we have an underlying XHR
+  if (!(event.innerTarget instanceof XMLHttpRequest)) {
+    return;
+  }
+
+  // make sure we ignore text/ and audio/ or init segments.
+  // (webm audio segments may be returned by the server as video/webm however)
+  contentType = event.innerTarget.getResponseHeader('Content-Type');
+  if (!contentType || !contentType.startsWith('video/')) {
+    return;
+  }
+
+  responseURL = event.innerTarget.responseURL;
+  pendingNetworkTransactions[responseURL] = event;
+
+  var pendingSegmentUrls =
+      Object.getOwnPropertyNames(pendingNetworkTransactions);
+
+  // only aggregate progress info when buffering
+  if (shakaDemo.player_.isBuffering()) {
+    pendingSegmentUrls.forEach(function(url) {
+      aggregatedLoaded += pendingNetworkTransactions[url].loaded;
+      aggregatedTotal += pendingNetworkTransactions[url].total;
+    });
+  }
+
+  progressBar = document.getElementById('bufferingProgressBar');
+  progressBar.value = aggregatedLoaded;
+  progressBar.max = aggregatedTotal;
+
+  // if we loaded the last byte remove it from map
+  if (event.loaded === event.total) {
+    delete pendingNetworkTransactions[responseURL];
+  }
 };
 
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -162,6 +162,8 @@ shakaDemo.init = function() {
 
       // add error handling
       shakaDemo.player_.addEventListener('error', shakaDemo.onErrorEvent_);
+      shakaDemo.player_.addEventListener('segmentbuffering', 
+          shakaDemo.onSegmentBufferingEvent_);
 
       // add network transactions progress events listener
       shakaDemo.player_.getNetworkingEngine().addEventListener('progress',
@@ -486,11 +488,29 @@ shakaDemo.onErrorEvent_ = function(event) {
 };
 
 
+shakaDemo.onSegmentBufferingEvent_ = function(event) {
+
+  console.log(event);
+
+  var contentType = event.contentType;
+
+  if (contentType === 'video') {
+
+    var progressBar = document.getElementById('bufferingProgressBar');
+    progressBar.value = event.bufferingProgress;
+    progressBar.max = event.bufferingGoal;
+  }
+};
+
 /**
  * @param {Object} event
  * @private
  */
 shakaDemo.onNetworkProgressEvent_ = function(event) {
+
+  return;
+
+  /*
 
   var responseURL;
   var aggregatedLoaded = 0;
@@ -538,6 +558,7 @@ shakaDemo.onNetworkProgressEvent_ = function(event) {
   if (event.loaded === event.total) {
     delete pendingNetworkTransactions[responseURL];
   }
+  */
 };
 
 

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -125,7 +125,9 @@ shakaExtern.Response;
  *
  * @typedef {!function(string,
  *                     shakaExtern.Request,
- *                     shaka.net.NetworkingEngine.RequestType):
+ *                     shaka.net.NetworkingEngine.RequestType,
+ *                     function(ProgressEvent,
+ *                      shaka.net.NetworkingEngine.RequestType)):
  *     !Promise.<shakaExtern.Response>}
  * @exportDoc
  */

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -100,7 +100,8 @@ shaka.cast.CastUtils.PlayerEvents = [
   'timelineregionadded',
   'timelineregionenter',
   'timelineregionexit',
-  'trackschanged'
+  'trackschanged',
+  'segmentbuffering'
 ];
 
 

--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -223,6 +223,11 @@ shaka.media.Playhead.prototype.setBuffering = function(buffering) {
 };
 
 
+shaka.media.Playhead.prototype.isBuffering = function(buffering) {
+  return this.buffering_;
+}
+
+
 /**
  * Gets the current effective playback rate.  This may be negative even if the
  * browser does not directly support rewinding.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -72,6 +72,8 @@ goog.require('shaka.util.StreamUtils');
  * @implements {shaka.util.IDestroyable}
  */
 shaka.media.StreamingEngine = function(manifest, playerInterface) {
+
+
   /** @private {?shaka.media.StreamingEngine.PlayerInterface} */
   this.playerInterface_ = playerInterface;
 
@@ -134,6 +136,9 @@ shaka.media.StreamingEngine = function(manifest, playerInterface) {
 
   /** @private {boolean} */
   this.destroyed_ = false;
+
+  this.requestTrackers_ =  [];
+  this.netProgressEventHandler_ = null;
 };
 
 
@@ -271,6 +276,9 @@ shaka.media.StreamingEngine.prototype.destroy = function() {
     this.cancelUpdate_(this.mediaStates_[type]);
   }
 
+  this.playerInterface_.netEngine.removeEventListener(
+      this.netProgressEventHandler_);
+
   this.playerInterface_ = null;
   this.manifest_ = null;
   this.setupPeriodPromise_ = null;
@@ -337,6 +345,10 @@ shaka.media.StreamingEngine.prototype.init = function() {
         shaka.util.Error.Category.STREAMING,
         shaka.util.Error.Code.INVALID_STREAMS_CHOSEN));
   }
+
+  this.netProgressEventHandler_ = this.onNetProgressEvent_.bind(this);
+  this.playerInterface_.netEngine.addEventListener('progress',
+      this.netProgressEventHandler_);
 
   // Setup the initial set of Streams and then begin each update cycle. After
   // startup completes onUpdate_() will set up the remaining Periods.
@@ -1208,7 +1220,7 @@ shaka.media.StreamingEngine.prototype.fetchAndAppend_ = function(
   mediaState.needInitSegment = false;
 
   shaka.log.v2(logPrefix, 'fetching segment');
-  var fetchSegment = this.fetch_(reference);
+  var fetchSegment = this.fetch_(reference, mediaState.type);
 
   Promise.all([initSourceBuffer, fetchSegment]).then(function(results) {
     if (this.destroyed_ || this.fatalError_) return;
@@ -1808,7 +1820,7 @@ shaka.media.StreamingEngine.prototype.findPeriodContainingStream_ = function(
  * @return {!Promise.<!ArrayBuffer>}
  * @private
  */
-shaka.media.StreamingEngine.prototype.fetch_ = function(reference) {
+shaka.media.StreamingEngine.prototype.fetch_ = function(reference, contentType) {
   var requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
   var request = shaka.net.NetworkingEngine.makeRequest(
       reference.getUris(), this.config_.retryParameters);
@@ -1822,10 +1834,136 @@ shaka.media.StreamingEngine.prototype.fetch_ = function(reference) {
   }
 
   shaka.log.v2('fetching: reference=' + reference);
+
+  this.addRequestTracker_(reference, request, contentType);
+
   var p = this.playerInterface_.netEngine.request(requestType, request);
   return p.then(function(response) {
     return response.data;
   });
+};
+
+/**
+ * Creates a request tracker for a request and adds it to the list of trackers.
+ * @private
+ */
+shaka.media.StreamingEngine.prototype.addRequestTracker_ = function(reference, request, contentType) {
+  this.requestTrackers_.push({
+    reference: reference,
+    request: request,
+    contentType: contentType,
+    loadedBytes: 0,
+    totalBytes: 0,
+    startTime: Date.now(),
+    endTime: null
+  });
+};
+
+
+/**
+ * Updates the appropriate request tracker (if existent) based on a net progress event.
+ * @private
+ */
+shaka.media.StreamingEngine.prototype.updateRequestTrackers_ = function(progressEvent) {
+  var request = progressEvent.request;
+  var loadedBytes = progressEvent.loaded;
+  var totalBytes = progressEvent.total;
+
+  // look for tracker
+  var requestTracker = this.requestTrackers_.filter(function(tracker) {
+    return tracker.request === request;
+  });
+
+  // the request for which a progress event was dispatched has no tracker
+  if (requestTracker.length === 0) {
+    return;
+  }
+
+  goog.asserts.assert(
+      requestTracker.length === 1,
+      'there can not be more than one request-tracker per request, found: ' + requestTracker.length);
+
+  requestTracker = requestTracker[0];
+
+  requestTracker.loadedBytes = loadedBytes;
+  requestTracker.totalBytes = totalBytes;
+  if (loadedBytes === totalBytes) {
+    requestTracker.endTime = Date.now();
+  }
+
+  this.consumeRequestTrackingEvents_();
+};
+
+/**
+ * Consumes the request trackers list and evaluates prebuffered mediatime.
+ * This means it removes trackers that are not needed anymore to indicate future
+ * buffering progress. Dispatches segmentbuffering events to player callback
+ * when in buffering state.
+ * @private
+ */
+shaka.media.StreamingEngine.prototype.consumeRequestTrackingEvents_ = function() {
+
+  var playerIsNotBuffering = !this.playerInterface_.playhead.isBuffering();
+  var ContentType = shaka.util.ManifestParserUtils.ContentType;
+  var bufferingGoal = this.getBufferingGoal_();
+
+  [ContentType.AUDIO, ContentType.VIDEO].forEach(function(contentType) {
+    var loadedMediaTime = 0;
+    var trackers = this.requestTrackers_.filter(function(tracker) {
+        return tracker.contentType === contentType
+            && tracker.totalBytes > 0;
+    }); 
+
+    trackers.forEach(function(tracker, index) {
+
+        var reference = tracker.reference;
+        var duration = reference.endTime - reference.startTime;
+        var isNotLast = index !== (trackers.length - 1);
+        var isDone = tracker.endTime !== null;
+
+        // if we are not buffering and this is not the last tracker added
+        // for this content type, and the request is done, 
+        // removes this tracker from the list.
+        if (playerIsNotBuffering && isNotLast && isDone) {
+          this.requestTrackers_.splice(this.requestTrackers_.findIndex(function(t) {
+            return t === tracker;
+          }), 1);
+        }
+
+        // we make an approximation of the loaded media time fraction
+        // by assuming that the segment data is CBR here.
+        // This will not be exact in reality (video is mostly VBR in practice)
+        // but it will still serve as good approximation to indicate progress
+        // and will be a better approximation with decreasing segment duration.
+        // We don't need precision here, 
+        // it is supposed to be approximate in a useful way.
+        loadedMediaTime += duration * (tracker.loadedBytes / tracker.totalBytes);
+    }.bind(this));
+
+    var event = new shaka.util.FakeEvent('segmentbuffering', {
+      'contentType': contentType,
+      'bufferingProgress': loadedMediaTime,
+      'bufferingGoal': bufferingGoal
+    });
+
+    // when we are not buffering we don't want to dispatch these events.
+    if (playerIsNotBuffering) {
+      return;
+    }
+
+    this.playerInterface_.onEvent(event);
+
+  }.bind(this));
+};
+
+
+/**
+ * Handles progress events from NetworkingEngine.
+ * @private
+ * @param {ProgressEvent} event
+ */
+shaka.media.StreamingEngine.prototype.onNetProgressEvent_ = function(event) {
+  this.updateRequestTrackers_(event);
 };
 
 

--- a/lib/net/data_uri_plugin.js
+++ b/lib/net/data_uri_plugin.js
@@ -30,10 +30,12 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/data_URIs
  * @param {string} uri
  * @param {shakaExtern.Request} request
+ * @param {shaka.net.NetworkingEngine.RequestType} type
+ * @param {function(ProgressEvent, shaka.net.NetworkingEngine.RequestType)} onProgress
  * @return {!Promise.<shakaExtern.Response>}
  * @export
  */
-shaka.net.DataUriPlugin = function(uri, request) {
+shaka.net.DataUriPlugin = function(uri, request, type, onProgress) {
   return new Promise(function(resolve, reject) {
     var parsed = shaka.net.DataUriPlugin.parse(uri);
 

--- a/lib/net/http_plugin.js
+++ b/lib/net/http_plugin.js
@@ -29,10 +29,14 @@ goog.require('shaka.util.StringUtils');
  * @summary A networking plugin to handle http and https URIs via XHR.
  * @param {string} uri
  * @param {shakaExtern.Request} request
+ * @param {shaka.net.NetworkingEngine.RequestType} type
+ * @param {function(ProgressEvent, shaka.net.NetworkingEngine.RequestType)} onProgress
+ * ProgressEvent handling function.
+ * It may or may not be called by plugin implementations.
  * @return {!Promise.<shakaExtern.Response>}
  * @export
  */
-shaka.net.HttpPlugin = function(uri, request) {
+shaka.net.HttpPlugin = function(uri, request, type, onProgress) {
   return new Promise(function(resolve, reject) {
     var xhr = new XMLHttpRequest();
 
@@ -100,6 +104,11 @@ shaka.net.HttpPlugin = function(uri, request) {
           shaka.util.Error.Category.NETWORK,
           shaka.util.Error.Code.TIMEOUT,
           uri));
+    };
+    xhr.onprogress = function(event) {
+      if (onProgress) {
+        onProgress(event, type);
+      }
     };
 
     for (var k in request.headers) {

--- a/lib/net/http_plugin.js
+++ b/lib/net/http_plugin.js
@@ -107,7 +107,7 @@ shaka.net.HttpPlugin = function(uri, request, type, onProgress) {
     };
     xhr.onprogress = function(event) {
       if (onProgress) {
-        onProgress(event, type);
+        onProgress(event, type, request);
       }
     };
 

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -21,6 +21,8 @@ goog.require('goog.Uri');
 goog.require('goog.asserts');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.Error');
+goog.require('shaka.util.FakeEvent');
+goog.require('shaka.util.FakeEventTarget');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.PublicPromise');
@@ -38,10 +40,13 @@ goog.require('shaka.util.PublicPromise');
  *
  * @struct
  * @constructor
+ * @extends {shaka.util.FakeEventTarget}
  * @implements {shaka.util.IDestroyable}
  * @export
  */
 shaka.net.NetworkingEngine = function(opt_onSegmentDownloaded) {
+  shaka.util.FakeEventTarget.call(this);
+
   /** @private {boolean} */
   this.destroyed_ = false;
 
@@ -57,6 +62,7 @@ shaka.net.NetworkingEngine = function(opt_onSegmentDownloaded) {
   /** @private {?function(number, number)} */
   this.onSegmentDownloaded_ = opt_onSegmentDownloaded || null;
 };
+goog.inherits(shaka.net.NetworkingEngine, shaka.util.FakeEventTarget);
 
 
 /**
@@ -79,6 +85,25 @@ shaka.net.NetworkingEngine.RequestType = {
  * @private {!Object.<string, ?shakaExtern.SchemePlugin>}
  */
 shaka.net.NetworkingEngine.schemes_ = {};
+
+/**
+ * @event shaka.net.NetworkingEngine.ProgressEvent
+ * @description Fired when scheme plugins notify about data transfer progress.
+ * @property {string} type
+ *   'progress'
+ * @property {number} loaded
+ *   Bytes loaded until
+ * @property {number} total
+ *   Bytes length to load
+ * @property {boolean} lengthComputable
+ *   Tells if the progress is measurable
+ * @property {EventTarget} innerTarget
+ *   Target object of the underlying ProgressEvent
+ *   This could be for example an XMLHttpRequest object.
+ * @property {shaka.net.NetworkingEngine.RequestType} requestType
+ *   Type of request this event reports progress on.
+ * @exportDoc
+ */
 
 
 /**
@@ -339,6 +364,30 @@ shaka.net.NetworkingEngine.prototype.request = function(type, request) {
 
 
 /**
+ * Handles progress events from plugins.
+ * May or may not be called by plugin implementations.
+ * We trigger progress events to allow applications to measure
+ * or display the actual network transaction throughput.
+ * @param {ProgressEvent} progressEvent
+ * Target property may allow to map the event to a specific transaction.
+ * @param {shaka.net.NetworkingEngine.RequestType} requestType
+ * @private
+ */
+shaka.net.NetworkingEngine.prototype.onProgress_ = function(
+    progressEvent, 
+    requestType) {
+  var event = new shaka.util.FakeEvent('progress', {
+    'innerTarget': progressEvent.target,
+    'lengthComputable': progressEvent.lengthComputable,
+    'loaded': progressEvent.loaded,
+    'total': progressEvent.total,
+    'requestType': requestType
+  });
+  this.dispatchEvent(event);
+};
+
+
+/**
  * Sends the given request to the correct plugin.  This does not handle retry.
  *
  * @param {shaka.net.NetworkingEngine.RequestType} type
@@ -380,7 +429,11 @@ shaka.net.NetworkingEngine.prototype.send_ = function(
   }
 
   var startTimeMs = Date.now();
-  return plugin(request.uris[index], request, type).then(function(response) {
+  return plugin(
+      request.uris[index],
+      request,
+      type,
+      this.onProgress_.bind(this)).then(function(response) {
     if (response.timeMs == undefined)
       response.timeMs = Date.now() - startTimeMs;
     var filterStartMs = Date.now();

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -101,6 +101,8 @@ shaka.net.NetworkingEngine.schemes_ = {};
  *   Target object of the underlying ProgressEvent (e.g an XMLHttpRequest).
  * @property {shaka.net.NetworkingEngine.RequestType} requestType
  *   Type of request this event reports progress on.
+ * @property {shakaExtern.Request} request
+ *   Request handling object this event reports progress on.
  * @exportDoc
  */
 
@@ -370,17 +372,18 @@ shaka.net.NetworkingEngine.prototype.request = function(type, request) {
  * @param {ProgressEvent} progressEvent
  * Target property may allow to map the event to a specific transaction.
  * @param {shaka.net.NetworkingEngine.RequestType} requestType
+ * @param {shaka.net.NetworkingEngine.Request} request
  * @private
  */
 shaka.net.NetworkingEngine.prototype.onProgress_ = function(
-    progressEvent, 
-    requestType) {
+    progressEvent, requestType, request) {
   var event = new shaka.util.FakeEvent('progress', {
     'innerTarget': progressEvent.target,
     'lengthComputable': progressEvent.lengthComputable,
     'loaded': progressEvent.loaded,
     'total': progressEvent.total,
-    'requestType': requestType
+    'requestType': requestType,
+    'request': request
   });
   this.dispatchEvent(event);
 };

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -98,8 +98,7 @@ shaka.net.NetworkingEngine.schemes_ = {};
  * @property {boolean} lengthComputable
  *   Tells if the progress is measurable
  * @property {EventTarget} innerTarget
- *   Target object of the underlying ProgressEvent
- *   This could be for example an XMLHttpRequest object.
+ *   Target object of the underlying ProgressEvent (e.g an XMLHttpRequest).
  * @property {shaka.net.NetworkingEngine.RequestType} requestType
  *   Type of request this event reports progress on.
  * @exportDoc

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -92,9 +92,9 @@ shaka.net.NetworkingEngine.schemes_ = {};
  * @property {string} type
  *   'progress'
  * @property {number} loaded
- *   Bytes loaded until
+ *   Bytes count loaded so far
  * @property {number} total
- *   Bytes length to load
+ *   Bytes total length to load
  * @property {boolean} lengthComputable
  *   Tells if the progress is measurable
  * @property {EventTarget} innerTarget

--- a/lib/offline/offline_scheme.js
+++ b/lib/offline/offline_scheme.js
@@ -27,10 +27,12 @@ goog.require('shaka.util.Error');
  * @summary A plugin that handles requests for offline content.
  * @param {string} uri
  * @param {shakaExtern.Request} request
+ * @param {shaka.net.NetworkingEngine.RequestType} type
+ * @param {function(ProgressEvent, shaka.net.NetworkingEngine.RequestType)} onProgress
  * @return {!Promise.<shakaExtern.Response>}
  * @export
  */
-shaka.offline.OfflineScheme = function(uri, request) {
+shaka.offline.OfflineScheme = function(uri, request, type, onProgress) {
   var manifestParts = /^offline:([0-9]+)$/.exec(uri);
   if (manifestParts) {
     /** @type {shakaExtern.Response} */

--- a/lib/player.js
+++ b/lib/player.js
@@ -267,6 +267,15 @@ shaka.Player.version = GIT_VERSION;
 
 
 /**
+ * @event shaka.Player.SegmentBuffering
+ * @description Fired when a segment buffers.
+ * @property {string} type
+ *   'segmentbuffering'
+ * @exportDoc
+ */
+
+
+/**
  * @event shaka.Player.TimelineRegionEnter
  * @description Fired when the playhead enters a timeline region.
  * @property {string} type

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -1028,7 +1028,8 @@ describe('DrmEngine', function() {
       // Not mocked.  Run data through real data URI parser to ensure that it is
       // correctly formatted.
       fakeNetEngine.request.and.callFake(function(type, request) {
-        return shaka.net.DataUriPlugin(request.uris[0], request);
+        return shaka.net.DataUriPlugin(request.uris[0], request,
+            shaka.net.NetworkingEngine.RequestType.LICENSE, function() {});
       });
 
       initAndAttach().then(function() {

--- a/test/net/data_uri_plugin_unit.js
+++ b/test/net/data_uri_plugin_unit.js
@@ -71,7 +71,8 @@ describe('DataUriPlugin', function() {
   function testSucceeds(uri, contentType, text, done) {
     var request =
         shaka.net.NetworkingEngine.makeRequest([uri], retryParameters);
-    shaka.net.DataUriPlugin(uri, request)
+    shaka.net.DataUriPlugin(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(function(response) {
           expect(response).toBeTruthy();
           expect(response.uri).toBe(uri);
@@ -87,7 +88,8 @@ describe('DataUriPlugin', function() {
   function testFails(uri, done, code) {
     var request =
         shaka.net.NetworkingEngine.makeRequest([uri], retryParameters);
-    shaka.net.DataUriPlugin(uri, request)
+    shaka.net.DataUriPlugin(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(fail)
         .catch(function(error) { expect(error.code).toBe(code); })
         .then(function() {

--- a/test/net/http_plugin_unit.js
+++ b/test/net/http_plugin_unit.js
@@ -137,6 +137,20 @@ describe('HttpPlugin', function() {
         .then(done);
   });
 
+  it('triggers progress events', function(done) {
+    testSucceeds('https://foo.bar/', done);
+  });
+
+  function checkProgressEvent(progressEvent) {
+    // see https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
+    expect(typeof progressEvent).toBe('object');
+    expect(typeof progressEvent.loaded).toBe('number');
+    expect(typeof progressEvent.total).toBe('number');
+    expect(typeof progressEvent.lengthComputable).toBe('boolean');
+    expect(progressEvent.loaded).toBeLessThanOrEqual(progressEvent.total);
+    expect(progressEvent.total).toBeGreaterThanOrEqual(0);
+  }
+
   /**
    * @param {string} uri
    * @param {function()} done
@@ -146,7 +160,10 @@ describe('HttpPlugin', function() {
     var request = shaka.net.NetworkingEngine.makeRequest(
         [uri], retryParameters);
     shaka.net.HttpPlugin(uri, request,
-        shaka.net.NetworkingEngine.RequestType.SEGMENT, function() {})
+        shaka.net.NetworkingEngine.RequestType.SEGMENT,
+        function(progressEvent) {
+          checkProgressEvent(progressEvent);
+        })
         .catch(fail)
         .then(function(response) {
           expect(jasmine.Ajax.requests.mostRecent().url).toBe(uri);

--- a/test/net/http_plugin_unit.js
+++ b/test/net/http_plugin_unit.js
@@ -77,7 +77,8 @@ describe('HttpPlugin', function() {
     request.method = 'POST';
     request.headers['BAZ'] = '123';
 
-    shaka.net.HttpPlugin(request.uris[0], request)
+    shaka.net.HttpPlugin(request.uris[0],
+        request, shaka.net.NetworkingEngine.RequestType.SEGMENT, function() {})
         .then(function() {
           var actual = jasmine.Ajax.requests.mostRecent();
           expect(actual).toBeTruthy();
@@ -126,7 +127,8 @@ describe('HttpPlugin', function() {
   it('detects cache headers', function(done) {
     var request = shaka.net.NetworkingEngine.makeRequest(
         ['https://foo.bar/cache'], retryParameters);
-    shaka.net.HttpPlugin(request.uris[0], request)
+    shaka.net.HttpPlugin(request.uris[0],
+        request, shaka.net.NetworkingEngine.RequestType.SEGMENT, function() {})
         .catch(fail)
         .then(function(response) {
           expect(response).toBeTruthy();
@@ -143,7 +145,8 @@ describe('HttpPlugin', function() {
   function testSucceeds(uri, done, opt_overrideUri) {
     var request = shaka.net.NetworkingEngine.makeRequest(
         [uri], retryParameters);
-    shaka.net.HttpPlugin(uri, request)
+    shaka.net.HttpPlugin(uri, request,
+        shaka.net.NetworkingEngine.RequestType.SEGMENT, function() {})
         .catch(fail)
         .then(function(response) {
           expect(jasmine.Ajax.requests.mostRecent().url).toBe(uri);
@@ -167,7 +170,8 @@ describe('HttpPlugin', function() {
   function testFails(uri, done, opt_severity) {
     var request = shaka.net.NetworkingEngine.makeRequest(
         [uri], retryParameters);
-    shaka.net.HttpPlugin(uri, request)
+    shaka.net.HttpPlugin(uri, request,
+        shaka.net.NetworkingEngine.RequestType.SEGMENT, function() {})
         .then(fail)
         .catch(function(error) {
           expect(error).toBeTruthy();

--- a/test/offline/offline_scheme_unit.js
+++ b/test/offline/offline_scheme_unit.js
@@ -64,7 +64,8 @@ describe('OfflineScheme', function() {
   it('will return special content-type header for manifests', function(done) {
     var uri = 'offline:123';
     fakeCreateStorageEngine.and.throwError();
-    OfflineScheme(uri, request)
+    OfflineScheme(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(function(response) {
           expect(response).toBeTruthy();
           expect(response.uri).toBe(uri);
@@ -78,7 +79,8 @@ describe('OfflineScheme', function() {
   it('will query DBEngine for segments', function(done) {
     var uri = 'offline:123/456/789';
 
-    OfflineScheme(uri, request)
+    OfflineScheme(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(function(response) {
           expect(response).toBeTruthy();
           expect(response.uri).toBe(uri);
@@ -98,7 +100,8 @@ describe('OfflineScheme', function() {
     var uri = 'offline:123/456/789';
     fakeStorageEngine.get.and.returnValue(Promise.resolve(null));
 
-    OfflineScheme(uri, request)
+    OfflineScheme(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(fail)
         .catch(function(err) {
           shaka.test.Util.expectToEqualError(
@@ -121,7 +124,8 @@ describe('OfflineScheme', function() {
   it('will fail for invalid URI', function(done) {
     var uri = 'offline:abc';
     fakeCreateStorageEngine.and.throwError();
-    OfflineScheme(uri, request)
+    OfflineScheme(uri, request,
+        shaka.net.NetworkingEngine.RequestType.LICENSE, function() {})
         .then(fail)
         .catch(function(err) {
           shaka.test.Util.expectToEqualError(

--- a/test/test/externs/jasmine.js
+++ b/test/test/externs/jasmine.js
@@ -105,7 +105,15 @@ jasmine.Matchers.prototype.toBeGreaterThan = function(value) {};
 
 
 /** @param {*} value */
+jasmine.Matchers.prototype.toBeGreaterThanOrEqual = function(value) {};
+
+
+/** @param {*} value */
 jasmine.Matchers.prototype.toBeLessThan = function(value) {};
+
+
+/** @param {*} value */
+jasmine.Matchers.prototype.toBeLessThanOrEqual = function(value) {};
 
 
 jasmine.Matchers.prototype.toBeNaN = function() {};

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -24,9 +24,11 @@ goog.provide('shaka.test.TestScheme');
  *
  * @param {string} uri
  * @param {shakaExtern.Request} request
+ * @param {shaka.net.NetworkingEngine.RequestType} requestType
+ * @param {function(ProgressEvent, shaka.net.NetworkingEngine.RequestType)} onProgress
  * @return {!Promise.<shakaExtern.Response>}
  */
-shaka.test.TestScheme = function(uri, request) {
+shaka.test.TestScheme = function(uri, request, requestType, onProgress) {
   var manifestParts = /^test:([^\/]+)$/.exec(uri);
   if (manifestParts) {
     /** @type {shakaExtern.Response} */


### PR DESCRIPTION
Hey

We thought it would be useful for users to see a percentage indication of re-buffering progress in certain cases. It creates a better awareness for available network bandwidth and overall a more transparent user experience. But also for analytics and internal player metrics reasons, it may be useful to be able to track the actual network buffers throughput (as much as browsers will allow it).

Hope this doesn't disrupt any architectural grand lines. Here is a summary of changes:

* Makes NetworkingEngine an EventTarget
* Introduces new event: `ProgressEvent`, with similar interface as the standard DOM ProgressEvent, see: https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent
* Listenening to the networking engines' events should allow for measuring download progress of segments (or any other item downloaded)
* Event data allows to track various transactions by their inner target, which my be an underlying XHR object (several transactions may happen concurrently, listeners can differentiate between their progress events)
* Extension on the SchemePlugin interface
* Updated testst


TODO: 

- [ ] Write tests

Before I write tests I'd like to make sure this is a viable approach with the other parties here on the project.

Cheers