### PR TITLE
Always use https://

### DIFF
--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -23,8 +23,8 @@ Basic usage of Shaka Player is very easy:
   <body>
     <video id="video"
            width="640"
-           poster="//shaka-player-demo.appspot.com/assets/poster.jpg"
-           controls autoplay></video>
+           poster="/assets/poster.jpg"
+           controls autoplay playsinline></video>
   </body>
 </html>
 ```
@@ -32,7 +32,7 @@ Basic usage of Shaka Player is very easy:
 ```js
 // myapp.js
 
-var manifestUri = '//storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd';
+var manifestUri = 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mpd';
 
 function initApp() {
   // Install built-in polyfills to patch browser incompatibilities.

--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -24,7 +24,7 @@ Basic usage of Shaka Player is very easy:
     <video id="video"
            width="640"
            poster="https://shaka-player-demo.appspot.com/assets/poster.jpg"
-           controls autoplay ></video>
+           controls autoplay></video>
   </body>
 </html>
 ```

--- a/docs/tutorials/basic-usage.md
+++ b/docs/tutorials/basic-usage.md
@@ -23,8 +23,8 @@ Basic usage of Shaka Player is very easy:
   <body>
     <video id="video"
            width="640"
-           poster="/assets/poster.jpg"
-           controls autoplay playsinline></video>
+           poster="https://shaka-player-demo.appspot.com/assets/poster.jpg"
+           controls autoplay ></video>
   </body>
 </html>
 ```

--- a/docs/tutorials/debugging.md
+++ b/docs/tutorials/debugging.md
@@ -9,7 +9,7 @@ and make a bad change.
 First, let's change `manifestUri` by removing the last letter.
 
 ```js
-var manifestUri = '//storage.googleapis.com/shaka-demo-assets/angel-one/dash.mp';
+var manifestUri = 'https://storage.googleapis.com/shaka-demo-assets/angel-one/dash.mp';
 ```
 
 Now reload the page.  This causes an error in the JS console that says "Error

--- a/docs/tutorials/license-server-auth.md
+++ b/docs/tutorials/license-server-auth.md
@@ -15,8 +15,8 @@ To start, we're going to use the code from {@tutorial basic-usage}, but use this
 manifest and license server:
 
 ```js
-var manifestUri = '//storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd';
-var licenseServer = '//cwip-shaka-proxy.appspot.com/no_auth';
+var manifestUri = 'https://storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/no_auth';
 ```
 
 We'll also need to configure the player to use this license server before it
@@ -43,7 +43,7 @@ Since the endpoint is `/no_auth`, this should play without authentication.
 First, we'll try authentication using headers.  Change the license server to:
 
 ```js
-var licenseServer = '//cwip-shaka-proxy.appspot.com/header_auth';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/header_auth';
 ```
 
 This endpoint requires a specific header value to deliver a license.  If you
@@ -78,7 +78,7 @@ Next, we'll try authentication using URL parameters.  Change the license server
 to:
 
 ```js
-var licenseServer = '//cwip-shaka-proxy.appspot.com/param_auth';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/param_auth';
 ```
 
 This endpoint requires a specific URL parameter to deliver a license.  If you
@@ -109,7 +109,7 @@ Finally, let's try using cookies for authentication.  Change the license server
 to:
 
 ```js
-var licenseServer = '//cwip-shaka-proxy.appspot.com/cookie_auth';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/cookie_auth';
 ```
 
 This endpoint requires a specific cookie to deliver a license.  If you try to
@@ -160,7 +160,7 @@ pointing your browser to the server's [delete\_cookie][] page.  Then set your
 license server back to:
 
 ```js
-var licenseServer = '//cwip-shaka-proxy.appspot.com/no_auth';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/no_auth';
 ```
 
 Since `allowCrossSiteCredentials` is `true` and that endpoint doesn't
@@ -193,8 +193,8 @@ of an asynchronous filter.
 To start, change the license server and add two additional variables:
 
 ```js
-var licenseServer = '//cwip-shaka-proxy.appspot.com/header_auth';
-var authTokenServer = '//cwip-shaka-proxy.appspot.com/get_auth_token';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/header_auth';
+var authTokenServer = 'https://cwip-shaka-proxy.appspot.com/get_auth_token';
 var authToken = null;
 ```
 

--- a/docs/tutorials/license-wrapping.md
+++ b/docs/tutorials/license-wrapping.md
@@ -37,8 +37,8 @@ manifest and license server:
 
 ```js
 var manifestUri =
-    '//storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd';
-var licenseServer = '//cwip-shaka-proxy.appspot.com/wrapped_request';
+    'https://storage.googleapis.com/shaka-demo-assets/sintel-widevine/dash.mpd';
+var licenseServer = 'https://cwip-shaka-proxy.appspot.com/wrapped_request';
 ```
 
 We'll also need to configure the player to use this license server before it
@@ -124,7 +124,7 @@ Change the license server to:
 
 ```js
 var licenseServer =
-    '//cwip-shaka-proxy.appspot.com/wrapped_request_and_response';
+    'https://cwip-shaka-proxy.appspot.com/wrapped_request_and_response';
 ```
 
 This license server is sending a wrapped response, so if we try to play now, we

--- a/docs/tutorials/upgrade-v1.md
+++ b/docs/tutorials/upgrade-v1.md
@@ -98,14 +98,14 @@ function interpretContentProtection(schemeIdUri, contentProtectionElement) {
     // This is the UUID which represents Widevine.
     return [{
       'keySystem': 'com.widevine.alpha',
-      'licenseServerUrl': '//proxy.uat.widevine.com/proxy'
+      'licenseServerUrl': 'https://proxy.uat.widevine.com/proxy'
     }];
   } else if (schemeIdUri.toLowerCase() ==
       'urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95') {
     // This is the UUID which represents PlayReady.
     return [{
       'keySystem': 'com.microsoft.playready',
-      'licenseServerUrl': '//playready.directtaps.net/pr/svc/rightsmanager.asmx'
+      'licenseServerUrl': 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx'
     }];
   } else {
     return null;
@@ -128,8 +128,8 @@ var player = new shaka.Player(video);
 player.configure({
   drm: {
     servers: {
-      'com.widevine.alpha': '//proxy.uat.widevine.com/proxy'
-      'com.microsoft.playready': '//playready.directtaps.net/pr/svc/rightsmanager.asmx'
+      'com.widevine.alpha': 'https://proxy.uat.widevine.com/proxy'
+      'com.microsoft.playready': 'https://playready.directtaps.net/pr/svc/rightsmanager.asmx'
     }
   }
 });
@@ -185,7 +185,7 @@ function interpretContentProtection(schemeIdUri, contentProtectionElement) {
       'urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed') {
     return [{
       'keySystem': 'com.widevine.alpha',
-      'licenseServerUrl': '//proxy.uat.widevine.com/proxy',
+      'licenseServerUrl': 'https://proxy.uat.widevine.com/proxy',
 
       'distinctiveIdentifierRequired': true,
       'persistentStateRequired': false,


### PR DESCRIPTION
~~This CL simply makes sure we don't use `//` and also adds playsinline which is almost always mandatory in iOS world~~

This CL simply makes sure we don't use protocol relative URLs.

> Now that SSL is encouraged for everyone and doesn’t have performance concerns, this technique is now an anti-pattern. If the asset you need is available on SSL, then always use the https:// asset.
> 
> Allowing the snippet to request over HTTP opens the door for attacks like the recent Github Man-on-the-side attack. It’s always safe to request HTTPS assets even if your site is on HTTP, however the reverse is not true.
> 

Source: See https://www.paulirish.com/2010/the-protocol-relative-url/ and https://google.github.io/styleguide/htmlcssguide.html#Protocol.
