### PR TITLE
Improve store/delete button UX on mobile

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -216,7 +216,8 @@
       <details id="offlineSection" class="input">
         <summary>Offline</summary>
         <div>
-          <button id="storeDelete">Store</button>
+          <button id="storeDeleteButton">Store</button>
+          <span id="storeDeleteHelpText"></span>
         </div>
         <div id="progressDiv">
           <span class="label">Progress:</span>

--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -70,7 +70,8 @@ shakaDemo.updateButtons_ = function(canHide) {
   else if (!supportsDrm)
     helpText.textContent = 'This browser does not support persistent licenses.';
   else if (button.disabled)
-    helpText.textContent = 'Selected asset is stored offline.';
+    helpText.textContent = 'The asset is stored offline. ' +
+        'Checkout the "Offline" section in the "Asset" list';
   else
     helpText.textContent = '';
 };

--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -61,23 +61,24 @@ shakaDemo.updateButtons_ = function(canHide) {
   document.getElementById('offlineNameDiv').style.display =
       option.asset ? 'none' : 'block';
 
-  var button = document.getElementById('storeDelete');
+  var button = document.getElementById('storeDeleteButton');
   button.disabled = (inProgress || !supportsDrm || option.isStored);
   button.innerText = storedContent ? 'Delete' : 'Store';
+  var helpText = document.getElementById('storeDeleteHelpText');
   if (inProgress)
-    button.title = 'There is already an operation in progress';
+    helpText.textContent = 'Operation is in progress...';
   else if (!supportsDrm)
-    button.title = 'This browser does not support persistent licenses';
+    helpText.textContent = 'This browser does not support persistent licenses.';
   else if (button.disabled)
-    button.title = 'Selected asset is already stored offline';
+    helpText.textContent = 'Selected asset is stored offline.';
   else
-    button.title = '';
+    helpText.textContent = '';
 };
 
 
 /** @private */
 shakaDemo.setupOffline_ = function() {
-  document.getElementById('storeDelete')
+  document.getElementById('storeDeleteButton')
       .addEventListener('click', shakaDemo.storeDeleteAsset_);
   document.getElementById('assetList')
       .addEventListener('change', shakaDemo.updateButtons_.bind(null, true));


### PR DESCRIPTION
Using `title` on `storeDelete` button in the demo is not helpful on a mobile device. This CL improves it by moving it in a separate `<span>` element.

