### PR TITLE
VDMS Multi DRM assets to consider for inclusion in demo app

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -75,6 +75,8 @@ shakaAssets.Feature = {
   MULTIKEY: 'multiple keys',
   MULTIPERIOD: 'multiple Periods',
   ENCRYPTED_WITH_CLEAR: 'mixing encrypted and unencrypted periods',
+  AESCTR_16_BYTE_IV: 'encrypted with AES CTR Mode using a 16 byte IV',
+  AESCTR_8_BYTE_IV: 'encrypted with AES CTR Mode using a 8 byte IV',
   TRICK_MODE: 'special trick mode track',
   XLINK: 'xlink',
 
@@ -206,7 +208,9 @@ shakaAssets.UplynkResponseFilter = function(type, response) {
   if (type == shaka.net.NetworkingEngine.RequestType.MANIFEST) {
     // Parse a custom header that contains a value needed to build a proper
     // license server URL
-    shakaAssets.uplynk_prefix = response.headers['x-uplynk-prefix'];
+    if (response.headers['x-uplynk-prefix']) {
+      shakaAssets.uplynk_prefix = response.headers['x-uplynk-prefix'];
+    }
   }
 };
 
@@ -222,15 +226,26 @@ shakaAssets.UplynkResponseFilter = function(type, response) {
 shakaAssets.UplynkRequestFilter = function(type, request) {
   if (type == shaka.net.NetworkingEngine.RequestType.LICENSE ||
       type == shaka.net.NetworkingEngine.RequestType.MANIFEST) {
-    request.allowCrossSiteCredentials = true;
+    // It appears UTCTiming requests are considered MANIFEST type requests
+    if (request.uris[0].indexOf('servertime') == -1) {
+      request.allowCrossSiteCredentials = true;
+    }
+    else {
+      request.allowCrossSiteCredentials = false;
+    }
   }
 
   if (type == shaka.net.NetworkingEngine.RequestType.LICENSE) {
     // Modify the license request URL based on our cookie
-    if (request.uris[0].indexOf('wv') !== -1) {
+    if (request.uris[0].indexOf('wv') !== -1 &&
+        shakaAssets.uplynk_prefix) {
       request.uris[0] = shakaAssets.uplynk_prefix.concat('/wv');
-    } else if (request.uris[0].indexOf('ck') !== -1) {
+    } else if (request.uris[0].indexOf('ck') !== -1 &&
+               shakaAssets.uplynk_prefix) {
       request.uris[0] = shakaAssets.uplynk_prefix.concat('/ck');
+    } else if (request.uris[0].indexOf('pr') !== -1 &&
+               shakaAssets.uplynk_prefix) {
+      request.uris[0] = shakaAssets.uplynk_prefix.concat('/pr');
     }
   }
 };
@@ -568,7 +583,7 @@ shakaAssets.testAssets = [
 
     licenseServers: {
       'com.widevine.alpha': '//drm-widevine-licensing.axtest.net/AcquireLicense',  // gjslint: disable=110
-      'com.microsoft.playready': '//drm-playready-licensing.axtest.net/AcquireLicense'  // gjslint: disable=110
+      'com.microsoft.playready': '//drm-playready-licensing.axtest.net/AcquireLicense' // gjslint: disable=110
     },
     licenseRequestHeaders: {
       'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.4lWwW46k-oWcah8oN18LPj5OLS5ZU-_AQv7fe0JhNjA'  // gjslint: disable=110
@@ -1073,30 +1088,82 @@ shakaAssets.testAssets = [
 
   // Verizon Digital Media Services (VDMS) assets {{{
   {
-    name: 'Big Buck Bunny',
-    manifestUri: 'https://content.uplynk.com/224ac8717e714b68831997ab6cea4015.mpd', // gjslint: disable=110
-
+    name: 'Multi DRM - 8 Byte IV',
+    // Reliable Playready playback requires Edge 16+
+    // The playenabler and sl url parameters allow for playback in VMs
+    manifestUri: 'https://content.uplynk.com/a3efd4fe40d84f31a82e839cffe6c0eb.mpd?pr.playenabler=B621D91F-EDCC-4035-8D4B-DC71760D43E9&pr.sl=150', // gjslint: disable=110
     encoder: shakaAssets.Encoder.UPLYNK,
     source: shakaAssets.Source.UPLYNK,
     drm: [
-      shakaAssets.KeySystem.WIDEVINE,
-      shakaAssets.KeySystem.CLEAR_KEY
+      shakaAssets.KeySystem.PLAYREADY,
+      shakaAssets.KeySystem.WIDEVINE
     ],
     features: [
       shakaAssets.Feature.MP4,
-      shakaAssets.Feature.SEGMENT_LIST_DURATION,
       shakaAssets.Feature.PSSH,
+      shakaAssets.Feature.MULTIKEY,
+      shakaAssets.Feature.AESCTR_8_BYTE_IV,
+      shakaAssets.Feature.SEGMENT_LIST_DURATION,
       shakaAssets.Feature.HIGH_DEFINITION
     ],
     licenseServers: {
-      'com.widevine.alpha': 'https://content.uplynk.com/wv',
-      'org.w3.clearkey': 'https://content.uplynk.com/ck'
+      'com.microsoft.playready': 'https://content.uplynk.com/pr',
+      'com.widevine.alpha': 'https://content.uplynk.com/wv'
     },
     requestFilter: shakaAssets.UplynkRequestFilter,
     responseFilter: shakaAssets.UplynkResponseFilter
   },
   {
-    name: 'Sintel - (multiperiod-mix of encrypted and unencrypted)',
+    name: 'Multi DRM - MultiPeriod - 8 Byte IV',
+    // Reliable Playready playback requires Edge 16+
+    // The playenabler and sl url parameters allow for playback in VMs
+    manifestUri: 'https://content.uplynk.com/64a9efb8ce204c7f8bbf40a764cccd3c.mpd?ad=cleardash&pr.version=2&pr.playenabler=B621D91F-EDCC-4035-8D4B-DC71760D43E9&pr.sl=150', // gjslint: disable=110
+    encoder: shakaAssets.Encoder.UPLYNK,
+    source: shakaAssets.Source.UPLYNK,
+    drm: [
+      shakaAssets.KeySystem.PLAYREADY,
+      shakaAssets.KeySystem.WIDEVINE
+    ],
+    features: [
+      shakaAssets.Feature.MP4,
+      shakaAssets.Feature.PSSH,
+      shakaAssets.Feature.MULTIKEY,
+      shakaAssets.Feature.MULTIPERIOD,
+      shakaAssets.Feature.SEGMENT_LIST_DURATION,
+      shakaAssets.Feature.AESCTR_8_BYTE_IV,
+      shakaAssets.Feature.HIGH_DEFINITION
+    ],
+    licenseServers: {
+      'com.microsoft.playready': 'https://content.uplynk.com/pr',
+      'com.widevine.alpha': 'https://content.uplynk.com/wv'
+    },
+    requestFilter: shakaAssets.UplynkRequestFilter,
+    responseFilter: shakaAssets.UplynkResponseFilter
+  },
+  {
+    name: 'Widevine - 16 Byte IV',
+    manifestUri: 'https://content.uplynk.com/224ac8717e714b68831997ab6cea4015.mpd', // gjslint: disable=110
+    encoder: shakaAssets.Encoder.UPLYNK,
+    source: shakaAssets.Source.UPLYNK,
+    drm: [
+      shakaAssets.KeySystem.WIDEVINE
+    ],
+    features: [
+      shakaAssets.Feature.MP4,
+      shakaAssets.Feature.PSSH,
+      shakaAssets.Feature.MULTIKEY,
+      shakaAssets.Feature.AESCTR_16_BYTE_IV,
+      shakaAssets.Feature.SEGMENT_LIST_DURATION,
+      shakaAssets.Feature.HIGH_DEFINITION
+    ],
+    licenseServers: {
+      'com.widevine.alpha': 'https://content.uplynk.com/wv'
+    },
+    requestFilter: shakaAssets.UplynkRequestFilter,
+    responseFilter: shakaAssets.UplynkResponseFilter
+  },
+  {
+    name: 'Widevine - 16 Byte IV - (mix of encrypted and unencrypted periods)',
     // Unencrypted periods interspersed with protected periods
     // Doesn't work on Chrome < 58
     manifestUri: 'https://content.uplynk.com/1eb40d8e64234f5c9879db7045c3d48c.mpd?ad=cleardash&rays=cdefg', // gjslint: disable=110
@@ -1104,8 +1171,7 @@ shakaAssets.testAssets = [
     encoder: shakaAssets.Encoder.UPLYNK,
     source: shakaAssets.Source.UPLYNK,
     drm: [
-      shakaAssets.KeySystem.WIDEVINE,
-      shakaAssets.KeySystem.CLEAR_KEY
+      shakaAssets.KeySystem.WIDEVINE
     ],
     features: [
       shakaAssets.Feature.MP4,
@@ -1114,11 +1180,12 @@ shakaAssets.testAssets = [
       shakaAssets.Feature.PSSH,
       shakaAssets.Feature.HIGH_DEFINITION,
       shakaAssets.Feature.MULTIPERIOD,
+      shakaAssets.Feature.MULTIKEY,
+      shakaAssets.Feature.AESCTR_16_BYTE_IV,
       shakaAssets.Feature.ENCRYPTED_WITH_CLEAR
     ],
     licenseServers: {
-      'com.widevine.alpha': 'https://content.uplynk.com/wv',
-      'org.w3.clearkey': 'https://content.uplynk.com/ck'
+      'com.widevine.alpha': 'https://content.uplynk.com/wv'
     },
     requestFilter: shakaAssets.UplynkRequestFilter,
     responseFilter: shakaAssets.UplynkResponseFilter

--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -583,7 +583,7 @@ shakaAssets.testAssets = [
 
     licenseServers: {
       'com.widevine.alpha': '//drm-widevine-licensing.axtest.net/AcquireLicense',  // gjslint: disable=110
-      'com.microsoft.playready': '//drm-playready-licensing.axtest.net/AcquireLicense' // gjslint: disable=110
+      'com.microsoft.playready': '//drm-playready-licensing.axtest.net/AcquireLicense'  // gjslint: disable=110
     },
     licenseRequestHeaders: {
       'X-AxDRM-Message': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ2ZXJzaW9uIjoxLCJjb21fa2V5X2lkIjoiYjMzNjRlYjUtNTFmNi00YWUzLThjOTgtMzNjZWQ1ZTMxYzc4IiwibWVzc2FnZSI6eyJ0eXBlIjoiZW50aXRsZW1lbnRfbWVzc2FnZSIsImtleXMiOlt7ImlkIjoiOWViNDA1MGQtZTQ0Yi00ODAyLTkzMmUtMjdkNzUwODNlMjY2IiwiZW5jcnlwdGVkX2tleSI6ImxLM09qSExZVzI0Y3Iya3RSNzRmbnc9PSJ9XX19.4lWwW46k-oWcah8oN18LPj5OLS5ZU-_AQv7fe0JhNjA'  // gjslint: disable=110


### PR DESCRIPTION
Add VDMS multi DRM demo assets.  Provide test assets encrypted with AES CTR 16 Byte IVs and AES CTR 8 Byte IVs.  This merge request addresses issue #1140.