### PR TITLE
Update Contributors to use personal email

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,7 +22,7 @@
 #
 # Please keep the list sorted.
 
-Aaron Vaage <vaage@google.com>
+Aaron Vaage <aaron.vaage@gmail.com>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>


### PR DESCRIPTION
Updating contributors to use my person email instead of my corp email.