### PR TITLE
Fix playback of VDMS assets in demo app

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -230,16 +230,6 @@ shakaAssets.UplynkResponseFilter = function(type, response) {
  * object, and requires that the uplynk manifest response filter also be set.
  */
 shakaAssets.UplynkRequestFilter = function(type, request) {
-  if (type == shaka.net.NetworkingEngine.RequestType.LICENSE ||
-      type == shaka.net.NetworkingEngine.RequestType.MANIFEST) {
-    // It appears UTCTiming requests are considered MANIFEST type requests.
-    if (request.uris[0].indexOf('servertime') == -1) {
-      request.allowCrossSiteCredentials = true;
-    } else {
-      request.allowCrossSiteCredentials = false;
-    }
-  }
-
   if (type == shaka.net.NetworkingEngine.RequestType.LICENSE) {
     // Modify the license request URL based on our cookie.
     if (request.uris[0].indexOf('wv') !== -1 &&


### PR DESCRIPTION
As of 04-02-2018 VDMS manifest servers are no longer passing
data via cookies.  As such the servers are no longer setting 
 'Access-Control-Allow-Credentials' header in the response.  
The demo player is currently configured to set include credentials
for the VDMS assets and without the Allow Credentials error we get
a CORS error when attempting playback:

 The value of the 'Access-Control-Allow-Credentials' header in the response is '' which must be 'true' when the request's credentials mode is 'include'. Origin 'https://shaka-player-demo.appspot.com' is therefore not allowed access

This change updates the VDMS asset callback to ensure that the credential
mode is no longer 'include'. 