### PR TITLE
Offline PSSH support for manifest that are missing inline init data (#1531)

### DIFF
--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -37,6 +37,7 @@ goog.require('shaka.util.Functional');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.MapUtils');
 goog.require('shaka.util.PlayerConfiguration');
+goog.require('shaka.util.Pssh');
 goog.require('shaka.util.StreamUtils');
 
 
@@ -610,6 +611,23 @@ shaka.offline.Storage.prototype.loadInternal = function(
       }.bind(this))
       .then(function(data) {
         this.checkDestroyed_();
+        let isEncrypted = data.periods.some((period) => {
+          return period.variants.some((variant) => variant.drmInfos.length);
+        });
+        let includesInitData = data.periods.some((period) => {
+          return period.variants.some((variant) => {
+            return variant.drmInfos.some((drmInfos) =>
+              drmInfos.initData.length);
+          });
+        });
+        if (isEncrypted && !includesInitData) {
+          return this.extractInitDataFromFirstSegment_(data, netEngine);
+        } else {
+          return data;
+        }
+      }.bind(this))
+      .then(function(data) {
+        this.checkDestroyed_();
         manifest = data;
         return drmEngine.init(
             manifest, this.config_.offline.usePersistentLicense);
@@ -770,6 +788,61 @@ shaka.offline.Storage.prototype.createOfflineManifest_ = function(
   };
 };
 
+/**
+ * Extract DRM initData from first segment
+ *
+ * @param {shaka.extern.Manifest} manifest
+ * @param {shaka.net.NetworkingEngine} networkingEngine
+ * @return {Promise<shaka.extern.Manifest>}
+ * @private
+ */
+shaka.offline.Storage.prototype.extractInitDataFromFirstSegment_ = async function(
+  manifest, networkingEngine) {
+  // get init segments uri of all variants
+  /** @type {Array<Array<string>>} */
+  let initSegmentReferences = [].concat.apply([], manifest.periods.map((period) => {
+    return period.variants.map((variant) => {
+      return variant.video.initSegmentReference;
+    });
+  }));
+
+  // download init segments
+  let segmentResult = await Promise.all(
+    initSegmentReferences.map((initSegmentReference) => {
+      this.checkDestroyed_();
+      let retryParams = this.player_.getConfiguration()
+          .streaming.retryParameters;
+      let request = shaka.net.NetworkingEngine.makeRequest(
+        initSegmentReference.getUris(), retryParams);
+      if (initSegmentReference.startByte != null) {
+        let end = (initSegmentReference.endByte != null ?
+          initSegmentReference.endByte : '');
+        request.headers['Range'] = 'bytes=' + initSegmentReference.startByte
+          + '-' + end;
+      }
+      let type = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+      return networkingEngine.request(type, request).promise;
+    })
+  );
+
+  // search for pssh atom in segment and insert init data into manifest
+  let counter = 0;
+  manifest.periods.forEach((period) => {
+    period.variants.forEach((variant) => {
+      let firstSegment = new Uint8Array(segmentResult[counter].data);
+      let normalisedInitData = shaka.util.Pssh.normaliseInitData(
+        firstSegment, true);
+      variant.drmInfos.forEach((drmInfo) => {
+        drmInfo.initData = [
+          {initDataType: 'cenc', initData: normalisedInitData},
+        ];
+      });
+      counter++;
+    });
+  });
+
+  return manifest;
+};
 
 /**
  * Converts a manifest Period to a database Period.  This will use the current

--- a/lib/polyfill/patchedmediakeys_ms.js
+++ b/lib/polyfill/patchedmediakeys_ms.js
@@ -20,7 +20,6 @@ goog.provide('shaka.polyfill.PatchedMediaKeysMs');
 goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.polyfill.register');
-goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
@@ -519,83 +518,15 @@ shaka.polyfill.PatchedMediaKeysMs.MediaKeySession.prototype.
 shaka.polyfill.PatchedMediaKeysMs.onMsNeedKey_ = function(event) {
   shaka.log.debug('PatchedMediaKeysMs.onMsNeedKey_', event);
 
-  // Alias
-  const PatchedMediaKeysMs = shaka.polyfill.PatchedMediaKeysMs;
-
   // NOTE: Because "this" is a real EventTarget, on IE, the event we dispatch
   // here must also be a real Event.
   let event2 = /** @type {!CustomEvent} */(document.createEvent('CustomEvent'));
   event2.initCustomEvent('encrypted', false, false, null);
   event2.initDataType = 'cenc';
-  event2.initData = PatchedMediaKeysMs.normaliseInitData_(event.initData);
+  event2.initData = shaka.util.Pssh.normaliseInitData(event.initData);
 
   this.dispatchEvent(event2);
 };
