### PR TITLE
Immediately switch audio tracks if different role selected

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -29,6 +29,7 @@ goog.require('shaka.media.SegmentReference');
 goog.require('shaka.media.StreamingEngine');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.text.SimpleTextDisplayer');
+goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.CancelableChain');
 goog.require('shaka.util.ConfigUtils');
 goog.require('shaka.util.Error');
@@ -2275,7 +2276,7 @@ shaka.Player.prototype.chooseStreams_ =
   }
 
   // Check if any of the active streams is no longer available
-  // or is using the wrong language.
+  // or is using the wrong language/role.
   var activeStreams = this.streamingEngine_.getActiveStreams();
   // activePeriod may reasonably be null before StreamingEngine is streaming.
   var activePeriod = this.streamingEngine_.getActivePeriod();
@@ -2294,10 +2295,14 @@ shaka.Player.prototype.chooseStreams_ =
     for (var type in activeStreams) {
       var stream = activeStreams[type];
       if (stream.type == ContentType.AUDIO &&
-          stream.language != variants[0].language) {
+          (stream.language != variants[0].language ||
+          !shaka.util.ArrayUtils.equal(stream.roles,
+              variants[0].audio.roles))) {
         needsUpdate.push(type);
       } else if (stream.type == ContentType.TEXT && textStreams.length > 0 &&
-                 stream.language != textStreams[0].language) {
+                 (stream.language != textStreams[0].language ||
+                 !shaka.util.ArrayUtils.equal(stream.roles,
+                     textStreams[0].roles))) {
         needsUpdate.push(type);
       }
     }

--- a/lib/util/array_utils.js
+++ b/lib/util/array_utils.js
@@ -80,3 +80,21 @@ shaka.util.ArrayUtils.remove = function(array, element) {
   if (index > -1)
     array.splice(index, 1);
 };
+
+
+/**
+ * Compare two arrays for equality.
+ * @param {!Array.<T>} arr1
+ * @param {!Array.<T>} arr2
+ * @return {boolean}
+ * @template T
+ */
+shaka.util.ArrayUtils.equal = function(arr1, arr2) {
+  if (!arr1 && !arr2) return true;
+  if (!arr1 || !arr2) return false;
+  if (arr1.length != arr2.length) return false;
+  for (var i = 0; i < arr1.length; ++i) {
+    if (arr1[i] != arr2[i]) return false;
+  }
+  return true;
+};

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -383,17 +383,8 @@ shaka.util.StreamUtils.filterVariantsByRoleAndLanguage = function(
   var ContentType = shaka.util.ManifestParserUtils.ContentType;
   var variants = shaka.util.StreamUtils.getPlayableVariants(period.variants);
 
-  // Initially choose the first language in the list.
-  /** @type {!Array.<!shakaExtern.Variant>} */
-  var chosen = variants.filter(function(variant) {
-    return variant.language == variants[0].language;
-  });
-
-  // Prefer primary variants.
-  var primaryVariants = variants.filter(function(variant) {
-    return variant.primary;
-  });
-  if (primaryVariants.length) chosen = primaryVariants;
+  // Start off with the full list of variants. These will be filtered
+  var chosen = variants;
 
   // Choose based on language preference.  Favor exact matches, then
   // base matches, finally different subtags.  Execute in reverse order so
@@ -423,22 +414,59 @@ shaka.util.StreamUtils.filterVariantsByRoleAndLanguage = function(
         }); // forEach(matchType)
   } // if (preferredLanguage)
 
