### PR TITLE
Fix seekable range on VOD HLS streams with minimum timestamp

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -409,6 +409,8 @@ shaka.hls.HlsParser.prototype.parseManifest_ = function(data, uri) {
         streamInfo.segmentIndex.fit(minDuration);
       }
     }
+    
+    this.notifySegments_();
 
     this.manifest_ = {
       presentationTimeline: this.presentationTimeline_,
@@ -1140,8 +1142,6 @@ shaka.hls.HlsParser.prototype.createPresentationTimeline_ =
         /* presentationStartTime */ null, /* delay */ 0);
     this.presentationTimeline_.setStatic(true);
   }
-
-  this.notifySegments_();
 
   // This asserts that the live edge is being calculated from segment times.
   // For VOD and event streams, this check should still pass.


### PR DESCRIPTION
I noticed that some of our VOD HLS streams don't start playback from 0 position when using shaka player. What is more you can't even seek to 0 position. After some debugging I found out that seekable range isn't correct (e.g. for one content the range was from 4200 seconds to 2700 seconds, 2700 seconds was the duration of the content and shaka player immediately seeked to this position & only played a few seconds before the end). I noticed that presentation timelines first segment start time is set before segments are offset back to 0 in hls parser. Calling notifySegments after applying the offset instead of before fixes this issue for me. One warning at this point... we just started using shaka player & I'm not familiar with the codebase... which means that I'm not sure if this can affect anything else.