### PR TITLE
Catch BAD_HTTP_STATUS error thrown by makeResponse in xhr.onload

### DIFF
--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -62,10 +62,15 @@ shaka.net.HttpXHRPlugin = function(uri, request, requestType) {
             return all;
           },
           {});
-      let response = shaka.net.HttpPluginUtils.makeResponse(headers,
+
+      try {
+        let response = shaka.net.HttpPluginUtils.makeResponse(headers,
           target.response, target.status, uri, target.responseURL,
           requestType);
-      resolve(response);
+        resolve(response);
+      } catch (error) {
+        reject(error);
+      }
     };
     xhr.onerror = function(event) {
       reject(new shaka.util.Error(

--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -69,6 +69,8 @@ shaka.net.HttpXHRPlugin = function(uri, request, requestType) {
           requestType);
         resolve(response);
       } catch (error) {
+        goog.asserts.assert(error instanceof shaka.util.Error,
+            'Wrong error type!');
         reject(error);
       }
     };

--- a/test/net/http_plugin_unit.js
+++ b/test/net/http_plugin_unit.js
@@ -57,7 +57,7 @@ function httpPluginTests(usingFetch) {
       jasmine.Ajax.uninstall();
 
       // Wrap event handlers to catch errors
-      const MockXHR = function () {
+      const MockXHR = function() {
         const instance = new jasmineXHRMock();
 
         ['abort', 'load', 'error', 'timeout'].forEach(function(eventName) {


### PR DESCRIPTION
Also wrap mock XHR event handlers in try-catch blocks in
http_plugin_unit to avoid regression.

Resolves #1302