-  // Choose based on role preference. If there's no exact match, return
-  // what was chosen based on the language preference.
+  // Choose based on role preference. If there's no exact match, pick the
+  // first role in the "chosen" list that was based on language preference.
   var role = opt_role || '';
   if (role) {
     var chosenWithRoles = chosen.filter(function(variant) {
       return (variant.audio && (variant.audio.roles.indexOf(role) > - 1)) ||
              (variant.video && (variant.video.roles.indexOf(role) > - 1));
     });
-    if (chosenWithRoles.length) return chosenWithRoles;
-    else {
+    if (chosenWithRoles.length) {
+      chosen = chosenWithRoles;
+    } else {
       shaka.log.warning(
           'No exact match for the role is found. Returning the selection ' +
           'based on language preference.');
     }
   }
-  return chosen;
+
+  // Prefer primary variants, if they exist
+  var primaryVariants = chosen.filter(function(variant) {
+    return variant.primary;
+  });
+  if (primaryVariants.length) chosen = primaryVariants;
+
+  // Ensure that final selection is uniform in language and roles. Go with
+  // the language and roles in the first variant of chosen
+  var firstVariant = chosen[0];
+  return chosen.filter(function(variant) {
+    // variants should have same language
+    if (variant.language != firstVariant.language) {
+      return false;
+    }
+    // existence of video/audio should be same across all variants
+    // Note that it's ok if the variants don't have audio or don't
+    // have video, as long as it's true for all
+    if (!variant.audio != !firstVariant.audio ||
+      !variant.video != !firstVariant.video) {
+      return false;
+    }
+    // when audio/video exists, roles should match
+    if (variant.audio && firstVariant.audio) {
+      if(!shaka.util.ArrayUtils.equal(variant.audio.roles,
+        firstVariant.audio.roles)) {
+          return false;
+        }
+    }
+    if (variant.video && firstVariant.video) {
+      if(!shaka.util.ArrayUtils.equal(variant.video.roles,
+        firstVariant.video.roles)) {
+          return false;
+        }
+    }
+    return true;
+  });
 };
 
 
@@ -457,17 +485,10 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
   var ContentType = shaka.util.ManifestParserUtils.ContentType;
   var streams = period.textStreams;
 
-  // Choose all the streams.
-  /** @type {!Array.<!shakaExtern.Stream>} */
+  // Start off with the full list of streams. These will be filtered
   var chosen = streams;
 
