### PR TITLE
Rename Timeline related events to include the "Event" suffix used throughout the rest of the project

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@
 # Please keep the list sorted.
 
 AdsWizz <*@adswizz.com>
+Alugha GmbH <*@alugha.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -51,6 +51,7 @@ Mattias Wadman <mattias.wadman@gmail.com>
 Michelle Zhuo <michellezhuo@google.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>
+Niklas Korz <nk@alugha.com>
 Oskar Arvidsson <oskar@irock.se>
 Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>

--- a/lib/player.js
+++ b/lib/player.js
@@ -289,7 +289,7 @@ shaka.Player.version = 'v2.3.0-uncompiled';
 
 
 /**
- * @event shaka.Player.TimelineRegionAdded
+ * @event shaka.Player.TimelineRegionAddedEvent
  * @description Fired when a media timeline region is added.
  * @property {string} type
  *   'timelineregionadded'
@@ -300,7 +300,7 @@ shaka.Player.version = 'v2.3.0-uncompiled';
 
 
 /**
- * @event shaka.Player.TimelineRegionEnter
+ * @event shaka.Player.TimelineRegionEnterEvent
  * @description Fired when the playhead enters a timeline region.
  * @property {string} type
  *   'timelineregionenter'
@@ -311,7 +311,7 @@ shaka.Player.version = 'v2.3.0-uncompiled';
 
 
 /**
- * @event shaka.Player.TimelineRegionExit
+ * @event shaka.Player.TimelineRegionExitEvent
  * @description Fired when the playhead exits a timeline region.
  * @property {string} type
  *   'timelineregionexit'


### PR DESCRIPTION
A very small change, I acknowledge, but while writing type definitions for using shaka-player with our TypeScript codebase, I came accross this one.
TimelineRegionAdded, TimelineRegionEnter and TimelineRegionExit are the only events to miss the "Event" suffix.

As this is indeed a very small change I do not think this justifies opening an issue next to this pull request.