### PR TITLE
Issue #1317 - Warn if we don't get a valid date from UTCTiming server.

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1440,15 +1440,21 @@ shaka.dash.DashParser.prototype.requestForTiming_ =
   return operation.promise.then((response) => {
     let text;
     if (method == 'HEAD') {
-      if (!response.headers || !response.headers['date']) return 0;
-
+      if (!response.headers || !response.headers['date']) {
+        shaka.log.warning('UTC timing response is missing',
+                          'expected date header');
+        return 0;
+      }
       text = response.headers['date'];
     } else {
       text = shaka.util.StringUtils.fromUTF8(response.data);
     }
-
     let date = Date.parse(text);
-    return isNaN(date) ? 0 : (date - Date.now());
+    if (isNaN(date)) {
+      shaka.log.warning('Unable to parse date from UTC timing response');
+      return 0;
+    }
+    return (date - Date.now());
   });
 };
 


### PR DESCRIPTION
Warn if parsing the date from the UTC timing element fails, instead of silently failing to do time synchronization.

