### PR TITLE
Update Playready test LAURL

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,6 +54,7 @@ Sanborn Hilland <sanbornh@rogers.com>
 Seth Madison <seth@philo.com>
 Thomas Stephens <thomas@ustudio.com>
 Timothy Drews <tdrews@google.com>
+Tomas Bucher <collapsingtesseract@gmail.com>
 Torbjörn Einarsson <torbjorn.einarsson@edgeware.tv>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 Vasanth Polipelli <vasanthap@google.com>

--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -849,7 +849,7 @@ shakaAssets.testAssets = [
     ],
 
     licenseServers: {
-      'com.microsoft.playready': '//playready.directtaps.net/pr/svc/rightsmanager.asmx?PlayRight=1&UseSimpleNonPersistentLicense=1'  // gjslint: disable=110
+      'com.microsoft.playready': '//test.playready.microsoft.com/service/rightsmanager.asmx?PlayRight=1&UseSimpleNonPersistentLicense=1'  // gjslint: disable=110
     }
   },
   {


### PR DESCRIPTION
Replacement of deprecated Playready test license server in Shaka Demo App.

closes #945 