### PR TITLE
Support for offline data with an online license request

### DIFF
--- a/lib/offline/offline_manifest_parser.js
+++ b/lib/offline/offline_manifest_parser.js
@@ -146,10 +146,15 @@ shaka.offline.OfflineManifestParser.reconstructManifest = function(manifest) {
   var timeline = new shaka.media.PresentationTimeline(null, 0);
   timeline.setDuration(manifest.duration);
   var drmInfos = manifest.drmInfo ? [manifest.drmInfo] : [];
+  // if only the data is stored (and not the license), there is no offline drm session
+  var offlineSessionIds = manifest.isDataOnly ? [] : manifest.sessionIds;
+  var sessionIds = !manifest.isDataOnly ? [] : manifest.sessionIds;
+
   return {
     presentationTimeline: timeline,
     minBufferTime: 10,
-    offlineSessionIds: manifest.sessionIds,
+    offlineSessionIds: offlineSessionIds,
+    sessionIds: sessionIds,
     periods: manifest.periods.map(function(period) {
       return shaka.offline.OfflineUtils.reconstructPeriod(period,
                                                           drmInfos,

--- a/lib/offline/offline_manifest_parser.js
+++ b/lib/offline/offline_manifest_parser.js
@@ -148,7 +148,7 @@ shaka.offline.OfflineManifestParser.reconstructManifest = function(manifest) {
   var drmInfos = manifest.drmInfo ? [manifest.drmInfo] : [];
   // if only the data is stored (and not the license), there is no offline drm session
   var offlineSessionIds = manifest.isDataOnly ? [] : manifest.sessionIds;
-  var sessionIds = !manifest.isDataOnly ? [] : manifest.sessionIds;
+  var sessionIds = manifest.isDataOnly ? manifest.sessionIds : [];
 
   return {
     presentationTimeline: timeline,

--- a/lib/offline/offline_manifest_parser.js
+++ b/lib/offline/offline_manifest_parser.js
@@ -146,15 +146,10 @@ shaka.offline.OfflineManifestParser.reconstructManifest = function(manifest) {
   var timeline = new shaka.media.PresentationTimeline(null, 0);
   timeline.setDuration(manifest.duration);
   var drmInfos = manifest.drmInfo ? [manifest.drmInfo] : [];
-  // if only the data is stored (and not the license), there is no offline drm session
-  var offlineSessionIds = manifest.isDataOnly ? [] : manifest.sessionIds;
-  var sessionIds = manifest.isDataOnly ? manifest.sessionIds : [];
-
   return {
     presentationTimeline: timeline,
     minBufferTime: 10,
-    offlineSessionIds: offlineSessionIds,
-    sessionIds: sessionIds,
+    offlineSessionIds: manifest.sessionIds,
     periods: manifest.periods.map(function(period) {
       return shaka.offline.OfflineUtils.reconstructPeriod(period,
                                                           drmInfos,

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -381,14 +381,13 @@ shaka.offline.Storage.prototype.list = function() {
  * @param {string} manifestUri
  * @param {function(*)} onError
  * @param {!shakaExtern.ManifestParser.Factory=} opt_manifestParserFactory
- * @param {!boolean=} opt_storeDataOnly
  * @return {!Promise.<{
  *   manifest: shakaExtern.Manifest,
  *   drmEngine: !shaka.media.DrmEngine
  * }>}
  */
 shaka.offline.Storage.prototype.loadInternal = function(
-    manifestUri, onError, opt_manifestParserFactory, opt_storeDataOnly) {
+    manifestUri, onError, opt_manifestParserFactory) {
 
   var netEngine = /** @type {!shaka.net.NetworkingEngine} */ (
       this.player_.getNetworkingEngine());

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -298,7 +298,8 @@ shaka.offline.Storage.prototype.remove = function(content) {
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, function() {}, function() {});
         drmEngine.configure(this.player_.getConfiguration().drm);
-        return drmEngine.init(manifest, this.config_.isPersistentLicense /* isOffline */);
+        return drmEngine.init(
+            manifest, this.config_.isPersistentLicense /* isOffline */);
       })
   .bind(this)).then(function() {
     return drmEngine.removeSessions(manifestDb.sessionIds);
@@ -422,7 +423,8 @@ shaka.offline.Storage.prototype.loadInternal = function(
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, onKeyStatusChange, function() {});
         drmEngine.configure(config.drm);
-        return drmEngine.init(manifest, this.config_.isPersistentLicense /* isOffline */);
+        return drmEngine.init(
+            manifest, this.config_.isPersistentLicense /* isOffline */);
       }.bind(this))
       .then(function() {
         this.checkDestroyed_();

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -171,8 +171,6 @@ shaka.offline.Storage.prototype.configure = function(config) {
  *   For details on the data types that can be stored here, please refer to
  *   https://goo.gl/h62coS
  * @param {!shakaExtern.ManifestParser.Factory=} opt_manifestParserFactory
- * @param {!boolean=} opt_storeDataOnly Indicates whether just the data will be stored
- *   whilst still using a remote (sessionType="temporary") drm license request.
  * @return {!Promise.<shakaExtern.StoredContent>}  A Promise to a structure
  *   representing what was stored.  The "offlineUri" member is the URI that
  *   should be given to Player.load() to play this piece of content offline.
@@ -180,7 +178,7 @@ shaka.offline.Storage.prototype.configure = function(config) {
  * @export
  */
 shaka.offline.Storage.prototype.store = function(
-    manifestUri, appMetadata, opt_manifestParserFactory, opt_storeDataOnly) {
+    manifestUri, appMetadata, opt_manifestParserFactory) {
   if (this.storeInProgress_) {
     return Promise.reject(new shaka.util.Error(
         shaka.util.Error.Severity.CRITICAL,
@@ -198,7 +196,7 @@ shaka.offline.Storage.prototype.store = function(
       .then(function() {
         this.checkDestroyed_();
         return this.loadInternal(
-            manifestUri, onError, opt_manifestParserFactory, opt_storeDataOnly);
+            manifestUri, onError, opt_manifestParserFactory);
       }.bind(this)).then((
           /**
            * @param {{manifest: shakaExtern.Manifest,
@@ -223,7 +221,7 @@ shaka.offline.Storage.prototype.store = function(
 
             this.manifestId_ = this.storageEngine_.reserveId('manifest');
             this.duration_ = 0;
-            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata, !!opt_storeDataOnly);
+            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata);
             return this.downloadManager_.downloadAndStore(manifestDb);
           })
       .bind(this))
@@ -301,13 +299,11 @@ shaka.offline.Storage.prototype.remove = function(content) {
             netEngine, onError, function() {}, function() {});
         drmEngine.configure(this.player_.getConfiguration().drm);
         // if the license is not stored, we dont need to enlist drmEngine in removing the license
-        if (manifestDb.isDataOnly) return Promise.resolve();
+        if (!this.config_.isPersistentLicense) return Promise.resolve();
 
         return drmEngine.init(manifest, true /* isOffline */);
       })
   .bind(this)).then(function() {
-    // once again, the license is not persisted so there is 0 drm sessions to remove
-    if (manifestDb.isDataOnly) return Promise.resolve();
     return drmEngine.removeSessions(manifestDb.sessionIds);
   }.bind(this)).then(function() {
     return drmEngine.destroy();
@@ -430,7 +426,7 @@ shaka.offline.Storage.prototype.loadInternal = function(
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, onKeyStatusChange, function() {});
         drmEngine.configure(config.drm);
-        return drmEngine.init(manifest, !opt_storeDataOnly /* isOffline */);
+        return drmEngine.init(manifest, this.config_.isPersistentLicense /* isOffline */);
       }.bind(this))
       .then(function() {
         this.checkDestroyed_();
@@ -575,7 +571,8 @@ shaka.offline.Storage.prototype.defaultConfig_ = function() {
       // NOTE: Chrome App Content Security Policy prohibits usage of new
       // Function().
       if (storedContent || percent) return null;
-    }
+    },
+    isPersistentLicense: true
   };
 };
 
@@ -689,12 +686,11 @@ shaka.offline.Storage.prototype.createSegmentIndex_ = function(manifest) {
  *
  * @param {string} originalManifestUri
  * @param {!Object} appMetadata
- * @param {boolean} isDataOnly
  * @return {shakaExtern.ManifestDB}
  * @private
  */
 shaka.offline.Storage.prototype.createOfflineManifest_ = function(
-    originalManifestUri, appMetadata, isDataOnly) {
+    originalManifestUri, appMetadata) {
   var periods = this.manifest_.periods.map(this.createPeriod_.bind(this));
   var drmInfo = this.drmEngine_.getDrmInfo();
   var sessions = this.drmEngine_.getSessionIds();
@@ -715,10 +711,9 @@ shaka.offline.Storage.prototype.createOfflineManifest_ = function(
     size: 0,
     expiration: this.drmEngine_.getExpiration(),
     periods: periods,
-    sessionIds: sessions,
+    sessionIds: this.config_.isPersistentLicense ? sessions : [],
     drmInfo: drmInfo,
-    appMetadata: appMetadata,
-    isDataOnly: !!isDataOnly
+    appMetadata: appMetadata
   };
 };
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -298,10 +298,7 @@ shaka.offline.Storage.prototype.remove = function(content) {
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, function() {}, function() {});
         drmEngine.configure(this.player_.getConfiguration().drm);
-        // if the license is not stored, we dont need to enlist drmEngine in removing the license
-        if (!this.config_.isPersistentLicense) return Promise.resolve();
-
-        return drmEngine.init(manifest, true /* isOffline */);
+        return drmEngine.init(manifest, this.config_.isPersistentLicense /* isOffline */);
       })
   .bind(this)).then(function() {
     return drmEngine.removeSessions(manifestDb.sessionIds);

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -171,6 +171,8 @@ shaka.offline.Storage.prototype.configure = function(config) {
  *   For details on the data types that can be stored here, please refer to
  *   https://goo.gl/h62coS
  * @param {!shakaExtern.ManifestParser.Factory=} opt_manifestParserFactory
+ * @param {!bool} opt_storeDataOnly Indicates whether just the data will be stored
+ *   whilst still using a remote (sessionType="temporary") drm license request.
  * @return {!Promise.<shakaExtern.StoredContent>}  A Promise to a structure
  *   representing what was stored.  The "offlineUri" member is the URI that
  *   should be given to Player.load() to play this piece of content offline.
@@ -178,7 +180,7 @@ shaka.offline.Storage.prototype.configure = function(config) {
  * @export
  */
 shaka.offline.Storage.prototype.store = function(
-    manifestUri, appMetadata, opt_manifestParserFactory) {
+    manifestUri, appMetadata, opt_manifestParserFactory, opt_storeDataOnly) {
   if (this.storeInProgress_) {
     return Promise.reject(new shaka.util.Error(
         shaka.util.Error.Severity.CRITICAL,
@@ -221,7 +223,7 @@ shaka.offline.Storage.prototype.store = function(
 
             this.manifestId_ = this.storageEngine_.reserveId('manifest');
             this.duration_ = 0;
-            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata);
+            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata, opt_storeDataOnly);
             return this.downloadManager_.downloadAndStore(manifestDb);
           })
       .bind(this))
@@ -298,9 +300,14 @@ shaka.offline.Storage.prototype.remove = function(content) {
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, function() {}, function() {});
         drmEngine.configure(this.player_.getConfiguration().drm);
-        return drmEngine.init(manifest, true /* isOffline */);
+        // if the license is not stored, we dont need to enlist drmEngine in removing the license
+        if (manifestDb.isDataOnly) return;
+
+        return drmEngine.init(manifest, true/* isOffline */);
       })
   .bind(this)).then(function() {
+    // once again, the license is not persisted so there is 0 drm sessions to remove
+    if (manifestDb.isDataOnly) return;
     return drmEngine.removeSessions(manifestDb.sessionIds);
   }.bind(this)).then(function() {
     return drmEngine.destroy();
@@ -422,7 +429,7 @@ shaka.offline.Storage.prototype.loadInternal = function(
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, onKeyStatusChange, function() {});
         drmEngine.configure(config.drm);
-        return drmEngine.init(manifest, true /* isOffline */);
+        return drmEngine.init(manifest, this.config_.persistLicense /* isOffline */);
       }.bind(this))
       .then(function() {
         this.checkDestroyed_();
@@ -685,7 +692,7 @@ shaka.offline.Storage.prototype.createSegmentIndex_ = function(manifest) {
  * @private
  */
 shaka.offline.Storage.prototype.createOfflineManifest_ = function(
-    originalManifestUri, appMetadata) {
+    originalManifestUri, appMetadata, isDataOnly) {
   var periods = this.manifest_.periods.map(this.createPeriod_.bind(this));
   var drmInfo = this.drmEngine_.getDrmInfo();
   var sessions = this.drmEngine_.getSessionIds();
@@ -708,7 +715,8 @@ shaka.offline.Storage.prototype.createOfflineManifest_ = function(
     periods: periods,
     sessionIds: sessions,
     drmInfo: drmInfo,
-    appMetadata: appMetadata
+    appMetadata: appMetadata,
+    isDataOnly: !!isDataOnly
   };
 };
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -171,7 +171,7 @@ shaka.offline.Storage.prototype.configure = function(config) {
  *   For details on the data types that can be stored here, please refer to
  *   https://goo.gl/h62coS
  * @param {!shakaExtern.ManifestParser.Factory=} opt_manifestParserFactory
- * @param {!bool} opt_storeDataOnly Indicates whether just the data will be stored
+ * @param {!boolean=} opt_storeDataOnly Indicates whether just the data will be stored
  *   whilst still using a remote (sessionType="temporary") drm license request.
  * @return {!Promise.<shakaExtern.StoredContent>}  A Promise to a structure
  *   representing what was stored.  The "offlineUri" member is the URI that
@@ -198,7 +198,7 @@ shaka.offline.Storage.prototype.store = function(
       .then(function() {
         this.checkDestroyed_();
         return this.loadInternal(
-            manifestUri, onError, opt_manifestParserFactory);
+            manifestUri, onError, opt_manifestParserFactory, opt_storeDataOnly);
       }.bind(this)).then((
           /**
            * @param {{manifest: shakaExtern.Manifest,
@@ -223,7 +223,7 @@ shaka.offline.Storage.prototype.store = function(
 
             this.manifestId_ = this.storageEngine_.reserveId('manifest');
             this.duration_ = 0;
-            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata, opt_storeDataOnly);
+            manifestDb = this.createOfflineManifest_(manifestUri, appMetadata, !!opt_storeDataOnly);
             return this.downloadManager_.downloadAndStore(manifestDb);
           })
       .bind(this))
@@ -301,13 +301,13 @@ shaka.offline.Storage.prototype.remove = function(content) {
             netEngine, onError, function() {}, function() {});
         drmEngine.configure(this.player_.getConfiguration().drm);
         // if the license is not stored, we dont need to enlist drmEngine in removing the license
-        if (manifestDb.isDataOnly) return;
+        if (manifestDb.isDataOnly) return Promise.resolve();
 
-        return drmEngine.init(manifest, true/* isOffline */);
+        return drmEngine.init(manifest, true /* isOffline */);
       })
   .bind(this)).then(function() {
     // once again, the license is not persisted so there is 0 drm sessions to remove
-    if (manifestDb.isDataOnly) return;
+    if (manifestDb.isDataOnly) return Promise.resolve();
     return drmEngine.removeSessions(manifestDb.sessionIds);
   }.bind(this)).then(function() {
     return drmEngine.destroy();
@@ -385,13 +385,14 @@ shaka.offline.Storage.prototype.list = function() {
  * @param {string} manifestUri
  * @param {function(*)} onError
  * @param {!shakaExtern.ManifestParser.Factory=} opt_manifestParserFactory
+ * @param {!boolean=} opt_storeDataOnly
  * @return {!Promise.<{
  *   manifest: shakaExtern.Manifest,
  *   drmEngine: !shaka.media.DrmEngine
  * }>}
  */
 shaka.offline.Storage.prototype.loadInternal = function(
-    manifestUri, onError, opt_manifestParserFactory) {
+    manifestUri, onError, opt_manifestParserFactory, opt_storeDataOnly) {
 
   var netEngine = /** @type {!shaka.net.NetworkingEngine} */ (
       this.player_.getNetworkingEngine());
@@ -429,7 +430,7 @@ shaka.offline.Storage.prototype.loadInternal = function(
         drmEngine = new shaka.media.DrmEngine(
             netEngine, onError, onKeyStatusChange, function() {});
         drmEngine.configure(config.drm);
-        return drmEngine.init(manifest, this.config_.persistLicense /* isOffline */);
+        return drmEngine.init(manifest, !opt_storeDataOnly /* isOffline */);
       }.bind(this))
       .then(function() {
         this.checkDestroyed_();
@@ -688,6 +689,7 @@ shaka.offline.Storage.prototype.createSegmentIndex_ = function(manifest) {
  *
  * @param {string} originalManifestUri
  * @param {!Object} appMetadata
+ * @param {boolean} isDataOnly
  * @return {shakaExtern.ManifestDB}
  * @private
  */

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-describe('Offline', function() {
+fdescribe('Offline', function() {
   var originalName;
   var dbEngine;
   var storage;
@@ -158,7 +158,8 @@ describe('Offline', function() {
         .then(done);
   });
 
-  drm_it('stores, plays, and deletes protected content with a temporary license',
+  drm_it(
+      'stores, plays, and deletes protected content with a temporary license',
       function(done) {
         if (!support['offline'] ||
             !support.drm['com.widevine.alpha']) {
@@ -166,17 +167,8 @@ describe('Offline', function() {
         }
 
         shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
-        var onError = function(e) {
-          // We should only get a not-found error.
-          var expected = new shaka.util.Error(
-              shaka.util.Error.Severity.CRITICAL,
-              shaka.util.Error.Category.DRM,
-              shaka.util.Error.Code.OFFLINE_SESSION_REMOVED);
-          shaka.test.Util.expectToEqualError(e, expected);
-        };
 
         var storedContent;
-        var drmEngine;
         storage.configure({ isPersistentLicense: false });
         storage.store('test:sintel-enc')
             .then(function(content) {
@@ -197,6 +189,10 @@ describe('Offline', function() {
               return player.unload();
             })
             .then(function() { return storage.remove(storedContent); })
+            .then(function() { return dbEngine.get('manifest', 0); })
+            .then(function(manifestDb){
+              expect(manifestDb).toBeFalsy();
+            })
             .catch(fail)
             .then(done);
       });

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-describe('Offline', function() {
+fdescribe('Offline', function() {
   var originalName;
   var dbEngine;
   var storage;
@@ -157,4 +157,45 @@ describe('Offline', function() {
         .catch(fail)
         .then(done);
   });
+
+  it('stores, plays, and deletes protected content with a temporary license', function(done) {
+    if (!support['offline']) {
+      pending('Offline storage not supported');
+    }
+
+    shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
+    var onError = function(e) {
+      // We should only get a not-found error.
+      var expected = new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.OFFLINE_SESSION_REMOVED);
+      shaka.test.Util.expectToEqualError(e, expected);
+    };
+
+    var storedContent;
+    var drmEngine;
+    storage.configure({ isPersistentLicense: false });
+    storage.store('test:sintel-enc')
+        .then(function(content) {
+          storedContent = content;
+          expect(storedContent.offlineUri).toBe('offline:0');
+          return player.load(storedContent.offlineUri);
+        })
+        .then(function() {
+          video.play();
+          return shaka.test.Util.delay(5);
+        })
+        .then(function() { return dbEngine.get('manifest', 0); })
+        .then(function(manifestDb) {
+          expect(manifestDb.sessionIds.length).toEqual(0);
+
+          expect(video.currentTime).toBeGreaterThan(3);
+          expect(video.ended).toBe(false);
+          return player.unload();
+        })
+        .then(function() { return storage.remove(storedContent); })
+        .catch(fail)
+        .then(done);
+  })
 });

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -158,8 +158,9 @@ describe('Offline', function() {
         .then(done);
   });
 
-  it('stores, plays, and deletes protected content with a temporary license', function(done) {
-    if (!support['offline']) {
+  drm_it('stores, plays, and deletes protected content with a temporary license', function(done) {
+    if (!support['offline'] ||
+        !support.drm['com.widevine.alpha']) {
       pending('Offline storage not supported');
     }
 

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -158,45 +158,46 @@ describe('Offline', function() {
         .then(done);
   });
 
-  drm_it('stores, plays, and deletes protected content with a temporary license', function(done) {
-    if (!support['offline'] ||
-        !support.drm['com.widevine.alpha']) {
-      pending('Offline storage not supported');
-    }
+  drm_it('stores, plays, and deletes protected content with a temporary license',
+      function(done) {
+        if (!support['offline'] ||
+            !support.drm['com.widevine.alpha']) {
+          pending('Offline storage not supported');
+        }
 
-    shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
-    var onError = function(e) {
-      // We should only get a not-found error.
-      var expected = new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.DRM,
-          shaka.util.Error.Code.OFFLINE_SESSION_REMOVED);
-      shaka.test.Util.expectToEqualError(e, expected);
-    };
+        shaka.test.TestScheme.setupPlayer(player, 'sintel-enc');
+        var onError = function(e) {
+          // We should only get a not-found error.
+          var expected = new shaka.util.Error(
+              shaka.util.Error.Severity.CRITICAL,
+              shaka.util.Error.Category.DRM,
+              shaka.util.Error.Code.OFFLINE_SESSION_REMOVED);
+          shaka.test.Util.expectToEqualError(e, expected);
+        };
 
-    var storedContent;
-    var drmEngine;
-    storage.configure({ isPersistentLicense: false });
-    storage.store('test:sintel-enc')
-        .then(function(content) {
-          storedContent = content;
-          expect(storedContent.offlineUri).toBe('offline:0');
-          return player.load(storedContent.offlineUri);
-        })
-        .then(function() {
-          video.play();
-          return shaka.test.Util.delay(5);
-        })
-        .then(function() { return dbEngine.get('manifest', 0); })
-        .then(function(manifestDb) {
-          expect(manifestDb.sessionIds.length).toEqual(0);
+        var storedContent;
+        var drmEngine;
+        storage.configure({ isPersistentLicense: false });
+        storage.store('test:sintel-enc')
+            .then(function(content) {
+              storedContent = content;
+              expect(storedContent.offlineUri).toBe('offline:0');
+              return player.load(storedContent.offlineUri);
+            })
+            .then(function() {
+              video.play();
+              return shaka.test.Util.delay(5);
+            })
+            .then(function() { return dbEngine.get('manifest', 0); })
+            .then(function(manifestDb) {
+              expect(manifestDb.sessionIds.length).toEqual(0);
 
-          expect(video.currentTime).toBeGreaterThan(3);
-          expect(video.ended).toBe(false);
-          return player.unload();
-        })
-        .then(function() { return storage.remove(storedContent); })
-        .catch(fail)
-        .then(done);
-  })
+              expect(video.currentTime).toBeGreaterThan(3);
+              expect(video.ended).toBe(false);
+              return player.unload();
+            })
+            .then(function() { return storage.remove(storedContent); })
+            .catch(fail)
+            .then(done);
+      });
 });

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-fdescribe('Offline', function() {
+describe('Offline', function() {
   var originalName;
   var dbEngine;
   var storage;

--- a/test/offline/offline_integration.js
+++ b/test/offline/offline_integration.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-fdescribe('Offline', function() {
+describe('Offline', function() {
   var originalName;
   var dbEngine;
   var storage;
@@ -190,7 +190,7 @@ fdescribe('Offline', function() {
             })
             .then(function() { return storage.remove(storedContent); })
             .then(function() { return dbEngine.get('manifest', 0); })
-            .then(function(manifestDb){
+            .then(function(manifestDb) {
               expect(manifestDb).toBeFalsy();
             })
             .catch(fail)

--- a/test/offline/storage_unit.js
+++ b/test/offline/storage_unit.js
@@ -869,6 +869,43 @@ describe('Storage', function() {
         }).catch(fail).then(done);
       });
     });  // describe('default track selection callback')
+
+    fdescribe('temporary license', function(){
+
+      beforeEach(function(){
+        storage.configure({ isPersistentLicense: false });
+      });
+
+      it('stores basic manifests', function(done) {
+        var originalUri = 'fake://foobar';
+        storage.store(originalUri)
+            .then(function(data) {
+              expect(data).toBeTruthy();
+              // Since we are using a memory DB, it will always be the first one.
+              expect(data.offlineUri).toBe('offline:0');
+              expect(data.originalManifestUri).toBe(originalUri);
+              expect(data.duration).toBe(0);  // There are no segments.
+              expect(data.size).toEqual(0);
+              expect(data.tracks).toEqual(tracks);
+            })
+            .catch(fail)
+            .then(done);
+      });
+
+      it('does not store offline sessions', function(done) {
+        storage.store('')
+            .then(function(data) {
+              expect(data.offlineUri).toBe('offline:0');
+              return fakeStorageEngine.get('manifest', 0);
+            })
+            .then(function(manifestDb) {
+              expect(manifestDb).toBeTruthy();
+              expect(manifestDb.sessionIds.length).toEqual(0);
+            })
+            .catch(fail)
+            .then(done);
+      });
+    }); // describe('temporary license')
   });  // describe('store')
 
   describe('remove', function() {

--- a/test/offline/storage_unit.js
+++ b/test/offline/storage_unit.js
@@ -871,8 +871,17 @@ describe('Storage', function() {
     });  // describe('default track selection callback')
 
     describe('temporary license', function(){
+      var drmInfo;
 
       beforeEach(function(){
+        drmInfo = {
+          keySystem: 'com.example.abc',
+          licenseServerUri: 'http://example.com',
+          persistentStateRequire: false,
+          audioRobustness: 'HARDY'
+        };
+        drmEngine.setDrmInfo(drmInfo);
+        drmEngine.setSessionIds(['abcd']);
         storage.configure({ isPersistentLicense: false });
       });
 
@@ -887,6 +896,20 @@ describe('Storage', function() {
               expect(data.duration).toBe(0);  // There are no segments.
               expect(data.size).toEqual(0);
               expect(data.tracks).toEqual(tracks);
+            })
+            .catch(fail)
+            .then(done);
+      });
+
+      it('stores drm info', function(done) {
+        storage.store('')
+            .then(function(data) {
+              expect(data.offlineUri).toBe('offline:0');
+              return fakeStorageEngine.get('manifest', 0);
+            })
+            .then(function(manifestDb) {
+              expect(manifestDb).toBeTruthy();
+              expect(manifestDb.drmInfo).toEqual(drmInfo);
             })
             .catch(fail)
             .then(done);

--- a/test/offline/storage_unit.js
+++ b/test/offline/storage_unit.js
@@ -885,23 +885,8 @@ describe('Storage', function() {
         storage.configure({ isPersistentLicense: false });
       });
 
-      it('stores basic manifests', function(done) {
-        var originalUri = 'fake://foobar';
-        storage.store(originalUri)
-            .then(function(data) {
-              expect(data).toBeTruthy();
-              // Since we are using a memory DB, it will always be the first one.
-              expect(data.offlineUri).toBe('offline:0');
-              expect(data.originalManifestUri).toBe(originalUri);
-              expect(data.duration).toBe(0);  // There are no segments.
-              expect(data.size).toEqual(0);
-              expect(data.tracks).toEqual(tracks);
-            })
-            .catch(fail)
-            .then(done);
-      });
+      it('does not store offline sessions', function(done) {
 
-      it('stores drm info', function(done) {
         storage.store('')
             .then(function(data) {
               expect(data.offlineUri).toBe('offline:0');
@@ -910,19 +895,6 @@ describe('Storage', function() {
             .then(function(manifestDb) {
               expect(manifestDb).toBeTruthy();
               expect(manifestDb.drmInfo).toEqual(drmInfo);
-            })
-            .catch(fail)
-            .then(done);
-      });
-
-      it('does not store offline sessions', function(done) {
-        storage.store('')
-            .then(function(data) {
-              expect(data.offlineUri).toBe('offline:0');
-              return fakeStorageEngine.get('manifest', 0);
-            })
-            .then(function(manifestDb) {
-              expect(manifestDb).toBeTruthy();
               expect(manifestDb.sessionIds.length).toEqual(0);
             })
             .catch(fail)

--- a/test/offline/storage_unit.js
+++ b/test/offline/storage_unit.js
@@ -870,10 +870,10 @@ describe('Storage', function() {
       });
     });  // describe('default track selection callback')
 
-    describe('temporary license', function(){
+    describe('temporary license', function() {
       var drmInfo;
 
-      beforeEach(function(){
+      beforeEach(function() {
         drmInfo = {
           keySystem: 'com.example.abc',
           licenseServerUri: 'http://example.com',
@@ -886,7 +886,6 @@ describe('Storage', function() {
       });
 
       it('does not store offline sessions', function(done) {
-
         storage.store('')
             .then(function(data) {
               expect(data.offlineUri).toBe('offline:0');
@@ -995,7 +994,7 @@ describe('Storage', function() {
           .then(done);
     });
 
-    it('will delete content with a temporary license', function(done){
+    it('will delete content with a temporary license', function(done) {
       storage.configure({ isPersistentLicense: false });
       var manifestId = 0;
       createAndInsertSegments(manifestId, 5)

--- a/test/offline/storage_unit.js
+++ b/test/offline/storage_unit.js
@@ -870,7 +870,7 @@ describe('Storage', function() {
       });
     });  // describe('default track selection callback')
 
-    fdescribe('temporary license', function(){
+    describe('temporary license', function(){
 
       beforeEach(function(){
         storage.configure({ isPersistentLicense: false });
@@ -993,6 +993,24 @@ describe('Storage', function() {
           })
           .then(function() {
             expectDatabaseCount(1, 8);
+            return removeManifest(manifestId);
+          })
+          .then(function() { expectDatabaseCount(0, 0); })
+          .catch(fail)
+          .then(done);
+    });
+
+    it('will delete content with a temporary license', function(done){
+      storage.configure({ isPersistentLicense: false });
+      var manifestId = 0;
+      createAndInsertSegments(manifestId, 5)
+          .then(function(refs) {
+            var manifest = createManifest(manifestId);
+            manifest.periods[0].streams.push({segments: refs});
+            return fakeStorageEngine.insert('manifest', manifest);
+          })
+          .then(function() {
+            expectDatabaseCount(1, 5);
             return removeManifest(manifestId);
           })
           .then(function() { expectDatabaseCount(0, 0); })


### PR DESCRIPTION
Carrying on from the discussion in Issue #873 

Currently only ChromeOS truly supports offline storage and playback.

This change allows other browsers to support offline storage of media only. A remote/temporary license request will be made during playback, so the user must still be online.

This will help users to pre-download content before traveling to a location with a patchy/expensive internet connection.