### PR TITLE
Add safe margin parameter to avoid rebuffering interruptions when clearing the buffer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>
 Google Inc. <*@google.com>
 Edgeware AB <*@edgeware.tv>
+Giuseppe Samela <giuseppe.samela@gmail.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -33,6 +33,7 @@ Donato Borrello <donato@jwplayer.com>
 Duc Pham <duc.pham@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>
 François Beaufort <fbeaufort@google.com>
+Giuseppe Samela <giuseppe.samela@gmail.com>
 Itay Kinnrot <itay.kinnrot@kaltura.com>
 Jacob Trimble <modmaker@google.com>
 Jason Palmer <jason@jason-palmer.com>

--- a/externs/shaka/abr_manager.js
+++ b/externs/shaka/abr_manager.js
@@ -45,10 +45,16 @@ shaka.extern.AbrManager = function() {};
  *
  * The first argument is a variant to switch to.
  *
- * The second argument is an optional boolean.  If true, all data will be
- * from the buffer, which will result in a buffering event.
+ * The second argument is an optional boolean. If true, all data will be removed
+ * from the buffer, which will result in a buffering event. Unless a third
+ * argument is passed.
  *
- * @typedef {function(shaka.extern.Variant, boolean=)}
+ * The third argument in an optional number that specifies how much data (in
+ * seconds) should be retained when clearing the buffer. This can help achieve
+ * a fast switch that doesn't involve a buffering event. A minimum of two video
+ * segments should always be kept buffered to avoid temporary hiccups.
+ *
+ * @typedef {function(shaka.extern.Variant, boolean=, number=)}
  * @exportDoc
  */
 shaka.extern.AbrManager.SwitchCallback;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -921,6 +921,7 @@ shaka.media.StreamingEngine.prototype.createMediaState_ = function(
     performingUpdate: false,
     updateTimer: null,
     waitingToClearBuffer: false,
+    deferredClearBufferOffset: 0,
     waitingToFlushBuffer: false,
     clearingBuffer: false,
     recovering: false,
@@ -1103,7 +1104,8 @@ shaka.media.StreamingEngine.prototype.onUpdate_ = function(mediaState) {
   if (mediaState.waitingToClearBuffer) {
     // Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'skipping update and clearing the buffer');
-    this.clearBuffer_(mediaState, mediaState.waitingToFlushBuffer,
+    this.clearBuffer_(
+        mediaState, mediaState.waitingToFlushBuffer,
         mediaState.deferredClearBufferOffset);
     return;
   }
@@ -2068,7 +2070,7 @@ shaka.media.StreamingEngine.prototype.handlePeriodTransition_ = function(
     for (let type in this.mediaStates_) {
       let stream = streamsByType[type];
       if (stream) {
-        this.switchInternal_(stream, /* clearBuffer */ false, /*safeMargin*/ 0);
+        this.switchInternal_(stream, /* clearBuffer */ false, 0);
         this.scheduleUpdate_(this.mediaStates_[type], 0);
       } else {
         goog.asserts.assert(type == ContentType.TEXT, 'Invalid streams chosen');
@@ -2179,10 +2181,10 @@ shaka.media.StreamingEngine.prototype.clearBuffer_ =
   mediaState.clearingBuffer = true;
 
   shaka.log.debug(logPrefix, 'clearing buffer');
-  var p;
+  let p;
   if (safeMargin) {
-    var playheadTime = this.playerInterface_.playhead.getTime();
-    var duration = this.playerInterface_.mediaSourceEngine.getDuration();
+    let playheadTime = this.playerInterface_.playhead.getTime();
+    let duration = this.playerInterface_.mediaSourceEngine.getDuration();
     p = this.playerInterface_.mediaSourceEngine.remove(mediaState.type,
         playheadTime + safeMargin, duration);
   } else {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1103,7 +1103,7 @@ shaka.media.StreamingEngine.prototype.onUpdate_ = function(mediaState) {
   if (mediaState.waitingToClearBuffer) {
     // Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'skipping update and clearing the buffer');
-    this.clearBuffer_(mediaState, mediaState.waitingToFlushBuffer, 
+    this.clearBuffer_(mediaState, mediaState.waitingToFlushBuffer,
         mediaState.deferredClearBufferOffset);
     return;
   }
@@ -2068,7 +2068,7 @@ shaka.media.StreamingEngine.prototype.handlePeriodTransition_ = function(
     for (let type in this.mediaStates_) {
       let stream = streamsByType[type];
       if (stream) {
-        this.switchInternal_(stream, /* clearBuffer */ false, /* safeMargin*/ 0);
+        this.switchInternal_(stream, /* clearBuffer */ false, /*safeMargin*/ 0);
         this.scheduleUpdate_(this.mediaStates_[type], 0);
       } else {
         goog.asserts.assert(type == ContentType.TEXT, 'Invalid streams chosen');
@@ -2183,7 +2183,7 @@ shaka.media.StreamingEngine.prototype.clearBuffer_ =
   if (safeMargin) {
     var playheadTime = this.playerInterface_.playhead.getTime();
     var duration = this.playerInterface_.mediaSourceEngine.getDuration();
-    p = this.playerInterface_.mediaSourceEngine.remove(mediaState.type, 
+    p = this.playerInterface_.mediaSourceEngine.remove(mediaState.type,
         playheadTime + safeMargin, duration);
   } else {
     p = this.playerInterface_.mediaSourceEngine.clear(mediaState.type);

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -237,6 +237,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   updateTimer: ?number,
  *   waitingToClearBuffer: boolean,
  *   waitingToFlushBuffer: boolean,
+ *   deferredClearBufferOffset: number,
  *   clearingBuffer: boolean,
  *   recovering: boolean,
  *   hasError: boolean,
@@ -275,6 +276,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   finishes.
  * @property {boolean} waitingToFlushBuffer
  *   True indicates that the buffer must be flushed after it is cleared.
+ * @property {number} deferredClearBufferOffset
+ *   The amount of buffer to retain when clearing the buffer after the update.
  * @property {boolean} clearingBuffer
  *   True indicates that the buffer is being cleared.
  * @property {boolean} recovering
@@ -593,7 +596,7 @@ shaka.media.StreamingEngine.prototype.setTrickPlay = function(on) {
     if (normalVideo) return;  // Already in trick play.
 
     shaka.log.debug('Engaging trick mode stream', trickModeVideo);
-    this.switchInternal_(trickModeVideo, false);
+    this.switchInternal_(trickModeVideo, false, false);
     mediaState.restoreStreamAfterTrickPlay = stream;
   } else {
     let normalVideo = mediaState.restoreStreamAfterTrickPlay;
@@ -601,7 +604,7 @@ shaka.media.StreamingEngine.prototype.setTrickPlay = function(on) {
 
     shaka.log.debug('Restoring non-trick-mode stream', normalVideo);
     mediaState.restoreStreamAfterTrickPlay = null;
-    this.switchInternal_(normalVideo, true);
+    this.switchInternal_(normalVideo, true, false);
   }
 };
 
@@ -609,15 +612,15 @@ shaka.media.StreamingEngine.prototype.setTrickPlay = function(on) {
 /**
  * @param {shaka.extern.Variant} variant
  * @param {boolean} clearBuffer
+ * @param {number} safeMargin
  */
 shaka.media.StreamingEngine.prototype.switchVariant =
-    function(variant, clearBuffer) {
+    function(variant, clearBuffer, safeMargin) {
   if (variant.video) {
-    this.switchInternal_(variant.video, clearBuffer);
+    this.switchInternal_(variant.video, clearBuffer, safeMargin);
   }
-
   if (variant.audio) {
-    this.switchInternal_(variant.audio, clearBuffer);
+    this.switchInternal_(variant.audio, clearBuffer, safeMargin);
   }
 };
 
@@ -628,7 +631,7 @@ shaka.media.StreamingEngine.prototype.switchVariant =
 shaka.media.StreamingEngine.prototype.switchTextStream = function(textStream) {
   goog.asserts.assert(textStream && textStream.type == 'text',
                       'Wrong stream type passed to switchTextStream!');
-  this.switchInternal_(textStream, /* clearBuffer */ true);
+  this.switchInternal_(textStream, /* clearBuffer */ true, false);
 };
 
 
@@ -637,10 +640,11 @@ shaka.media.StreamingEngine.prototype.switchTextStream = function(textStream) {
  *
  * @param {shaka.extern.Stream} stream
  * @param {boolean} clearBuffer
+ * @param {number} safeMargin
  * @private
  */
 shaka.media.StreamingEngine.prototype.switchInternal_ = function(
-    stream, clearBuffer) {
+    stream, clearBuffer, safeMargin) {
   const ContentType = shaka.util.ManifestParserUtils.ContentType;
   let mediaState = this.mediaStates_[/** @type {!ContentType} */(stream.type)];
 
@@ -723,13 +727,16 @@ shaka.media.StreamingEngine.prototype.switchInternal_ = function(
     } else if (mediaState.performingUpdate) {
       // We are performing an update, so we have to wait until it's finished.
       // onUpdate_() will call clearBuffer_() when the update has finished.
+      // We need to save the safe margin because its value will be needed when
+      // clearing the buffer after the update.
       mediaState.waitingToClearBuffer = true;
+      mediaState.deferredClearBufferOffset = safeMargin;
       mediaState.waitingToFlushBuffer = true;
     } else {
       // Cancel the update timer, if any.
       this.cancelUpdate_(mediaState);
       // Clear right away.
-      this.clearBuffer_(mediaState, /* flush */ true);
+      this.clearBuffer_(mediaState, /* flush */ true, safeMargin);
     }
   }
 };
@@ -796,6 +803,9 @@ shaka.media.StreamingEngine.prototype.clearAllBuffers_ = function() {
       // onUpdate_() will call clearBuffer_() when the update has finished.
       shaka.log.debug(logPrefix, 'clear: currently updating');
       mediaState.waitingToClearBuffer = true;
+      // We can set the offset to zero to remember that this was a call to
+      // clearAllBuffers.
+      mediaState.deferredClearBufferOffset = 0;
       continue;
     }
 
@@ -814,7 +824,7 @@ shaka.media.StreamingEngine.prototype.clearAllBuffers_ = function() {
     // buffer right away. Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'clear: handling right now');
     this.cancelUpdate_(mediaState);
-    this.clearBuffer_(mediaState, /* flush */ false);
+    this.clearBuffer_(mediaState, /* flush */ false, 0);
   }
 };
 
@@ -1093,7 +1103,8 @@ shaka.media.StreamingEngine.prototype.onUpdate_ = function(mediaState) {
   if (mediaState.waitingToClearBuffer) {
     // Note: clearBuffer_() will schedule the next update.
     shaka.log.debug(logPrefix, 'skipping update and clearing the buffer');
-    this.clearBuffer_(mediaState, mediaState.waitingToFlushBuffer);
+    this.clearBuffer_(mediaState, mediaState.waitingToFlushBuffer, 
+        mediaState.deferredClearBufferOffset);
     return;
   }
 
@@ -2057,7 +2068,7 @@ shaka.media.StreamingEngine.prototype.handlePeriodTransition_ = function(
     for (let type in this.mediaStates_) {
       let stream = streamsByType[type];
       if (stream) {
-        this.switchInternal_(stream, /* clearBuffer */ false);
+        this.switchInternal_(stream, /* clearBuffer */ false, false);
         this.scheduleUpdate_(this.mediaStates_[type], 0);
       } else {
         goog.asserts.assert(type == ContentType.TEXT, 'Invalid streams chosen');
@@ -2145,13 +2156,17 @@ shaka.media.StreamingEngine.prototype.fetch_ = function(reference) {
 
 /**
  * Clears the buffer and schedules another update.
+ * The optional parameter safeMargin allows to retain a certain amount
+ * of buffer, which can help avoiding rebuffering events.
+ * The value of the safe margin should be provided by the ABR manager.
  *
  * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
  * @param {boolean} flush
+ * @param {number} safeMargin
  * @private
  */
 shaka.media.StreamingEngine.prototype.clearBuffer_ =
-    function(mediaState, flush) {
+    function(mediaState, flush, safeMargin) {
   let logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
 
   goog.asserts.assert(
@@ -2160,12 +2175,21 @@ shaka.media.StreamingEngine.prototype.clearBuffer_ =
 
   mediaState.waitingToClearBuffer = false;
   mediaState.waitingToFlushBuffer = false;
+  mediaState.deferredClearBufferOffset = 0;
   mediaState.clearingBuffer = true;
 
   shaka.log.debug(logPrefix, 'clearing buffer');
-  let p = this.playerInterface_.mediaSourceEngine.clear(mediaState.type);
+  var p;
+  if (safeMargin) {
+    var playheadTime = this.playerInterface_.playhead.getTime();
+    var duration = this.playerInterface_.mediaSourceEngine.getDuration();
+    p = this.playerInterface_.mediaSourceEngine.remove(mediaState.type, 
+        playheadTime + safeMargin, duration);
+  } else {
+    p = this.playerInterface_.mediaSourceEngine.clear(mediaState.type);
+  }
   p.then(function() {
-    if (!this.destroyed_ && flush) {
+    if (!this.destroyed_ && flush && safeMargin == 0) {
       return this.playerInterface_.mediaSourceEngine.flush(mediaState.type);
     }
   }.bind(this)).then(function() {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -237,7 +237,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   updateTimer: ?number,
  *   waitingToClearBuffer: boolean,
  *   waitingToFlushBuffer: boolean,
- *   deferredClearBufferOffset: number,
+ *   clearBufferSafeMargin: number,
  *   clearingBuffer: boolean,
  *   recovering: boolean,
  *   hasError: boolean,
@@ -276,7 +276,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   finishes.
  * @property {boolean} waitingToFlushBuffer
  *   True indicates that the buffer must be flushed after it is cleared.
- * @property {number} deferredClearBufferOffset
+ * @property {number} clearBufferSafeMargin
  *   The amount of buffer to retain when clearing the buffer after the update.
  * @property {boolean} clearingBuffer
  *   True indicates that the buffer is being cleared.
@@ -730,7 +730,7 @@ shaka.media.StreamingEngine.prototype.switchInternal_ = function(
       // We need to save the safe margin because its value will be needed when
       // clearing the buffer after the update.
       mediaState.waitingToClearBuffer = true;
-      mediaState.deferredClearBufferOffset = safeMargin;
+      mediaState.clearBufferSafeMargin = safeMargin;
       mediaState.waitingToFlushBuffer = true;
     } else {
       // Cancel the update timer, if any.
@@ -805,7 +805,7 @@ shaka.media.StreamingEngine.prototype.clearAllBuffers_ = function() {
       mediaState.waitingToClearBuffer = true;
       // We can set the offset to zero to remember that this was a call to
       // clearAllBuffers.
-      mediaState.deferredClearBufferOffset = 0;
+      mediaState.clearBufferSafeMargin = 0;
       continue;
     }
 
@@ -921,7 +921,7 @@ shaka.media.StreamingEngine.prototype.createMediaState_ = function(
     performingUpdate: false,
     updateTimer: null,
     waitingToClearBuffer: false,
-    deferredClearBufferOffset: 0,
+    clearBufferSafeMargin: 0,
     waitingToFlushBuffer: false,
     clearingBuffer: false,
     recovering: false,
@@ -1106,7 +1106,7 @@ shaka.media.StreamingEngine.prototype.onUpdate_ = function(mediaState) {
     shaka.log.debug(logPrefix, 'skipping update and clearing the buffer');
     this.clearBuffer_(
         mediaState, mediaState.waitingToFlushBuffer,
-        mediaState.deferredClearBufferOffset);
+        mediaState.clearBufferSafeMargin);
     return;
   }
 
@@ -2177,7 +2177,7 @@ shaka.media.StreamingEngine.prototype.clearBuffer_ =
 
   mediaState.waitingToClearBuffer = false;
   mediaState.waitingToFlushBuffer = false;
-  mediaState.deferredClearBufferOffset = 0;
+  mediaState.clearBufferSafeMargin = 0;
   mediaState.clearingBuffer = true;
 
   shaka.log.debug(logPrefix, 'clearing buffer');
@@ -2185,16 +2185,18 @@ shaka.media.StreamingEngine.prototype.clearBuffer_ =
   if (safeMargin) {
     let playheadTime = this.playerInterface_.playhead.getTime();
     let duration = this.playerInterface_.mediaSourceEngine.getDuration();
-    p = this.playerInterface_.mediaSourceEngine.remove(mediaState.type,
-        playheadTime + safeMargin, duration);
+    p = this.playerInterface_.mediaSourceEngine.remove(
+        mediaState.type, playheadTime + safeMargin, duration);
   } else {
-    p = this.playerInterface_.mediaSourceEngine.clear(mediaState.type);
+    p = this.playerInterface_.mediaSourceEngine.clear(mediaState.type).then(
+        function() {
+          if (!this.destroyed_ && flush) {
+            return this.playerInterface_.mediaSourceEngine.flush(
+                mediaState.type);
+          }
+        }.bind(this));
   }
   p.then(function() {
-    if (!this.destroyed_ && flush && safeMargin == 0) {
-      return this.playerInterface_.mediaSourceEngine.flush(mediaState.type);
-    }
-  }.bind(this)).then(function() {
     if (this.destroyed_) return;
     shaka.log.debug(logPrefix, 'cleared buffer');
     mediaState.lastStream = null;

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -596,7 +596,7 @@ shaka.media.StreamingEngine.prototype.setTrickPlay = function(on) {
     if (normalVideo) return;  // Already in trick play.
 
     shaka.log.debug('Engaging trick mode stream', trickModeVideo);
-    this.switchInternal_(trickModeVideo, false, false);
+    this.switchInternal_(trickModeVideo, false, 0);
     mediaState.restoreStreamAfterTrickPlay = stream;
   } else {
     let normalVideo = mediaState.restoreStreamAfterTrickPlay;
@@ -604,7 +604,7 @@ shaka.media.StreamingEngine.prototype.setTrickPlay = function(on) {
 
     shaka.log.debug('Restoring non-trick-mode stream', normalVideo);
     mediaState.restoreStreamAfterTrickPlay = null;
-    this.switchInternal_(normalVideo, true, false);
+    this.switchInternal_(normalVideo, true, 0);
   }
 };
 
@@ -631,7 +631,7 @@ shaka.media.StreamingEngine.prototype.switchVariant =
 shaka.media.StreamingEngine.prototype.switchTextStream = function(textStream) {
   goog.asserts.assert(textStream && textStream.type == 'text',
                       'Wrong stream type passed to switchTextStream!');
-  this.switchInternal_(textStream, /* clearBuffer */ true, false);
+  this.switchInternal_(textStream, /* clearBuffer */ true, /* safeMargin */ 0);
 };
 
 
@@ -2068,7 +2068,7 @@ shaka.media.StreamingEngine.prototype.handlePeriodTransition_ = function(
     for (let type in this.mediaStates_) {
       let stream = streamsByType[type];
       if (stream) {
-        this.switchInternal_(stream, /* clearBuffer */ false, false);
+        this.switchInternal_(stream, /* clearBuffer */ false, /* safeMargin*/ 0);
         this.scheduleUpdate_(this.mediaStates_[type], 0);
       } else {
         goog.asserts.assert(type == ContentType.TEXT, 'Invalid streams chosen');

--- a/lib/player.js
+++ b/lib/player.js
@@ -136,7 +136,7 @@ shaka.Player = function(video, dependencyInjector) {
   /** @private {number} */
   this.deferredVariantClearBufferOffset_ = 0;
 
-  /** @private {?shakaExtern.Stream} */
+  /** @private {?shaka.extern.Stream} */
   this.deferredTextStream_ = null;
 
   /**
@@ -1642,12 +1642,12 @@ shaka.Player.prototype.usingEmbeddedTextTrack = function() {
  * track selections.
  *
  * @param {shaka.extern.Track} track
- * @param {boolean=} opt_clearBuffer
- * @param {number=} opt_safeMargin
+ * @param {boolean=} clearBuffer
+ * @param {?number=} safeMargin
  * @export
  */
-shaka.Player.prototype.selectVariantTrack = function(track, opt_clearBuffer, 
-    opt_safeMargin) {
+shaka.Player.prototype.selectVariantTrack = function(
+    track, clearBuffer, safeMargin = 0) {
   if (!this.streamingEngine_) {
     return;
   }
@@ -1682,7 +1682,7 @@ shaka.Player.prototype.selectVariantTrack = function(track, opt_clearBuffer,
 
   // Add entries to the history.
   this.addVariantToSwitchHistory_(variant, /* fromAdaptation */ false);
-  this.switchVariant_(variant, opt_clearBuffer, opt_safeMargin);
+  this.switchVariant_(variant, clearBuffer, safeMargin || 0);
 
   // Workaround for https://github.com/google/shaka-player/issues/1299
   // When track is selected, back-propogate the language to
@@ -2499,21 +2499,21 @@ shaka.Player.prototype.filterNewPeriod_ = function(period) {
 /**
  * Switches to the given variant, deferring if needed.
  * @param {shaka.extern.Variant} variant
- * @param {boolean=} opt_clearBuffer
- * @param {number=} opt_safeMargin
+ * @param {boolean=} clearBuffer
+ * @param {?number=} safeMargin
  * @private
  */
 shaka.Player.prototype.switchVariant_ =
-    function(variant, opt_clearBuffer, opt_safeMargin) {
+    function(variant, clearBuffer, safeMargin = 0) {
   if (this.switchingPeriods_) {
     // Store this action for later.
     this.deferredVariant_ = variant;
-    this.deferredVariantClearBuffer_ = opt_clearBuffer || false;
-    this.deferredVariantClearBufferOffset_ = opt_safeMargin || 0;
+    this.deferredVariantClearBuffer_ = clearBuffer || false;
+    this.deferredVariantClearBufferOffset_ = safeMargin || 0;
   } else {
     // Act now.
-    this.streamingEngine_.switchVariant(variant, opt_clearBuffer || false,
-        opt_safeMargin || 0);
+    this.streamingEngine_.switchVariant(
+        variant, clearBuffer || false, safeMargin || 0);
   }
 };
 
@@ -2969,12 +2969,12 @@ shaka.Player.prototype.onSegmentAppended_ = function() {
  * Callback from AbrManager.
  *
  * @param {shaka.extern.Variant} variant
- * @param {boolean=} opt_clearBuffer
- * @param {number=} opt_safeMargin
+ * @param {boolean=} clearBuffer
+ * @param {?number=} safeMargin
  * @private
  */
-shaka.Player.prototype.switch_ = function(variant, opt_clearBuffer, 
-    opt_safeMargin) {
+shaka.Player.prototype.switch_ = function(
+    variant, clearBuffer, safeMargin = 0) {
   shaka.log.debug('switch_');
   goog.asserts.assert(this.config_.abr.enabled,
       'AbrManager should not call switch while disabled!');
@@ -2988,9 +2988,8 @@ shaka.Player.prototype.switch_ = function(variant, opt_clearBuffer,
     return;
   }
 
-  var clearBuffer = opt_clearBuffer || false;
-  var safeMargin = opt_safeMargin || 0;
-  this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin);
+  this.streamingEngine_.switchVariant(
+      variant, clearBuffer || false, safeMargin || 0);
   this.onAdaptation_();
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2988,8 +2988,7 @@ shaka.Player.prototype.switch_ = function(
     return;
   }
 
-  this.streamingEngine_.switchVariant(
-      variant, clearBuffer, safeMargin);
+  this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin);
   this.onAdaptation_();
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2509,11 +2509,11 @@ shaka.Player.prototype.switchVariant_ =
     // Store this action for later.
     this.deferredVariant_ = variant;
     this.deferredVariantClearBuffer_ = opt_clearBuffer || false;
-    this.deferredVariantClearBufferOffset_ = opt_safeMargin || false;
+    this.deferredVariantClearBufferOffset_ = opt_safeMargin || 0;
   } else {
     // Act now.
     this.streamingEngine_.switchVariant(variant, opt_clearBuffer || false,
-        opt_safeMargin || false);
+        opt_safeMargin || 0);
   }
 };
 
@@ -2930,7 +2930,7 @@ shaka.Player.prototype.canSwitch_ = function() {
   // If we still have deferred switches, switch now.
   if (this.deferredVariant_) {
     this.streamingEngine_.switchVariant(
-        this.deferredVariant_, this.deferredVariantClearBuffer_, 
+        this.deferredVariant_, this.deferredVariantClearBuffer_,
         this.deferredVariantClearBufferOffset_);
     this.deferredVariant_ = null;
   }
@@ -2989,7 +2989,7 @@ shaka.Player.prototype.switch_ = function(variant, opt_clearBuffer,
   }
 
   var clearBuffer = opt_clearBuffer || false;
-  var safeMargin = opt_safeMargin || false;
+  var safeMargin = opt_safeMargin || 0;
   this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin);
   this.onAdaptation_();
 };

--- a/lib/player.js
+++ b/lib/player.js
@@ -1643,7 +1643,7 @@ shaka.Player.prototype.usingEmbeddedTextTrack = function() {
  *
  * @param {shaka.extern.Track} track
  * @param {boolean=} clearBuffer
- * @param {?number=} safeMargin
+ * @param {number=} safeMargin
  * @export
  */
 shaka.Player.prototype.selectVariantTrack = function(
@@ -1682,7 +1682,7 @@ shaka.Player.prototype.selectVariantTrack = function(
 
   // Add entries to the history.
   this.addVariantToSwitchHistory_(variant, /* fromAdaptation */ false);
-  this.switchVariant_(variant, clearBuffer, safeMargin || 0);
+  this.switchVariant_(variant, clearBuffer, safeMargin);
 
   // Workaround for https://github.com/google/shaka-player/issues/1299
   // When track is selected, back-propogate the language to
@@ -2500,20 +2500,20 @@ shaka.Player.prototype.filterNewPeriod_ = function(period) {
  * Switches to the given variant, deferring if needed.
  * @param {shaka.extern.Variant} variant
  * @param {boolean=} clearBuffer
- * @param {?number=} safeMargin
+ * @param {number=} safeMargin
  * @private
  */
 shaka.Player.prototype.switchVariant_ =
-    function(variant, clearBuffer, safeMargin = 0) {
+    function(variant, clearBuffer = false, safeMargin = 0) {
   if (this.switchingPeriods_) {
     // Store this action for later.
     this.deferredVariant_ = variant;
-    this.deferredVariantClearBuffer_ = clearBuffer || false;
-    this.deferredVariantClearBufferOffset_ = safeMargin || 0;
+    this.deferredVariantClearBuffer_ = clearBuffer;
+    this.deferredVariantClearBufferOffset_ = safeMargin;
   } else {
     // Act now.
     this.streamingEngine_.switchVariant(
-        variant, clearBuffer || false, safeMargin || 0);
+        variant, clearBuffer, safeMargin);
   }
 };
 
@@ -2970,11 +2970,11 @@ shaka.Player.prototype.onSegmentAppended_ = function() {
  *
  * @param {shaka.extern.Variant} variant
  * @param {boolean=} clearBuffer
- * @param {?number=} safeMargin
+ * @param {number=} safeMargin
  * @private
  */
 shaka.Player.prototype.switch_ = function(
-    variant, clearBuffer, safeMargin = 0) {
+    variant, clearBuffer = false, safeMargin = 0) {
   shaka.log.debug('switch_');
   goog.asserts.assert(this.config_.abr.enabled,
       'AbrManager should not call switch while disabled!');
@@ -2989,7 +2989,7 @@ shaka.Player.prototype.switch_ = function(
   }
 
   this.streamingEngine_.switchVariant(
-      variant, clearBuffer || false, safeMargin || 0);
+      variant, clearBuffer, safeMargin);
   this.onAdaptation_();
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -133,7 +133,10 @@ shaka.Player = function(video, dependencyInjector) {
   /** @private {boolean} */
   this.deferredVariantClearBuffer_ = false;
 
-  /** @private {?shaka.extern.Stream} */
+  /** @private {number} */
+  this.deferredVariantClearBufferOffset_ = 0;
+
+  /** @private {?shakaExtern.Stream} */
   this.deferredTextStream_ = null;
 
   /**
@@ -1639,10 +1642,12 @@ shaka.Player.prototype.usingEmbeddedTextTrack = function() {
  * track selections.
  *
  * @param {shaka.extern.Track} track
- * @param {boolean=} clearBuffer
+ * @param {boolean=} opt_clearBuffer
+ * @param {number=} opt_safeMargin
  * @export
  */
-shaka.Player.prototype.selectVariantTrack = function(track, clearBuffer) {
+shaka.Player.prototype.selectVariantTrack = function(track, opt_clearBuffer, 
+    opt_safeMargin) {
   if (!this.streamingEngine_) {
     return;
   }
@@ -1677,7 +1682,7 @@ shaka.Player.prototype.selectVariantTrack = function(track, clearBuffer) {
 
   // Add entries to the history.
   this.addVariantToSwitchHistory_(variant, /* fromAdaptation */ false);
-  this.switchVariant_(variant, clearBuffer);
+  this.switchVariant_(variant, opt_clearBuffer, opt_safeMargin);
 
   // Workaround for https://github.com/google/shaka-player/issues/1299
   // When track is selected, back-propogate the language to
@@ -2494,18 +2499,21 @@ shaka.Player.prototype.filterNewPeriod_ = function(period) {
 /**
  * Switches to the given variant, deferring if needed.
  * @param {shaka.extern.Variant} variant
- * @param {boolean=} clearBuffer
+ * @param {boolean=} opt_clearBuffer
+ * @param {number=} opt_safeMargin
  * @private
  */
 shaka.Player.prototype.switchVariant_ =
-    function(variant, clearBuffer = false) {
+    function(variant, opt_clearBuffer, opt_safeMargin) {
   if (this.switchingPeriods_) {
     // Store this action for later.
     this.deferredVariant_ = variant;
-    this.deferredVariantClearBuffer_ = clearBuffer;
+    this.deferredVariantClearBuffer_ = opt_clearBuffer || false;
+    this.deferredVariantClearBufferOffset_ = opt_safeMargin || false;
   } else {
     // Act now.
-    this.streamingEngine_.switchVariant(variant, clearBuffer);
+    this.streamingEngine_.switchVariant(variant, opt_clearBuffer || false,
+        opt_safeMargin || false);
   }
 };
 
@@ -2922,7 +2930,8 @@ shaka.Player.prototype.canSwitch_ = function() {
   // If we still have deferred switches, switch now.
   if (this.deferredVariant_) {
     this.streamingEngine_.switchVariant(
-        this.deferredVariant_, this.deferredVariantClearBuffer_);
+        this.deferredVariant_, this.deferredVariantClearBuffer_, 
+        this.deferredVariantClearBufferOffset_);
     this.deferredVariant_ = null;
   }
   if (this.deferredTextStream_) {
@@ -2960,10 +2969,12 @@ shaka.Player.prototype.onSegmentAppended_ = function() {
  * Callback from AbrManager.
  *
  * @param {shaka.extern.Variant} variant
- * @param {boolean=} clearBuffer
+ * @param {boolean=} opt_clearBuffer
+ * @param {number=} opt_safeMargin
  * @private
  */
-shaka.Player.prototype.switch_ = function(variant, clearBuffer = false) {
+shaka.Player.prototype.switch_ = function(variant, opt_clearBuffer, 
+    opt_safeMargin) {
   shaka.log.debug('switch_');
   goog.asserts.assert(this.config_.abr.enabled,
       'AbrManager should not call switch while disabled!');
@@ -2977,7 +2988,9 @@ shaka.Player.prototype.switch_ = function(variant, clearBuffer = false) {
     return;
   }
 
-  this.streamingEngine_.switchVariant(variant, clearBuffer);
+  var clearBuffer = opt_clearBuffer || false;
+  var safeMargin = opt_safeMargin || false;
+  this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin);
   this.onAdaptation_();
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -134,7 +134,7 @@ shaka.Player = function(video, dependencyInjector) {
   this.deferredVariantClearBuffer_ = false;
 
   /** @private {number} */
-  this.deferredVariantClearBufferOffset_ = 0;
+  this.deferredVariantClearBufferSafeMargin_ = 0;
 
   /** @private {?shaka.extern.Stream} */
   this.deferredTextStream_ = null;
@@ -1643,7 +1643,12 @@ shaka.Player.prototype.usingEmbeddedTextTrack = function() {
  *
  * @param {shaka.extern.Track} track
  * @param {boolean=} clearBuffer
- * @param {number=} safeMargin
+ * @param {number=} safeMargin Optional amount of buffer (in seconds) to retain
+ *   when clearing the buffer. Useful for switching variant quickly without
+ *   causing a buffering event.
+ *   Defaults to 0 if not provided. Ignored if clearBuffer is false.
+ *   Can cause hiccups on some browsers if chosen too small, e.g. The amount of
+ *   two segments is a fair minimum to consider as safeMargin value.
  * @export
  */
 shaka.Player.prototype.selectVariantTrack = function(
@@ -2509,11 +2514,10 @@ shaka.Player.prototype.switchVariant_ =
     // Store this action for later.
     this.deferredVariant_ = variant;
     this.deferredVariantClearBuffer_ = clearBuffer;
-    this.deferredVariantClearBufferOffset_ = safeMargin;
+    this.deferredVariantClearBufferSafeMargin_ = safeMargin;
   } else {
     // Act now.
-    this.streamingEngine_.switchVariant(
-        variant, clearBuffer, safeMargin);
+    this.streamingEngine_.switchVariant(variant, clearBuffer, safeMargin);
   }
 };
 
@@ -2931,7 +2935,7 @@ shaka.Player.prototype.canSwitch_ = function() {
   if (this.deferredVariant_) {
     this.streamingEngine_.switchVariant(
         this.deferredVariant_, this.deferredVariantClearBuffer_,
-        this.deferredVariantClearBufferOffset_);
+        this.deferredVariantClearBufferSafeMargin_);
     this.deferredVariant_ = null;
   }
   if (this.deferredTextStream_) {
@@ -2970,7 +2974,9 @@ shaka.Player.prototype.onSegmentAppended_ = function() {
  *
  * @param {shaka.extern.Variant} variant
  * @param {boolean=} clearBuffer
- * @param {number=} safeMargin
+ * @param {number=} safeMargin Optional amount of buffer (in seconds) to retain
+ *   when clearing the buffer.
+ *   Defaults to 0 if not provided. Ignored if clearBuffer is false.
  * @private
  */
 shaka.Player.prototype.switch_ = function(

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -1167,14 +1167,16 @@ describe('StreamingEngine', function() {
     it('will not clear buffers if streams have not changed', function() {
       onCanSwitch.and.callFake(function() {
         mediaSourceEngine.clear.calls.reset();
-        streamingEngine.switchVariant(sameAudioVariant, /* clearBuffer */ true);
+        streamingEngine.switchVariant(sameAudioVariant, /* clearBuffer */ true,
+            /* safeMargin */ 0);
         Util.fakeEventLoop(1);
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('audio');
         expect(mediaSourceEngine.clear).toHaveBeenCalledWith('video');
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('text');
 
         mediaSourceEngine.clear.calls.reset();
-        streamingEngine.switchVariant(sameVideoVariant, /* clearBuffer */ true);
+        streamingEngine.switchVariant(sameVideoVariant, /* clearBuffer */ true,
+            /* safeMargin */ 0);
         Util.fakeEventLoop(1);
         expect(mediaSourceEngine.clear).toHaveBeenCalledWith('audio');
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('video');

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -1167,16 +1167,16 @@ describe('StreamingEngine', function() {
     it('will not clear buffers if streams have not changed', function() {
       onCanSwitch.and.callFake(function() {
         mediaSourceEngine.clear.calls.reset();
-        streamingEngine.switchVariant(sameAudioVariant, /* clearBuffer */ true,
-            /* safeMargin */ 0);
+        streamingEngine.switchVariant(
+            sameAudioVariant, /* clearBuffer */ true, /* safeMargin */ 0);
         Util.fakeEventLoop(1);
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('audio');
         expect(mediaSourceEngine.clear).toHaveBeenCalledWith('video');
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('text');
 
         mediaSourceEngine.clear.calls.reset();
-        streamingEngine.switchVariant(sameVideoVariant, /* clearBuffer */ true,
-            /* safeMargin */ 0);
+        streamingEngine.switchVariant(
+            sameVideoVariant, /* clearBuffer */ true, /* safeMargin */ 0);
         Util.fakeEventLoop(1);
         expect(mediaSourceEngine.clear).toHaveBeenCalledWith('audio');
         expect(mediaSourceEngine.clear).not.toHaveBeenCalledWith('video');


### PR DESCRIPTION
The goal of this PR is to introduce an optional parameter that allows the buffer to be cleared but not entirely.

The idea is to keep a safe margin that avoids rebuffering events but allows for fast switches. The value of this parameter should be computed and provided by a custom ABR manager. Nothing changes if the value is not provided of course (e.g. SimpleAbrManager).

Since the buffer could be busy, another parameter had to be introduced to save the value of the safe margin when the call to clear the buffer is deferred to a later update.

Something similar was present in Shaka v1, but it was removed with the redesign.