### PR TITLE
Change so that default presentation delay for DASH is configurable #1234

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@
 # Please keep the list sorted.
 
 AdsWizz <*@adswizz.com>
+Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>
 Google Inc. <*@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -24,6 +24,7 @@
 
 Aaron Vaage <vaage@google.com>
 Andy Hochhaus <ahochhaus@samegoal.com>
+Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Chad Assareh <assareh@google.com>
 Chris Fillmore <fillmore.chris@gmail.com>

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -488,7 +488,8 @@ shakaExtern.DrmConfiguration;
  *   customScheme: shakaExtern.DashContentProtectionCallback,
  *   clockSyncUri: string,
  *   ignoreDrmInfo: boolean,
- *   xlinkFailGracefully: boolean
+ *   xlinkFailGracefully: boolean,
+ *   defaultPresentationDelay: number
  * }}
  *
  * @property {shakaExtern.DashContentProtectionCallback} customScheme
@@ -508,6 +509,9 @@ shakaExtern.DrmConfiguration;
  *   existing contents. If false, xlink-related errors will be propagated
  *   to the application and will result in a playback failure. Defaults to
  *   false if not provided.
+ * @property {number} defaultPresentationDelay
+ *   A default presentationDelay if suggestedPresentationDelay is missing
+ *   in the MPEG DASH manifest, has to be bigger than minBufferTime * 1.5.
  *
  * @exportDoc
  */

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -96,15 +96,6 @@ shaka.dash.DashParser.MIN_UPDATE_PERIOD_ = 3;
 
 
 /**
- * The default MPD@suggestedPresentationDelay in seconds.
- *
- * @private
- * @const {number}
- */
-shaka.dash.DashParser.DEFAULT_SUGGESTED_PRESENTATION_DELAY_ = 10;
-
-
-/**
  * @typedef {
  *   !function(!Array.<string>, ?number, ?number):!Promise.<!ArrayBuffer>
  * }
@@ -491,12 +482,12 @@ shaka.dash.DashParser.prototype.processManifest_ =
     // available, and anything less than minBufferTime will cause buffering
     // issues.
     //
-    // We have decided that our default will be 1.5 * minBufferTime, or 10s,
-    // whichever is larger.  This is fairly conservative.  Content providers
-    // should provide a suggestedPresentationDelay whenever possible to optimize
-    // the live streaming experience.
+    // We have decided that our default will be 1.5 * minBufferTime,
+    // or 10s (configurable) whichever is larger.  This is fairly conservative.
+    // Content providers should provide a suggestedPresentationDelay
+    // whenever possible to optimize the live streaming experience.
     var defaultPresentationDelay = Math.max(
-        shaka.dash.DashParser.DEFAULT_SUGGESTED_PRESENTATION_DELAY_,
+        this.config_.dash.defaultPresentationDelay,
         minBufferTime * 1.5);
     var presentationDelay = suggestedPresentationDelay != null ?
         suggestedPresentationDelay : defaultPresentationDelay;

--- a/lib/player.js
+++ b/lib/player.js
@@ -1973,7 +1973,8 @@ shaka.Player.prototype.defaultConfig_ = function() {
         },
         clockSyncUri: '',
         ignoreDrmInfo: false,
-        xlinkFailGracefully: false
+        xlinkFailGracefully: false,
+        defaultPresentationDelay: 10
       }
     },
     streaming: {

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -44,7 +44,8 @@ describe('DashParser ContentProtection', function() {
         clockSyncUri: '',
         customScheme: callback,
         ignoreDrmInfo: ignoreDrmInfo,
-        xlinkFailGracefully: false
+        xlinkFailGracefully: false,
+        defaultPresentationDelay: 10
       }
     });
     var playerEvents = {

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -54,7 +54,8 @@ describe('DashParser Live', function() {
         clockSyncUri: '',
         customScheme: function(node) { return null; },
         ignoreDrmInfo: false,
-        xlinkFailGracefully: false
+        xlinkFailGracefully: false,
+        defaultPresentationDelay: 10
       }
     });
     playerInterface = {

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -69,7 +69,8 @@ describe('HlsParser live', function() {
         customScheme: function(node) { return null; },
         clockSyncUri: '',
         ignoreDrmInfo: false,
-        xlinkFailGracefully: false
+        xlinkFailGracefully: false,
+        defaultPresentationDelay: 10
       }
     };
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -67,7 +67,8 @@ describe('HlsParser', function() {
         customScheme: function(node) { return null; },
         clockSyncUri: '',
         ignoreDrmInfo: false,
-        xlinkFailGracefully: false
+        xlinkFailGracefully: false,
+        defaultPresentationDelay: 10
       }
     };
 

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -31,7 +31,8 @@ shaka.test.Dash.makeDashParser = function() {
       customScheme: function(node) { return null; },
       clockSyncUri: '',
       ignoreDrmInfo: false,
-      xlinkFailGracefully: false
+      xlinkFailGracefully: false,
+      defaultPresentationDelay: 10
     }
   });
   return parser;


### PR DESCRIPTION
The DEFAULT_SUGGESTED_PRESENTATION_DELAY_ in DashParser is useful to have configurable
when the stream provider isn't able to add `suggestedPresentationDelay` in the manifest.

Fixes #1234