### PR TITLE
Explicitly bind wrapping IIFE to window for ES5 strict mode compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
+Patrick Kunka <patrick@kunkalabs.com>
 Philo Inc. <*@philo.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Roi Lipman <roilipman@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -53,6 +53,7 @@ Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>
 Niklas Korz <nk@alugha.com>
 Oskar Arvidsson <oskar@irock.se>
+Patrick Kunka <patrick@kunkalabs.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>

--- a/build/wrapper.template.js
+++ b/build/wrapper.template.js
@@ -3,4 +3,4 @@
 if (typeof(module)!="undefined"&&module.exports)module.exports=g.shaka;
 else if (typeof(define)!="undefined" && define.amd)define(function(){return g.shaka});
 else this.shaka=g.shaka;
-})();
+}).call(window);


### PR DESCRIPTION
I came across the following  issue while using Shaka as a dependency of another pre-bundled library that was delivered to my company as a single UMD-wrapped package with no resolvable dependencies. While I can see that this is an abuse of the node module system, I anticipate many other video libraries may deliver Shaka to customers like this to avoid complexity for their customers. I will be following up with the author of the library as well, but I can't see any downside of adding the suggested changes and making Shaka more robust in the process.

Thanks!

#### Description

Shaka assumes that `this` within the top-level IIFE will be bound to `window` in a browser environment.

```js
(function() {
    console.log(this); // window
})()
```

This works correctly as long as Shaka is a top-level dependency (node_module) of an ES6+ project and therefore ignored from babel transpilation. However, when it is part of some other bundle which is transpiled from ES6 to ES5 before being consumed, this process will add the following:

```js
function() { // wrapping webpack module closure
    'use strict';
    ...
    (function() { // shaka UMD module
        console.log(this); // undefined
    })()
}
```
As per the strict-mode definition, `this` is `undefined` within an implicitly called IIFE.

Shaka is then broken, as various pieces of code such as `window.console` become lookups on undefined.

To address this, we can explicitly bind the IIFE to the window, and Shaka will function correctly regardless of whether it is being evaluated in a strict mode context or not.

```js
(function() {
    console.log(this); // window
}).call(window)
```


