### PR TITLE
Stop infinitely retrying on network errors for VOD

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@
 # Please keep the list sorted.
 
 AdsWizz <*@adswizz.com>
+Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>
 Google Inc. <*@google.com>
 Edgeware AB <*@edgeware.tv>

--- a/docs/tutorials/config.md
+++ b/docs/tutorials/config.md
@@ -46,6 +46,7 @@ player.getConfiguration();
        bufferBehind: 30
        bufferingGoal: 10
        ignoreTextStreamFailures: false
+       infiniteRetriesForLiveStreams: true
        rebufferingGoal: 2
        retryParameters: Object
 

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -489,6 +489,7 @@ shakaExtern.ManifestConfiguration;
 /**
  * @typedef {{
  *   retryParameters: shakaExtern.RetryParameters,
+ *   infiniteRetriesForLiveStreams: boolean,
  *   rebufferingGoal: number,
  *   bufferingGoal: number,
  *   bufferBehind: number,
@@ -503,6 +504,9 @@ shakaExtern.ManifestConfiguration;
  *
  * @property {shakaExtern.RetryParameters} retryParameters
  *   Retry parameters for segment requests.
+ * @property {boolean} infiniteRetriesForLiveStreams
+ *   If true, will retry infinitely on network errors, for live streams only.
+ *   Defaults to true.
  * @property {number} rebufferingGoal
  *   The minimum number of seconds of content that the StreamingEngine must
  *   buffer before it can begin playback or can continue playback after it has

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1243,9 +1243,11 @@ shaka.media.StreamingEngine.prototype.fetchAndAppend_ = function(
 
     mediaState.performingUpdate = false;
 
-    if (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS ||
+    if (this.manifest_.presentationTimeline.isLive() &&
+        this.config_.infiniteRetriesForLiveStreams &&
+        (error.code == shaka.util.Error.Code.BAD_HTTP_STATUS ||
         error.code == shaka.util.Error.Code.HTTP_ERROR ||
-        error.code == shaka.util.Error.Code.TIMEOUT) {
+        error.code == shaka.util.Error.Code.TIMEOUT)) {
       this.handleNetworkError_(mediaState, error);
     } else if (error.code == shaka.util.Error.Code.QUOTA_EXCEEDED_ERROR) {
       this.handleQuotaExceeded_(mediaState, error);

--- a/lib/player.js
+++ b/lib/player.js
@@ -1752,6 +1752,7 @@ shaka.Player.prototype.defaultConfig_ = function() {
     },
     streaming: {
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+      infiniteRetriesForLiveStreams: true,
       rebufferingGoal: 2,
       bufferingGoal: 10,
       bufferBehind: 30,

--- a/test/media/playhead_observer_unit.js
+++ b/test/media/playhead_observer_unit.js
@@ -55,6 +55,7 @@ describe('PlayheadObserver', function() {
       rebufferingGoal: 10,
       bufferingGoal: 5,
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+      infiniteRetriesForLiveStreams: true,
       bufferBehind: 15,
       ignoreTextStreamFailures: false,
       useRelativeCueTimestamps: false,

--- a/test/media/playhead_unit.js
+++ b/test/media/playhead_unit.js
@@ -138,6 +138,7 @@ describe('Playhead', function() {
       rebufferingGoal: 10,
       bufferingGoal: 5,
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+      infiniteRetriesForLiveStreams: true,
       bufferBehind: 15,
       ignoreTextStreamFailures: false,
       useRelativeCueTimestamps: false,

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -65,6 +65,7 @@ describe('StreamingEngine', function() {
       rebufferingGoal: 2,
       bufferingGoal: 5,
       retryParameters: shaka.net.NetworkingEngine.defaultRetryParameters(),
+      infiniteRetriesForLiveStreams: true,
       bufferBehind: 15,
       ignoreTextStreamFailures: false,
       useRelativeCueTimestamps: false,
@@ -128,7 +129,8 @@ describe('StreamingEngine', function() {
       timeline = shaka.test.StreamingEngineUtil.createFakePresentationTimeline(
           0 /* segmentAvailabilityStart */,
           60 /* segmentAvailabilityEnd */,
-          60 /* presentationDuration */);
+          60 /* presentationDuration */,
+          false /* isLive */);
 
       setupNetworkingEngine(
           0 /* firstPeriodStartTime */,
@@ -162,7 +164,8 @@ describe('StreamingEngine', function() {
       timeline = shaka.test.StreamingEngineUtil.createFakePresentationTimeline(
           275 - 10 /* segmentAvailabilityStart */,
           295 - 10 /* segmentAvailabilityEnd */,
-          Infinity /* presentationDuration */);
+          Infinity /* presentationDuration */,
+          true /* isLive */);
 
       setupNetworkingEngine(
           0 /* firstPeriodStartTime */,
@@ -669,7 +672,8 @@ describe('StreamingEngine', function() {
             shaka.test.StreamingEngineUtil.createFakePresentationTimeline(
                 0 /* segmentAvailabilityStart */,
                 30 /* segmentAvailabilityEnd */,
-                30 /* presentationDuration */);
+                30 /* presentationDuration */,
+                false /* isLive */);
 
         setupNetworkingEngine(
             0 /* firstPeriodStartTime */,

--- a/test/test/util/streaming_engine_util.js
+++ b/test/test/util/streaming_engine_util.js
@@ -101,11 +101,13 @@ shaka.test.StreamingEngineUtil.createFakeNetworkingEngine = function(
  * @param {number} segmentAvailabilityEnd The initial value of
  *   |segmentAvailabilityEnd|.
  * @param {number} presentationDuration
+ * @param {boolean} isLive
  * @return {!Object} A PresentationTimeline look-alike.
  *
  */
 shaka.test.StreamingEngineUtil.createFakePresentationTimeline = function(
-    segmentAvailabilityStart, segmentAvailabilityEnd, presentationDuration) {
+    segmentAvailabilityStart, segmentAvailabilityEnd, presentationDuration,
+    isLive) {
   var timeline = {
     getDuration: jasmine.createSpy('getDuration'),
     setDuration: jasmine.createSpy('setDuration'),
@@ -127,7 +129,7 @@ shaka.test.StreamingEngineUtil.createFakePresentationTimeline = function(
   timeline.getDuration.and.returnValue(presentationDuration);
 
   timeline.isLive.and.callFake(function() {
-    return presentationDuration == Infinity;
+    return isLive;
   });
 
   timeline.getEarliestStart.and.callFake(function() {


### PR DESCRIPTION
Do not infinitely retry on top of the retry-policy already defined by
RetryParameters, especially for VOD. For live video the previous retry
logic is still useful to be robust against clock-sync or asset
availability issues. This commit adds a boolean configuration parameter,
infiniteRetriesForLiveStreams, to allow the user to turn this behavior
off even for live video.

Fixes #830 and #762