### PR TITLE
Add a missing word in ManifestParser comments

### DIFF
--- a/externs/shaka/manifest_parser.js
+++ b/externs/shaka/manifest_parser.js
@@ -48,8 +48,8 @@ shakaExtern.ManifestParser = function() {};
  * @description
  * Defines the interface of the Player to the manifest parser.  This defines
  * fields and callback methods that the parser will use to interact with the
- * Player.  The callback methods do not to be called as member functions (i.e.
- * they can be called as "free" functions).
+ * Player.  The callback methods do not need to be called as member functions
+ * (i.e. they can be called as "free" functions).
  *
  * @property {!shaka.net.NetworkingEngine} networkingEngine
  *   The networking engine to use for network requests.

--- a/lib/util/mp4_parser.js
+++ b/lib/util/mp4_parser.js
@@ -99,7 +99,7 @@ shaka.util.Mp4Parser.BoxType_ = {
 
 
 /**
- * Delcare a box type as a Box.
+ * Declare a box type as a Box.
  *
  * @param {string} type
  * @param {!shaka.util.Mp4Parser.CallbackType} definition


### PR DESCRIPTION
The comment for the definition of `shakaExtern.ManifestParser.PlayerInterface` misses a word, adding it here.

Also fixes a typo in another comment.