### PR TITLE
specific rebufferingGoal override manifest one #1547 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Alugha GmbH <*@alugha.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>
+Fadomire <fadomire@gmail.com>
 Google Inc. <*@google.com>
 Edgeware AB <*@edgeware.tv>
 Giuseppe Samela <giuseppe.samela@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Costel Madalin Grecu <madalin.grecu@adswizz.com>
 Donato Borrello <donato@jwplayer.com>
 Duc Pham <duc.pham@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>
+Fadomire <fadomire@gmail.com>
 François Beaufort <fbeaufort@google.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
 Itay Kinnrot <itay.kinnrot@kaltura.com>

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -513,7 +513,8 @@ shaka.extern.DrmConfiguration;
  *   clockSyncUri: string,
  *   ignoreDrmInfo: boolean,
  *   xlinkFailGracefully: boolean,
- *   defaultPresentationDelay: number
+ *   defaultPresentationDelay: number,
+ *   ignoreMinBufferTime: boolean
  * }}
  *
  * @property {shaka.extern.DashContentProtectionCallback} customScheme
@@ -536,6 +537,10 @@ shaka.extern.DrmConfiguration;
  * @property {number} defaultPresentationDelay
  *   A default presentationDelay if suggestedPresentationDelay is missing
  *   in the MPEG DASH manifest. This has to be bigger than minBufferTime * 1.5.
+ * @property {boolean} ignoreMinBufferTime
+ *   If true will cause DASH parser to ignore minBufferTime from manifest
+ *   it allows player config to take precedence over manifest for
+ *   rebufferingGoal. Defaults to false if not provided.
  *
  * @exportDoc
  */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -538,8 +538,8 @@ shaka.extern.DrmConfiguration;
  *   A default presentationDelay if suggestedPresentationDelay is missing
  *   in the MPEG DASH manifest. This has to be bigger than minBufferTime * 1.5.
  * @property {boolean} ignoreMinBufferTime
- *   If true will cause DASH parser to ignore minBufferTime from manifest
- *   it allows player config to take precedence over manifest for
+ *   If true will cause DASH parser to ignore minBufferTime from manifest.
+ *   It allows player config to take precedence over manifest for
  *   rebufferingGoal. Defaults to false if not provided.
  *
  * @exportDoc

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -487,7 +487,7 @@ shaka.dash.DashParser.prototype.processManifest_ =
       manifestBaseUris, uris);
 
   let ignoreMinBufferTime = this.config_.dash.ignoreMinBufferTime;
-  let minBufferTime = 0;
+  let minBufferTime;
   if (!ignoreMinBufferTime) {
     minBufferTime =
       XmlUtils.parseAttr(mpd, 'minBufferTime', XmlUtils.parseDuration);
@@ -579,7 +579,7 @@ shaka.dash.DashParser.prototype.processManifest_ =
       presentationTimeline: presentationTimeline,
       periods: periods,
       offlineSessionIds: [],
-      minBufferTime: minBufferTime,
+      minBufferTime: minBufferTime || 0,
     };
 
     // We only need to do clock sync when we're using presentation start time.

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -486,8 +486,13 @@ shaka.dash.DashParser.prototype.processManifest_ =
   let baseUris = shaka.util.ManifestParserUtils.resolveUris(
       manifestBaseUris, uris);
 
-  let minBufferTime =
+  let ignoreMinBufferTime = this.config_.dash.ignoreMinBufferTime;
+  let minBufferTime = 0;
+  if (!ignoreMinBufferTime) {
+    minBufferTime =
       XmlUtils.parseAttr(mpd, 'minBufferTime', XmlUtils.parseDuration);
+  }
+
   this.updatePeriod_ = /** @type {number} */ (XmlUtils.parseAttr(
       mpd, 'minimumUpdatePeriod', XmlUtils.parseDuration, -1));
 
@@ -574,7 +579,7 @@ shaka.dash.DashParser.prototype.processManifest_ =
       presentationTimeline: presentationTimeline,
       periods: periods,
       offlineSessionIds: [],
-      minBufferTime: minBufferTime || 0,
+      minBufferTime: minBufferTime,
     };
 
     // We only need to do clock sync when we're using presentation start time.

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -101,6 +101,7 @@ shaka.util.PlayerConfiguration = class {
         ignoreDrmInfo: false,
         xlinkFailGracefully: false,
         defaultPresentationDelay: 10,
+        ignoreMinBufferTime: false,
       },
     };
 

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -45,6 +45,7 @@ describe('DashParser ContentProtection', function() {
         ignoreDrmInfo: ignoreDrmInfo,
         xlinkFailGracefully: false,
         defaultPresentationDelay: 10,
+        ignoreMinBufferTime: false,
       },
     });
     let playerEvents = {

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -51,6 +51,7 @@ describe('DashParser Live', function() {
         ignoreDrmInfo: false,
         xlinkFailGracefully: false,
         defaultPresentationDelay: 10,
+        ignoreMinBufferTime: false,
       },
     });
     playerInterface = {
@@ -713,6 +714,7 @@ describe('DashParser Live', function() {
           ignoreDrmInfo: false,
           xlinkFailGracefully: false,
           defaultPresentationDelay: 10,
+          ignoreMinBufferTime: false,
         },
       });
 

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -126,6 +126,7 @@ describe('HlsParser live', function() {
         ignoreDrmInfo: false,
         xlinkFailGracefully: false,
         defaultPresentationDelay: 10,
+        ignoreMinBufferTime: false,
       },
     };
 
@@ -498,6 +499,7 @@ describe('HlsParser live', function() {
             ignoreDrmInfo: false,
             xlinkFailGracefully: false,
             defaultPresentationDelay: 10,
+            ignoreMinBufferTime: false,
           },
         });
 

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -93,6 +93,7 @@ describe('HlsParser', function() {
         ignoreDrmInfo: false,
         xlinkFailGracefully: false,
         defaultPresentationDelay: 10,
+        ignoreMinBufferTime: false,
       },
     };
 

--- a/test/test/util/dash_parser_util.js
+++ b/test/test/util/dash_parser_util.js
@@ -34,6 +34,7 @@ shaka.test.Dash.makeDashParser = function() {
       ignoreDrmInfo: false,
       xlinkFailGracefully: false,
       defaultPresentationDelay: 10,
+      ignoreMinBufferTime: false,
     },
   });
   return parser;


### PR DESCRIPTION
EDIT: pull request updated to add manifest.dash.ignoreMinBufferTime

~~i'm not really satisfied of adding a defaultRebufferingGoal to config but at least changes in code are very light~~

see #1547 