### PR TITLE
Use FakeNetworkingEngine#setResponseText everywhere

### DIFF
--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1072,7 +1072,7 @@ describe('DashParser Manifest', function() {
       '</MPD>',
     ].join('\n');
 
-    fakeNetEngine.setResponseMapAsText({'dummy://foo': manifestText});
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
     const manifest = await parser.start('dummy://foo', playerInterface);
     const variant = manifest.periods[0].variants[0];
     const textStream = manifest.periods[0].textStreams[0];


### PR DESCRIPTION
In commit 78142719eb3fa71315012b6ad0d634157bed1f50, the method
FakeNetworkingEngine#setResponseMapAsText was removed, and every
instance of its usage (except one) was replaced with
setResponseText. This change fixes the one missed case.

Closes #1536