### PR TITLE
Do not adapt across variants with different roles

### DIFF
--- a/lib/util/array_utils.js
+++ b/lib/util/array_utils.js
@@ -80,3 +80,21 @@ shaka.util.ArrayUtils.remove = function(array, element) {
   if (index > -1)
     array.splice(index, 1);
 };
+
+
+/**
+ * Compare two arrays for equality.
+ * @param {!Array.<T>} arr1
+ * @param {!Array.<T>} arr2
+ * @return {boolean}
+ * @template T
+ */
+shaka.util.ArrayUtils.equal = function(arr1, arr2) {
+  if (!arr1 && !arr2) return true;
+  if (!arr1 || !arr2) return false;
+  if (arr1.length != arr2.length) return false;
+  for (var i = 0; i < arr1.length; ++i) {
+    if (arr1[i] != arr2[i]) return false;
+  }
+  return true;
+};

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -383,17 +383,8 @@ shaka.util.StreamUtils.filterVariantsByRoleAndLanguage = function(
   var ContentType = shaka.util.ManifestParserUtils.ContentType;
   var variants = shaka.util.StreamUtils.getPlayableVariants(period.variants);
 
-  // Initially choose the first language in the list.
-  /** @type {!Array.<!shakaExtern.Variant>} */
-  var chosen = variants.filter(function(variant) {
-    return variant.language == variants[0].language;
-  });
-
-  // Prefer primary variants.
-  var primaryVariants = variants.filter(function(variant) {
-    return variant.primary;
-  });
-  if (primaryVariants.length) chosen = primaryVariants;
+  // Start off with the full list of variants. These will be filtered
+  var chosen = variants;
 
   // Choose based on language preference.  Favor exact matches, then
   // base matches, finally different subtags.  Execute in reverse order so
@@ -423,22 +414,59 @@ shaka.util.StreamUtils.filterVariantsByRoleAndLanguage = function(
         }); // forEach(matchType)
   } // if (preferredLanguage)
 
-  // Choose based on role preference. If there's no exact match, return
-  // what was chosen based on the language preference.
+  // Choose based on role preference. If there's no exact match, pick the
+  // first role in the "chosen" list that was based on language preference.
   var role = opt_role || '';
   if (role) {
     var chosenWithRoles = chosen.filter(function(variant) {
       return (variant.audio && (variant.audio.roles.indexOf(role) > - 1)) ||
              (variant.video && (variant.video.roles.indexOf(role) > - 1));
     });
-    if (chosenWithRoles.length) return chosenWithRoles;
-    else {
+    if (chosenWithRoles.length) {
+      chosen = chosenWithRoles;
+    } else {
       shaka.log.warning(
           'No exact match for the role is found. Returning the selection ' +
           'based on language preference.');
     }
   }
-  return chosen;
+
+  // Prefer primary variants, if they exist
+  var primaryVariants = chosen.filter(function(variant) {
+    return variant.primary;
+  });
+  if (primaryVariants.length) chosen = primaryVariants;
+
+  // Ensure that final selection is uniform in language and roles. Go with
+  // the language and roles in the first variant of chosen
+  var firstVariant = chosen[0];
+  return chosen.filter(function(variant) {
+    // variants should have same language
+    if (variant.language != firstVariant.language) {
+      return false;
+    }
+    // existence of video/audio should be same across all variants
+    // Note that it's ok if the variants don't have audio or don't
+    // have video, as long as it's true for all
+    if (!variant.audio != !firstVariant.audio ||
+      !variant.video != !firstVariant.video) {
+      return false;
+    }
+    // when audio/video exists, roles should match
+    if (variant.audio && firstVariant.audio) {
+      if(!shaka.util.ArrayUtils.equal(variant.audio.roles,
+        firstVariant.audio.roles)) {
+          return false;
+        }
+    }
+    if (variant.video && firstVariant.video) {
+      if(!shaka.util.ArrayUtils.equal(variant.video.roles,
+        firstVariant.video.roles)) {
+          return false;
+        }
+    }
+    return true;
+  });
 };
 
 
@@ -457,17 +485,10 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
   var ContentType = shaka.util.ManifestParserUtils.ContentType;
   var streams = period.textStreams;
 
-  // Choose all the streams.
-  /** @type {!Array.<!shakaExtern.Stream>} */
+  // Start off with the full list of streams. These will be filtered
   var chosen = streams;
 
