### PR TITLE
Move Fetch API support detection into public method.

### DIFF
--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -116,6 +116,18 @@ shaka.net.HttpFetchPlugin = function(uri, request) {
 
 
 /**
+ * Determine if Fetch API is supported in the browser. Note: this is
+ * deliberately exposed as a method to allow the client app to use the same
+ * logic as Shaka when determining support.
+ * @return {boolean}
+ * @export
+ */
+shaka.net.HttpFetchPlugin.isSupported = function() {
+  return !!(window.fetch && window.AbortController);
+};
+
+
+/**
  * Overridden in unit tests, but compiled out in production.
  *
  * @const {function(string, !RequestInit)}
@@ -142,7 +154,7 @@ shaka.net.HttpFetchPlugin.AbortController_ = window.AbortController;
 shaka.net.HttpFetchPlugin.Headers_ = window.Headers;
 
 
-if (window.fetch && window.AbortController) {
+if (shaka.net.HttpFetchPlugin.isSupported()) {
   shaka.net.NetworkingEngine.registerScheme('http', shaka.net.HttpFetchPlugin,
       shaka.net.NetworkingEngine.PluginPriority.PREFERRED);
   shaka.net.NetworkingEngine.registerScheme('https', shaka.net.HttpFetchPlugin,


### PR DESCRIPTION
The motivation for this change is to allow the client app to
share Shaka's support detection.

This should enable #1075.