-  // Prefer primary text streams.
-  var primaryStreams = streams.filter(function(stream) {
-    return stream.primary;
-  });
-  if (primaryStreams.length) chosen = primaryStreams;
-
-  // Override based on language preference.  Favor exact matches, then
+  // Choose based on language preference.  Favor exact matches, then
   // base matches, finally different subtags.  Execute in reverse order so
   // the later steps override the previous ones.
   if (preferredLanguage) {
@@ -478,6 +499,7 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
         .forEach(function(matchType) {
           var betterLangMatchFound = false;
           streams.forEach(function(stream) {
+            pref = LanguageUtils.normalize(pref);
             var lang = LanguageUtils.normalize(stream.language);
             if (LanguageUtils.match(matchType, pref, lang)) {
               if (betterLangMatchFound) {
@@ -486,27 +508,48 @@ shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage = function(
                 chosen = [stream];
                 betterLangMatchFound = true;
               }
-              if (opt_languageMatches)
+              if (opt_languageMatches) {
                 opt_languageMatches[ContentType.TEXT] = true;
+              }
             }
           }); // forEach(stream)
         }); // forEach(matchType)
   } // if (preferredLanguage)
-  // Choose based on role preference. If there's no exact match, return
-  // what was chosen based on the language preference.
+  // Choose based on role preference. If there's no exact match, pick the
+  // first role in the "chosen" list that was based on language preference.
   var role = opt_role || '';
   if (role) {
     var chosenWithRoles = chosen.filter(function(stream) {
       return (stream && (stream.roles.indexOf(role) > - 1));
     });
-    if (chosenWithRoles.length) return chosenWithRoles;
-    else {
+    if (chosenWithRoles.length) {
+      chosen = chosenWithRoles;
+    } else {
       shaka.log.warning(
           'No exact match for the role is found. Returning the selection ' +
           'based on language preference.');
     }
   }
-  return chosen;
+
+  // Prefer primary streams, if they exist
+  var primaryStreams = chosen.filter(function(stream) {
+    return stream.primary;
+  });
+  if (primaryStreams.length) chosen = primaryStreams;
+
+  // Ensure that final selection is uniform in language and roles. Go with
+  // the language and roles in the first stream of chosen
+  var firstStream = chosen[0];
+  return chosen.filter(function(stream) {
+    // streams should have same language
+    if (stream.language != firstStream.language) {
+      return false;
+    }
+    if(!shaka.util.ArrayUtils.equal(stream.roles, firstStream.roles)) {
+      return false;
+    }
+    return true;
+  });
 };
 
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -1033,7 +1033,7 @@ describe('Player', function() {
           .addVariant(3)
             .bandwidth(200)
             .language('en')
-            .addAudio(2).bandwidth(100)
+            .addAudio(2).bandwidth(100).roles(['secondary'])
             .addVideo(4).bandwidth(100).size(100, 200)
             .frameRate(1000000 / 42000)
           .addVariant(4)
@@ -1044,7 +1044,7 @@ describe('Player', function() {
           .addVariant(5)
             .language('es')
             .bandwidth(300)
-            .addAudio(8).bandwidth(100)
+            .addAudio(9).bandwidth(100)
             .addVideo(5).bandwidth(200).size(200, 400).frameRate(24)
           .addTextStream(6)
             .language('es')
@@ -1056,6 +1056,11 @@ describe('Player', function() {
             .label('English')
             .bandwidth(100).kind('caption')
                          .mime('application/ttml+xml')
+          .addTextStream(8)
+            .language('es')
+            .label('Spanish')
+            .bandwidth(100).kind('caption').roles(['caption', 'secondary'])
+                         .mime('text/vtt')
           // Both text tracks should remain, even with different MIME types.
         .build();
 
@@ -1122,7 +1127,7 @@ describe('Player', function() {
           audioCodec: 'mp4a.40.2',
           videoCodec: 'avc1.4d401f',
           primary: false,
-          roles: [],
+          roles: ['secondary'],
           videoId: 4,
           audioId: 2,
           channelsCount: null,
@@ -1145,7 +1150,7 @@ describe('Player', function() {
           audioCodec: 'mp4a.40.2',
           videoCodec: 'avc1.4d401f',
           primary: false,
-          roles: [],
+          roles: ['secondary'],
           videoId: 5,
           audioId: 2,
           channelsCount: null,
@@ -1170,7 +1175,7 @@ describe('Player', function() {
           primary: false,
           roles: [],
           videoId: 5,
-          audioId: 8,
+          audioId: 9,
           channelsCount: null,
           audioBandwidth: 100,
           videoBandwidth: 200
@@ -1211,7 +1216,24 @@ describe('Player', function() {
           channelsCount: null,
           audioBandwidth: null,
           videoBandwidth: null
-        }
+        },
+        {
+          id: 8,
+          active: false,
+          type: ContentType.TEXT,
+          language: 'es',
+          label: 'Spanish',
+          kind: 'caption',
+          mimeType: 'text/vtt',
+          codecs: null,
+          audioCodec: null,
+          videoCodec: null,
+          primary: false,
+          roles: ['caption', 'secondary'],
+          channelsCount: null,
+          audioBandwidth: null,
+          videoBandwidth: null
+        },
       ];
     });
 
@@ -1421,6 +1443,46 @@ describe('Player', function() {
           .toHaveBeenCalledWith(ContentType.AUDIO, spanishStream, true);
     });
 
+    it('selectAudioLanguage() does not switch if language already selected',
+        function() {
+          chooseStreams();
+          canSwitch();
+          player.configure({
+            preferredAudioLanguage: 'en'
+          });
+
+          var period = manifest.periods[0];
+          var englishStream = period.variants[3].audio;
+          var activeTrack = getActiveTrack('variant')
+          expect(activeTrack.language).toEqual('en')
+
+          player.selectAudioLanguage('en');
+          expect(streamingEngine.switch).not.toHaveBeenCalled();
+        });
+
+    it('selectAudioLanguage() switches tracks if new role selected',
+        function() {
+          chooseStreams();
+          canSwitch();
+          player.configure({
+            preferredAudioLanguage: 'en'
+          });
+
+          var period = manifest.periods[0];
+          var variant1 = period.variants[0];
+          var variant2 = period.variants[2]; // role "secondary"
+          expect(variant1.video).toEqual(variant2.video);
+          expect(variant1.language).toEqual(variant2.language);
+          expect(variant1.audio.roles.length).not.toEqual(
+            variant2.audio.roles.length);
+          var activeTrack = getActiveTrack('variant')
+          expect(variant1.id).toEqual(activeTrack.id);
+
+          player.selectAudioLanguage('en', 'secondary');
+          expect(streamingEngine.switch)
+              .toHaveBeenCalledWith(ContentType.AUDIO, variant2.audio, true);
+        });
+
     it('changing currentTextLanguage changes active stream', function() {
       chooseStreams();
       canSwitch();
@@ -1434,6 +1496,43 @@ describe('Player', function() {
       expect(streamingEngine.switch)
           .toHaveBeenCalledWith(ContentType.TEXT, englishStream, true);
     });
+
+    it('selectTextLanguage() does not switch if language already selected',
+        function() {
+          chooseStreams();
+          canSwitch();
+          player.configure({
+            preferredTextLanguage: 'es'
+          });
+
+          var period = manifest.periods[0];
+          var activeTrack = getActiveTextTrack()
+          expect(activeTrack.language).toEqual('es')
+
+          player.selectTextLanguage('es');
+          expect(streamingEngine.switch).not.toHaveBeenCalled();
+        });
+
+    it('selectTextLanguage() switches tracks if new role selected',
+        function() {
+          chooseStreams();
+          canSwitch();
+          player.configure({
+            preferredTextLanguage: 'es'
+          });
+
+          var period = manifest.periods[0];
+          var text1 = period.textStreams[0];
+          var text2 = period.textStreams[2]; // role "secondary"
+          expect(text1.language).toEqual(text2.language);
+          expect(text1.roles.length).not.toEqual(text2.roles.length);
+          var activeTrack = getActiveTextTrack()
+          expect(text1.id).toEqual(activeTrack.id)
+
+          player.selectTextLanguage('es', 'secondary');
+          expect(streamingEngine.switch)
+              .toHaveBeenCalledWith(ContentType.TEXT, text2, true);
+        });
   });
 
   describe('languages', function() {
@@ -2284,20 +2383,6 @@ describe('Player', function() {
     });
 
     /**
-     * Gets the currently active track.
-     * @param {string} type
-     * @return {shakaExtern.Track}
-     */
-    function getActiveTrack(type) {
-      var activeTracks = player.getVariantTracks().filter(function(track) {
-        return track.type == type && track.active;
-      });
-
-      expect(activeTracks.length).toBe(1);
-      return activeTracks[0];
-    }
-
-    /**
      * @param {!Object.<string, string>} keyStatusMap
      * @suppress {accessControls}
      */
@@ -2389,6 +2474,33 @@ describe('Player', function() {
       player.load('', 0, parserFactory).catch(fail).then(done);
     });
   });
+
+  /**
+   * Gets the currently active track.
+   * @param {string} type
+   * @return {shakaExtern.Track}
+   */
+  function getActiveTrack(type) {
+    var activeTracks = player.getVariantTracks().filter(function(track) {
+      return track.type == type && track.active;
+    });
+
+    expect(activeTracks.length).toBe(1);
+    return activeTracks[0];
+  }
+
+  /**
+   * Gets the currently active text track.
+   * @return {shakaExtern.Track}
+   */
+  function getActiveTextTrack() {
+    var activeTracks = player.getTextTracks().filter(function(track) {
+      return track.active;
+    });
+
+    expect(activeTracks.length).toBe(1);
+    return activeTracks[0];
+  }
 
   /**
    * Choose streams for the given period.

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -41,39 +41,25 @@ describe('StreamUtils', function() {
       expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
     });
 
-    it('chooses primary variants', function() {
-      manifest = new shaka.test.ManifestGenerator()
-        .addPeriod(0)
-         .addVariant(0)
-            .primary()
-         .addVariant(1)
-         .addVariant(2)
-         .addVariant(3)
-            .primary()
-        .build();
-
-      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
-          manifest.periods[0], preferredAudioLanguage);
-      expect(chosen.length).toBe(2);
-      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
-      expect(chosen[1]).toBe(manifest.periods[0].variants[3]);
-    });
-
-    it('filters out resctricted variants', function() {
+    it("chooses variants in user's preferred role", function() {
       manifest = new shaka.test.ManifestGenerator()
         .addPeriod(0)
           .addVariant(0)
+            .language('es')
+            .addAudio(0).roles(['main'])
           .addVariant(1)
+            .language('es')
+            .addAudio(1).roles(['commentary'])
           .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['main'])
         .build();
 
-      manifest.periods[0].variants[0].allowedByKeySystem = false;
-      manifest.periods[0].variants[1].allowedByApplication = false;
-
       var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
-          manifest.periods[0], preferredAudioLanguage);
-      expect(chosen.length).toBe(1);
-      expect(chosen[0]).toBe(manifest.periods[0].variants[2]);
+          manifest.periods[0], undefined, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
     });
 
     it('chooses variants in preferred language and role', function() {
@@ -96,6 +82,177 @@ describe('StreamUtils', function() {
       expect(chosen.length).toBe(1);
       expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
     });
+
+    it("chooses variants in user's preferred language if " +
+       'preferred role does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .language('en')
+            .addAudio(0).roles(['secondary'])
+          .addVariant(1)
+            .language('en')
+            .addAudio(1).roles(['secondary'])
+          .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['supplementary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[1]);
+    });
+
+    it("chooses variants in user's preferred role if " +
+       'preferred language does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .language('es')
+            .addAudio(0).roles(['main'])
+          .addVariant(1)
+            .language('es')
+            .addAudio(1).roles(['commentary'])
+          .addVariant(2)
+            .language('es')
+            .addAudio(2).roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0], preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses variants in preferred language within single role', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0) // this variant will be chosen and used as baseline
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(2).roles(['secondary'])
+          .addVariant(1)
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(3).roles(['commentary'])
+          .addVariant(2)
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(4).roles(['secondary'])
+          .addVariant(3)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(5).roles(['commentary'])
+          .addVariant(4) // Will not be chosen because roles list is different
+            .language('en')
+            .addVideo(0).roles(['main'])
+            .addAudio(6).roles(['secondary', 'alternate'])
+          .addVariant(5) // Will not be chosen because video role differs
+            .language('en')
+            .addVideo(1).roles(['alternate'])
+            .addAudio(7).roles(['secondary'])
+          .addVariant(6) // Will not be chosen because no video
+            .language('en')
+            .addAudio(8).roles(['secondary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses variants with language and role of first variant when ' +
+       'neither preferred language nor preferred role match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0) // this variant will be chosen and used as baseline
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(2).roles(['secondary'])
+          .addVariant(1)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(3).roles(['commentary'])
+          .addVariant(2)
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(4).roles(['secondary'])
+          .addVariant(3) // Will not be chosen because language is different
+            .language('fr')
+            .addVideo(0).roles(['main'])
+            .addAudio(5).roles(['secondary'])
+          .addVariant(4) // Will not be chosen because roles list is different
+            .language('es')
+            .addVideo(0).roles(['main'])
+            .addAudio(6).roles(['secondary', 'alternate'])
+          .addVariant(5) // Will not be chosen because video role differs
+            .language('es')
+            .addVideo(1).roles(['alternate'])
+            .addAudio(7).roles(['secondary'])
+          .addVariant(6) // Will not be chosen because no video
+            .language('es')
+            .addAudio(8).roles(['secondary'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('chooses primary variants', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+            .primary()
+            .language('en')
+            .addAudio(0).roles(['main'])
+          .addVariant(1) // Won't be chosen because doesn't match user prefs
+            .primary()
+            .language('es')
+            .addAudio(1).roles(['main'])
+          .addVariant(2)
+            .primary()
+            .language('en')
+            .addAudio(2).roles(['main'])
+          .addVariant(4) // Won't be chosen because not primary
+            .language('en')
+            .addAudio(2).roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredAudioLanguage, undefined, preferredAudioRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].variants[2]);
+    });
+
+    it('filters out restricted variants', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addVariant(0)
+          .addVariant(1)
+          .addVariant(2)
+        .build();
+
+      manifest.periods[0].variants[0].allowedByKeySystem = false;
+      manifest.periods[0].variants[1].allowedByApplication = false;
+
+      var chosen = shaka.util.StreamUtils.filterVariantsByRoleAndLanguage(
+          manifest.periods[0], preferredAudioLanguage);
+      expect(chosen.length).toBe(1);
+      expect(chosen[0]).toBe(manifest.periods[0].variants[2]);
+    });
   });
 
   describe('filterTextStreamsByRoleAndLanguage', function() {
@@ -117,20 +274,67 @@ describe('StreamUtils', function() {
       expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
 
-    it('chooses primary text streams', function() {
+    it("chooses text streams in user's preferred role", function() {
       manifest = new shaka.test.ManifestGenerator()
         .addPeriod(0)
           .addTextStream(1)
+            .language('es')
+            .roles(['main'])
           .addTextStream(2)
-            .primary()
+            .language('es')
+            .roles(['commentary'])
           .addTextStream(3)
-            .primary()
+            .language('es')
+            .roles(['main'])
+        .build();
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it("chooses text streams in user's preferred language if " +
+       'preferred role does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0)
+            .language('en')
+            .roles(['secondary'])
+          .addTextStream(1)
+            .language('en')
+            .roles(['secondary'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['supplementary'])
         .build();
 
       var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
-          manifest.periods[0], preferredTextLanguage);
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
       expect(chosen.length).toBe(2);
-      expect(chosen[0]).toBe(manifest.periods[0].textStreams[1]);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[1]);
+    });
+
+    it("chooses variants in user's preferred role if " +
+       'preferred language does not match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0)
+            .language('es')
+            .roles(['main'])
+          .addTextStream(1)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage, undefined, preferredTextRole);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
       expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
 
@@ -152,6 +356,91 @@ describe('StreamUtils', function() {
           preferredTextLanguage, undefined, preferredTextRole);
       expect(chosen.length).toBe(1);
       expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+    });
+
+    it('chooses text streams in preferred language ' +
+       'within single role', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0) // this variant will be chosen and used as baseline
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(1)
+            .language('en')
+            .roles(['commentary'])
+          .addTextStream(2)
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(3)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(4) // Will not be chosen because roles list is different
+            .language('en')
+            .roles(['caption', 'alternate'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it('chooses text streams with language and role of first variant when ' +
+       'neither preferred language nor preferred role match', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(0) // this variant will be chosen and used as baseline
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(1)
+            .language('es')
+            .roles(['commentary'])
+          .addTextStream(2)
+            .language('es')
+            .roles(['caption'])
+          .addTextStream(3) // Will not be chosen because language differs
+            .language('fr')
+            .roles(['caption'])
+          .addTextStream(4) // Will not be chosen because roles list is different
+            .language('es')
+            .roles(['caption', 'alternate'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0],
+          preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
+    });
+
+    it('chooses primary text streams', function() {
+      manifest = new shaka.test.ManifestGenerator()
+        .addPeriod(0)
+          .addTextStream(1)
+            .primary()
+            .language('en')
+            .roles(['main'])
+          .addTextStream(2) // Won't be chosen because doesn't match user prefs
+            .primary()
+            .language('en')
+            .roles(['caption'])
+          .addTextStream(3)
+            .primary()
+            .language('en')
+            .roles(['main'])
+          .addTextStream(4) // Won't be chosen because not primary
+            .language('en')
+            .roles(['main'])
+        .build();
+
+      var chosen = shaka.util.StreamUtils.filterTextStreamsByRoleAndLanguage(
+          manifest.periods[0], preferredTextLanguage);
+      expect(chosen.length).toBe(2);
+      expect(chosen[0]).toBe(manifest.periods[0].textStreams[0]);
+      expect(chosen[1]).toBe(manifest.periods[0].textStreams[2]);
     });
   });
 


### PR DESCRIPTION
Previously, selecting a new audio track with selectAudioLanguage(), with
the same language but different role, would only set the variants to
switch to for ABR, but wouldn't actually switch to any of those variants
at the moment of selection due to a bug in chooseStreams_(), which was
still looking at only audio language as a differentiating mechanism.
This change honors the role as well, so that a switch to the correct
variants immediately happens.

Closes #948