### PR TITLE
Don't wait for sessions to close on DrmEngine#destroy

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -170,15 +170,20 @@ shaka.media.DrmEngine.prototype.destroy = function() {
   var Functional = shaka.util.Functional;
   this.destroyed_ = true;
 
-  var async = this.activeSessions_.map(function(activeSession) {
+  // TODO: wait for sessions to close when destroying. Due to a bug in Chrome,
+  // sometimes the Promise returned by MediaKeySession#close never resolves.
+  // See #1093 and https://crbug.com/690583
+  this.activeSessions_.forEach(function(activeSession) {
     // Ignore any errors when closing the sessions.  One such error would be
     // an invalid state error triggered by closing a session which has not
     // generated any key requests.
     // Chrome sometimes returns |undefined|: https://crbug.com/690664
     var p = activeSession.session.close() || Promise.resolve();
-    return p.catch(Functional.noop);
+    p = p.catch(Functional.noop);
   });
   this.allSessionsLoaded_.reject();
+
+  var async = [];
 
   if (this.eventManager_)
     async.push(this.eventManager_.destroy());


### PR DESCRIPTION
This is a workaround for Chrome bug https://crbug.com/690583.

Resolves #1093