-  // Prefer primary text streams.
-  var primaryStreams = streams.filter(function(stream) {
-    return stream.primary;
-  });
-  if (primaryStreams.length) chosen = primaryStreams;
-
-  // Override based on language preference.  Favor exact matches, then
+  // Choose based on language preference.  Favor exact matches, then
   // base matches, finally different subtags.  Execute in reverse order so
   // the later steps override the previous ones.
   if (preferredLanguage) {
@@ -478,6 +499,7 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
         .forEach(function(matchType) {
           var betterLangMatchFound = false;
           streams.forEach(function(stream) {
+            pref = LanguageUtils.normalize(pref);
             var lang = LanguageUtils.normalize(stream.language);
             if (LanguageUtils.match(matchType, pref, lang)) {
               if (betterLangMatchFound) {
@@ -486,27 +508,48 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
                 chosen = [stream];
                 betterLangMatchFound = true;
               }
-              if (opt_languageMatches)
+              if (opt_languageMatches) {
                 opt_languageMatches[ContentType.TEXT] = true;
+              }
             }
           }); // forEach(stream)
         }); // forEach(matchType)
   } // if (preferredLanguage)
-  // Choose based on role preference. If there's no exact match, return
-  // what was chosen based on the language preference.
+  // Choose based on role preference. If there's no exact match, pick the
+  // first role in the "chosen" list that was based on language preference.
   var role = opt_role || '';
   if (role) {
     var chosenWithRoles = chosen.filter(function(stream) {
       return (stream && (stream.roles.indexOf(role) > - 1));
     });
-    if (chosenWithRoles.length) return chosenWithRoles;
-    else {
+    if (chosenWithRoles.length) {
+      chosen = chosenWithRoles;
+    } else {
       shaka.log.warning(
           'No exact match for the role is found. Returning the selection ' +
           'based on language preference.');
     }
   }
-  return chosen;
+
+  // Prefer primary streams, if they exist
+  var primaryStreams = chosen.filter(function(stream) {
+    return stream.primary;
+  });
+  if (primaryStreams.length) chosen = primaryStreams;
+
+  // Ensure that final selection is uniform in language and roles. Go with
+  // the language and roles in the first stream of chosen
+  var firstStream = chosen[0];
+  return chosen.filter(function(stream) {
+    // streams should have same language
+    if (stream.language != firstStream.language) {
+      return false;
+    }
+    if(!shaka.util.ArrayUtils.equal(stream.roles, firstStream.roles)) {
+      return false;
+    }
+    return true;
+  });
 };
 
 

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -41,39 +41,25 @@ describe('StreamUtils', function() {
       expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
     });
 