-
-
-/**
- * Normalise the initData array. This is to apply browser specific work-arounds,
- * e.g. removing duplicates which appears to occur intermittently when the
- * native msneedkey event fires (i.e. event.initData contains dupes).
- *
- * @param {?Uint8Array} initData
- * @private
- * @return {?Uint8Array}
- */
-shaka.polyfill.PatchedMediaKeysMs.normaliseInitData_ = function(initData) {
-  if (!initData) {
-    return initData;
-  }
-
-  let pssh = new shaka.util.Pssh(initData);
-
-  // If there is only a single pssh, return the original array.
-  if (pssh.dataBoundaries.length <= 1) {
-    return initData;
-  }
-
-  let unfilteredInitDatas = [];
-  for (let i = 0; i < pssh.dataBoundaries.length; i++) {
-    let currPssh = initData.subarray(
-        pssh.dataBoundaries[i].start,
-        pssh.dataBoundaries[i].end + 1); // End is exclusive, hence the +1.
-
-    unfilteredInitDatas.push(currPssh);
-  }
-
-  // Dedupe psshData.
-  let dedupedInitDatas = shaka.util.ArrayUtils.removeDuplicates(
-      unfilteredInitDatas,
-      shaka.polyfill.PatchedMediaKeysMs.compareInitDatas_);
-
-  let targetLength = 0;
-  for (let i = 0; i < dedupedInitDatas.length; i++) {
-    targetLength += dedupedInitDatas[i].length;
-  }
-
-  // Flatten the array of Uint8Arrays back into a single Uint8Array.
-  let normalisedInitData = new Uint8Array(targetLength);
-  let offset = 0;
-  for (let i = 0; i < dedupedInitDatas.length; i++) {
-    normalisedInitData.set(dedupedInitDatas[i], offset);
-    offset += dedupedInitDatas[i].length;
-  }
-
-  return normalisedInitData;
-};
-
-
-/**
- * @param {!Uint8Array} initDataA
- * @param {!Uint8Array} initDataB
- * @return {boolean}
- * @private
- */
-shaka.polyfill.PatchedMediaKeysMs.compareInitDatas_ =
-    function(initDataA, initDataB) {
-  return shaka.util.Uint8ArrayUtils.equal(initDataA, initDataB);
-};
-
 
 /**
  * Handler for the native keymessage event on MSMediaKeySession.

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -27,12 +27,13 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * Parse a PSSH box and extract the system IDs.
  *
  * @param {!Uint8Array} psshBox
+ * @param {boolean=} extractMoov boolean to extract pssh from moov atom
  * @constructor
  * @struct
  * @throws {shaka.util.Error} if a PSSH box is truncated or contains a size
  *   field over 53 bits.
  */
