### PR TITLE
Add ms:laurl and mspr:pro parsing

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -250,6 +250,179 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
   return repContext.defaultKeyId || context.defaultKeyId;
 };
 
+/**
+ * Gets a Widevine license URL from a content protection element
+ * containing a custom `ms:laurl` element
+ *
+ * @param {shaka.dash.ContentProtection.Element} element
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getWidevineLicenseUrl_ = function(element) {
+  var mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
+
+  if (mslaurlNode) {
+    return mslaurlNode.getAttribute('licenseUrl') || '';
+  }
+
+  return '';
+};
+
+/**
+ * @typedef {{
+ *   type: number,
+ *   length: number,
+ *   value: string
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object record.
+ *
+ * @property {number} type
+ *   Type of data stored in the record.
+ * @property {number} length
+ *   Size of the record in bytes.
+ * @property {string} value
+ *   Record content.
+ */
+shaka.dash.ContentProtection.PlayReadyRecord;
+
+/**
+ * @typedef {{
+ *   length: number,
+ *   recordCount: number,
+ *   records: Array.<shaka.dash.ContentProtection.PlayReadyRecord>,
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object.
+ *
+ * @property {number} length
+ *   Size of the PlayReady header object in bytes.
+ * @property {number} recordCount
+ *   Number of records in the PlayReady object.
+ * @property {Array.<shaka.dash.ContentProtection.PlayReadyRecord>} records
+ *   Contains a variable number of records that contain license acquisition information.
+ */
+shaka.dash.ContentProtection.PlayReadyHeaderObject;
+
+/**
+ * A map of PlayReady record types to description.
+ *
+ * @const {!Object.<number, string>}
+ * @private
+ */
+var PLAYREADY_RECORD_TYPES = {
+  0x0001 : 'RIGHTS_MANAGEMENT',
+  0x0002 : 'RESERVED',
+  0x0003 : 'EMBEDDED_LICENSE'
+};
+
+/**
+ * @param {Uint16Array} recordData
+ * @param {number} recordCount
+ * @return {Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+ * @private
+ */
+shaka.dash.ContentProtection.parseRecords_ = function(recordData, recordCount) {
+  var head = 0;
+  var records = [];
+  for (var i = 0; i < recordCount; i++) {
+    var recordRaw = recordData.subarray(head);
+
+    var type = recordRaw[0];
+    var length = recordRaw[1];
+    var offset = 2;
+    var charCount = length / 2;
+    var end = charCount + offset;
+
+    // subarray end is exclusive
+    var rawValue = recordRaw.subarray(offset, end);
+    var value = String.fromCharCode.apply(null, rawValue);
+
+    records.push({
+      type: type,
+      length: length,
+      value: value
+    });
+
+    head = end;
+  }
+
+  return records;
+};
+
+/**
+ * Based off getLicenseServerURLFromInitData from dash.js
+ * https://github.com/Dash-Industry-Forum/dash.js
+ *
+ * @param {Uint16Array} bytes
+ * @return {shaka.dash.ContentProtection.PlayReadyHeaderObject}
+ * @private
+ */
+shaka.dash.ContentProtection.parsePro_ = function(bytes) {
+  var length = bytes[0] | bytes[1];
+  var recordCount = bytes[2];
+
+  var recordData = bytes.subarray(3);
+  var records = shaka.dash.ContentProtection.parseRecords_(recordData, recordCount);
+
+  return {
+    length: length,
+    recordCount: recordCount,
+    records: records
+  };
+};
+
+/**
+ * @param {!Element} xml
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getLaurl_ = function(xml) {
+  var laurlNode = xml.getElementsByTagName('LA_URL')[0];
+  if (laurlNode) {
+    var laurl = laurlNode.childNodes[0].nodeValue;
+
+    if (laurl) {
+      return laurl;
+    }
+  }
+
+  return '';
+};
+
+/**
+ * Gets a PlayReady license URL from a content protection element
+ * containing a PlayReady Header Object
+ *
+ * @param {shaka.dash.ContentProtection.Element} element
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_ = function(element) {
+  var proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
+
+  if (!proNode) {
+    return '';
+  }
+
+  var bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
+  var parsedPro = shaka.dash.ContentProtection.parsePro_(new Uint16Array(bytes.buffer));
+
+  var records = parsedPro.records;
+  var parser = new DOMParser();
+  for (var i = 0; i < records.length; i++) {
+    var record = records[i];
+    if (PLAYREADY_RECORD_TYPES[record.type] === 'RIGHTS_MANAGEMENT') {
+      var xml = parser.parseFromString(record.value, 'application/xml').documentElement;
+
+      return shaka.dash.ContentProtection.getLaurl_(xml);
+    }
+  }
+
+  return '';
+};
 
 /**
  * Creates DrmInfo objects from the given element.
@@ -276,7 +449,19 @@ shaka.dash.ContentProtection.convertElements_ = function(
           goog.asserts.assert(!element.init || element.init.length,
                               'Init data must be null or non-empty.');
           var initData = element.init || defaultInit;
-          return [ManifestParserUtils.createDrmInfo(keySystem, initData)];
+          var drmInfo = ManifestParserUtils.createDrmInfo(keySystem, initData);
+
+          // extract Widevine license URL
+          if (keySystem === 'com.widevine.alpha') {
+            drmInfo.licenseServerUri = shaka.dash.ContentProtection.getWidevineLicenseUrl_(element);
+          }
+
+          // extract PlayReady license URL from PlayReady header Object
+          if (keySystem === 'com.microsoft.playready') {
+            drmInfo.licenseServerUri = shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_(element);
+          }
+
+          return [drmInfo];
         } else {
           goog.asserts.assert(
               callback, 'ContentProtection callback is required');


### PR DESCRIPTION
This PR closes #484 and parses license urls from `<ms:laurl>` and `<mspr:pro>` in the manifest. 