-    it('chooses primary variants', function() {
-      manifest = new shaka.test.ManifestGenerator()
-        .addPeriod(0)
-         .addVariant(0)
-            .primary()
-         .addVariant(1)
-         .addVariant(2)
-         .addVariant(3)
-            .primary()
-        .build();
-
-      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
-          manifest.periods[0], preferredAudioLanguage);
-      expect(chosen.length).toBe(2);
-      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
-      expect(chosen[1]).toBe(manifest.periods[0].variants[3]);
-    });
-
-    it('filters out resctricted variants', function() {
+    it("chooses variants in user's preferred role", function() {
       manifest = new shaka.test.ManifestGenerator()
         .addPeriod(0)
           .addVariant(0)
+            .language('es')
+            .addAudio(0).roles(['main'])
           .addVariant(1)
+            .language('es')
+            .addAudio(1).roles(['commentary'])
           .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['main'])
         .build();
 
-      manifest.periods[0].variants[0].allowedByKeySystem = false;
-      manifest.periods[0].variants[1].allowedByApplication = false;
-
       var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
-          manifest.periods[0], preferredAudioLanguage);
-      expect(chosen.length).toBe(1);
-      expect(chosen[0]).toBe(manifest.periods[0].variants[2]);
+          manifest.periods[0], undefined, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
     });
 
     it('chooses variants in preferred language and role', function() {
@@ -96,6 +82,177 @@ describe('StreamUtils', function() {
       expect(chosen.length).toBe(1);
       expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
     });
+
+    it("chooses variants in user's preferred language if " +
+       'preferred role does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .language('en')
+            .addAudio(0).roles(['secondary'])
+          .addVariant(1)
+            .language('en')
+            .addAudio(1).roles(['secondary'])
+          .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['supplementary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[1]);
+    });
+
+    it("chooses variants in user's preferred role if " +
+       'preferred language does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .language('es')
+            .addAudio(0).roles(['main'])
+          .addVariant(1)
+            .language('es')
+            .addAudio(1).roles(['commentary'])
+          .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0], preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses variants in preferred language within single role', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0) // this variant will be chosen and used as baseline
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(2).roles(['secondary'])
+          .addVariant(1)
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(3).roles(['commentary'])
+          .addVariant(2)
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(4).roles(['secondary'])
+          .addVariant(3)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(5).roles(['commentary'])
+          .addVariant(4) // Will not be chosen because roles list is different
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(6).roles(['secondary', 'alternate'])
+          .addVariant(5) // Will not be chosen because video role differs
+            .language('en')
+            .addVideo(1).roles(['alternate'])
+            .addAudio(7).roles(['secondary'])
+          .addVariant(6) // Will not be chosen because no video
+            .language('en')
+            .addAudio(8).roles(['secondary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses variants with language and role of first variant when ' +
+       'neither preferred language nor preferred role match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0) // this variant will be chosen and used as baseline
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(2).roles(['secondary'])
+          .addVariant(1)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(3).roles(['commentary'])
+          .addVariant(2)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(4).roles(['secondary'])
+          .addVariant(3) // Will not be chosen because language is different
+            .language('fr')
+            .addVideo(0).roles(['main'])
+            .addAudio(5).roles(['secondary'])
+          .addVariant(4) // Will not be chosen because roles list is different
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(6).roles(['secondary', 'alternate'])
+          .addVariant(5) // Will not be chosen because video role differs
+            .language('es')
+            .addVideo(1).roles(['alternate'])
+            .addAudio(7).roles(['secondary'])
+          .addVariant(6) // Will not be chosen because no video
+            .language('es')
+            .addAudio(8).roles(['secondary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses primary variants', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .primary()
+            .language('en')
+            .addAudio(0).roles(['main'])
+          .addVariant(1) // Won't be chosen because doesn't match user prefs
+            .primary()
+            .language('es')
+            .addAudio(1).roles(['main'])
+          .addVariant(2)
+            .primary()
+            .language('en')
+            .addAudio(2).roles(['main'])
+          .addVariant(4) // Won't be chosen because not primary
+            .language('en')
+            .addAudio(2).roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('filters out restricted variants', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+          .addVariant(1)
+          .addVariant(2)
+        .build();
+
+      manifest.periods[0].variants[0].allowedByKeySystem = false;
+      manifest.periods[0].variants[1].allowedByApplication = false;
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0], preferredAudioLanguage);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[2]);
+    });
   });
 
   describe('filterTextStreamsByRoleAndLanguage', function() {
@@ -117,20 +274,67 @@ describe('StreamUtils', function() {
       expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
 
-    it('chooses primary text streams', function() {
+    it("chooses text streams in user's preferred role", function() {
       manifest = new shaka.test.ManifestGenerator()
         .addPeriod(0)
           .addTextStream(1)
+            .language('es')
+            .roles(['main'])
           .addTextStream(2)
-            .primary()
+            .language('es')
+            .roles(['commentary'])
           .addTextStream(3)
-            .primary()
+            .language('es')
+            .roles(['main'])
+        .build();
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it("chooses text streams in user's preferred language if " +
+       'preferred role does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0)
+            .language('en')
+            .roles(['secondary'])
+          .addTextStream(1)
+            .language('en')
+            .roles(['secondary'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['supplementary'])
         .build();
 
       var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
-          manifest.periods[0], preferredTextLanguage);
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
       expect(chosen.length).toBe(2);
-      expect(chosen[0]).toBe(manifest.periods[0].textStreams[1]);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[1]);
+    });
+
+    it("chooses variants in user's preferred role if " +
+       'preferred language does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0)
+            .language('es')
+            .roles(['main'])
+          .addTextStream(1)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
       expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
 
@@ -152,6 +356,91 @@ describe('StreamUtils', function() {
           preferredTextLanguage, undefined, preferredTextRole);
       expect(chosen.length).toBe(1);
       expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+    });
+
+    it('chooses text streams in preferred language ' +
+       'within single role', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0) // this variant will be chosen and used as baseline
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(1)
+            .language('en')
+            .roles(['commentary'])
+          .addTextStream(2)
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(3)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(4) // Will not be chosen because roles list is different
+            .language('en')
+            .roles(['caption', 'alternate'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it('chooses text streams with language and role of first variant when ' +
+       'neither preferred language nor preferred role match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0) // this variant will be chosen and used as baseline
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(1)
+            .language('es')
+            .roles(['commentary'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(3) // Will not be chosen because language differs
+            .language('fr')
+            .roles(['caption'])
+          .addTextStream(4) // Will not be chosen because roles list is different
+            .language('es')
+            .roles(['caption', 'alternate'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it('chooses primary text streams', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(1)
+            .primary()
+            .language('en')
+            .roles(['main'])
+          .addTextStream(2) // Won't be chosen because doesn't match user prefs
+            .primary()
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(3)
+            .primary()
+            .language('en')
+            .roles(['main'])
+          .addTextStream(4) // Won't be chosen because not primary
+            .language('en')
+            .roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
   });
 


### PR DESCRIPTION
This fixes a bug where two audio tracks with the same language but
different roles might be switched in and out due to ABR.

Technically the DASH spec requires that the player not adapt in/out of a
single AdaptationSet, but since the "variant" concept does not track the
AdaptationSet that its component streams originate from, the closest
thing we can go by is the "role", since two streams with different roles
certainly come from different adaptation sets.

Issue #947