-shaka.util.Pssh = function(psshBox) {
+shaka.util.Pssh = function(psshBox, extractMoov) {
   /**
    * In hex.
    * @type {!Array.<string>}
@@ -51,8 +52,14 @@ shaka.util.Pssh = function(psshBox) {
   * */
   this.dataBoundaries = [];
 
-  new shaka.util.Mp4Parser()
+  if (extractMoov) {
+    new shaka.util.Mp4Parser()
+      .box('moov', shaka.util.Mp4Parser.children)
       .fullBox('pssh', this.parseBox_.bind(this)).parse(psshBox.buffer);
+  } else {
+    new shaka.util.Mp4Parser()
+      .fullBox('pssh', this.parseBox_.bind(this)).parse(psshBox.buffer);
+  }
 
   if (this.dataBoundaries.length == 0) {
     shaka.log.warning('No pssh box found!');
@@ -103,4 +110,66 @@ shaka.util.Pssh.prototype.parseBox_ = function(box) {
   if (box.reader.getPosition() != box.reader.getLength()) {
     shaka.log.warning('Mismatch between box size and data size!');
   }
+};
+
+
+/**
+ * Normalise the initData array. This is to apply browser specific work-arounds,
+ * e.g. removing duplicates which appears to occur intermittently when the
+ * native msneedkey event fires (i.e. event.initData contains dupes).
+ *
+ * @param {?Uint8Array} initData
+ * @param {boolean=} extractMoov boolean to extract pssh from moov atom
+ * @return {?Uint8Array}
+ */
+shaka.util.Pssh.normaliseInitData = function(initData, extractMoov) {
+  if (!initData) {
+    return initData;
+  }
+
+  let pssh = new shaka.util.Pssh(initData, extractMoov);
+
+  // If there is only a single pssh, return the original array.
+  if (pssh.dataBoundaries.length <= 1) {
+    return initData;
+  }
+
+  let unfilteredInitDatas = [];
+  for (let i = 0; i < pssh.dataBoundaries.length; i++) {
+    let currPssh = initData.subarray(
+        pssh.dataBoundaries[i].start + (extractMoov ? 8 : 0),
+        // End is exclusive, hence the +1.
+        pssh.dataBoundaries[i].end + 1 + (extractMoov ? 8 : 0));
+    unfilteredInitDatas.push(currPssh);
+  }
+
+  // Dedupe psshData.
+  let dedupedInitDatas = shaka.util.ArrayUtils.removeDuplicates(
+      unfilteredInitDatas,
+      shaka.util.Pssh.compareInitDatas);
+
+  let targetLength = 0;
+  for (let i = 0; i < dedupedInitDatas.length; i++) {
+    targetLength += dedupedInitDatas[i].length;
+  }
+
+  // Flatten the array of Uint8Arrays back into a single Uint8Array.
+  let normalisedInitData = new Uint8Array(targetLength);
+  let offset = 0;
+  for (let i = 0; i < dedupedInitDatas.length; i++) {
+    normalisedInitData.set(dedupedInitDatas[i], offset);
+    offset += dedupedInitDatas[i].length;
+  }
+
+  return normalisedInitData;
+};
+
+/**
+ * @param {!Uint8Array} initDataA
+ * @param {!Uint8Array} initDataB
+ * @return {boolean}
+ */
+shaka.util.Pssh.compareInitDatas =
+    function(initDataA, initDataB) {
+  return shaka.util.Uint8ArrayUtils.equal(initDataA, initDataB);
 };


### PR DESCRIPTION
This is an initial implementation to manually parse the first media segments to extract the PSSH data from the moov atom to support offline storage of content that does not include inline PSSH init data. 

Per ticket #1531
> When we store content, we need to create an EME offline session so we can play the encrypted content later. To create the session we need the init data, which is usually PSSH data. If it is in the manifest, we can just pass it to EME to create the offline session. But if we don't have it, we need to get it from the media.

> In a streaming situation, we pass the media to the browser and it gives us an encrypted event with the PSSH data in it. But when we are storing content, we can't give it to the browser since we don't want to create a <video> element and have to deal with MSE.

The implementation manually fetches the first segments of the stream and then parses them using the existing shaka mp4 atom parser and re-used logic from the 'shaka.polyfill.PatchedMediaKeysMs' to correctly extract the PSSH value which is then inserted into the DrmEngine.