### PR TITLE
Set server certificate before Store and Delete

### DIFF
--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -212,24 +212,24 @@ shakaDemo.storeDeleteAsset_ = function() {
     }
 
     p = configureCertificate.then(function() {
-    let nameField = document.getElementById('offlineName').value;
-    let assetName = asset.name ? '[OFFLINE] ' + asset.name : null;
-    let metadata = {name: assetName || nameField || asset.manifestUri};
-      return storage.store(asset.manifestUri, metadata).then(function() {
-      if (option.asset) {
-        option.isStored = true;
-      }
-      return shakaDemo.refreshAssetList_().then(function() {
-        // Auto-select offline copy of asset after storing.
-        let group = shakaDemo.offlineOptGroup_;
-        for (let i = 0; i < group.childNodes.length; i++) {
-          let option = group.childNodes[i];
-          if (option.textContent == assetName) {
-            assetList.selectedIndex = option.index;
-          }
+      let nameField = document.getElementById('offlineName').value;
+      let assetName = asset.name ? '[OFFLINE] ' + asset.name : null;
+      let metadata = {name: assetName || nameField || asset.manifestUri};
+        return storage.store(asset.manifestUri, metadata).then(function() {
+        if (option.asset) {
+          option.isStored = true;
         }
+        return shakaDemo.refreshAssetList_().then(function() {
+          // Auto-select offline copy of asset after storing.
+          let group = shakaDemo.offlineOptGroup_;
+          for (let i = 0; i < group.childNodes.length; i++) {
+            let option = group.childNodes[i];
+            if (option.textContent == assetName) {
+              assetList.selectedIndex = option.index;
+            }
+          }
+        });
       });
-    });
     });
   }
 

--- a/demo/offline_section.js
+++ b/demo/offline_section.js
@@ -202,11 +202,20 @@ shakaDemo.storeDeleteAsset_ = function() {
       return shakaDemo.refreshAssetList_();
     });
   } else {
+    let configureCertificate = Promise.resolve();
+
     let asset = shakaDemo.preparePlayer_(option.asset);
+
+    if (asset.certificateUri) {
+      configureCertificate = shakaDemo.requestCertificate_(asset.certificateUri)
+        .then(shakaDemo.configureCertificate_);
+    }
+
+    p = configureCertificate.then(function() {
     let nameField = document.getElementById('offlineName').value;
     let assetName = asset.name ? '[OFFLINE] ' + asset.name : null;
     let metadata = {name: assetName || nameField || asset.manifestUri};
-    p = storage.store(asset.manifestUri, metadata).then(function() {
+      return storage.store(asset.manifestUri, metadata).then(function() {
       if (option.asset) {
         option.isStored = true;
       }
@@ -220,6 +229,7 @@ shakaDemo.storeDeleteAsset_ = function() {
           }
         }
       });
+    });
     });
   }
 

--- a/externs/shaka/offline.js
+++ b/externs/shaka/offline.js
@@ -212,6 +212,7 @@ shaka.extern.SegmentDataDB;
  *   sessionId: string,
  *   keySystem: string,
  *   licenseUri: string,
+ *   serverCertificate: Uint8Array,
  *   audioCapabilities: !Array.<MediaKeySystemMediaCapability>,
  *   videoCapabilities: !Array.<MediaKeySystemMediaCapability>
  * }}
@@ -222,6 +223,10 @@ shaka.extern.SegmentDataDB;
  *   The EME key system string the session belongs to.
  * @property {string} licenseUri
  *   The URI for the license server.
+ * @property {Uint8Array} serverCertificate
+ *   A key-system-specific server certificate used to encrypt license requests.
+ *   Its use is optional and is meant as an optimization to avoid a round-trip
+ *   to request a certificate.
  * @property {!Array.<MediaKeySystemMediacapability>} audioCapabilities
  *   The EME audio capabilities used to create the session.
  * @property {!Array.<MediaKeySystemMediacapability>} videoCapabilities

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -307,12 +307,14 @@ shaka.media.DrmEngine.prototype.initForPlayback = function(
  *
  * @param {string} keySystem
  * @param {string} licenseServerUri
+ * @param {Uint8Array} serverCertificate
  * @param {!Array.<MediaKeySystemMediaCapability>} audioCapabilities
  * @param {!Array.<MediaKeySystemMediaCapability>} videoCapabilities
  * @return {!Promise}
  */
 shaka.media.DrmEngine.prototype.initForRemoval = function(
-    keySystem, licenseServerUri, audioCapabilities, videoCapabilities) {
+    keySystem, licenseServerUri, serverCertificate,
+    audioCapabilities, videoCapabilities) {
   /** @type {!Map.<string, MediaKeySystemConfiguration>} */
   const configsByKeySystem = new Map();
   configsByKeySystem.set(keySystem, {
@@ -329,7 +331,7 @@ shaka.media.DrmEngine.prototype.initForRemoval = function(
       persistentStateRequired: true,
       audioRobustness: '',  // Not required by queryMediaKeys_
       videoRobustness: '',  // Same
-      serverCertificate: null,
+      serverCertificate: serverCertificate,
       initData: null,
       keyIds: null,
     }],  // Tracked by us, ignored by EME.
@@ -439,23 +441,7 @@ shaka.media.DrmEngine.prototype.attach = function(video) {
         exception.message));
   });
 
-  let setServerCertificate = null;
-  if (this.currentDrmInfo_.serverCertificate &&
-      this.currentDrmInfo_.serverCertificate.length) {
-    setServerCertificate = this.mediaKeys_.setServerCertificate(
-        this.currentDrmInfo_.serverCertificate).then(function(supported) {
-      if (!supported) {
-        shaka.log.warning('Server certificates are not supported by the key' +
-                          ' system.  The server certificate has been ignored.');
-      }
-    }).catch(function(exception) {
-      return Promise.reject(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.DRM,
-          shaka.util.Error.Code.INVALID_SERVER_CERTIFICATE,
-          exception.message));
-    });
-  }
+  let setServerCertificate = this.setServerCertificate();
 
   return Promise.all([setMediaKeys, setServerCertificate]).then(() => {
     if (this.destroyed_) return Promise.reject();
@@ -473,6 +459,40 @@ shaka.media.DrmEngine.prototype.attach = function(video) {
     if (this.destroyed_) return Promise.resolve();  // Ignore destruction errors
     return Promise.reject(error);
   });
+};
+
+
+/**
+ * Create a promise that will be resolved after the server certificate
+ * will be set.
+ *
+ * @return {!Promise|null}
+ */
+shaka.media.DrmEngine.prototype.setServerCertificate = function() {
+  goog.asserts.assert(this.initialized_,
+    'Must call init() before setServerCertificate');
+
+  let setServerCertificate = null;
+  if (this.mediaKeys_ &&
+      this.currentDrmInfo_ &&
+      this.currentDrmInfo_.serverCertificate &&
+      this.currentDrmInfo_.serverCertificate.length) {
+    setServerCertificate = this.mediaKeys_.setServerCertificate(
+        this.currentDrmInfo_.serverCertificate).then(function(supported) {
+      if (!supported) {
+        shaka.log.warning('Server certificates are not supported by the key' +
+                          ' system.  The server certificate has been ignored.');
+      }
+    }).catch(function(exception) {
+      return Promise.reject(new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.INVALID_SERVER_CERTIFICATE,
+          exception.message));
+    });
+  }
+
+  return setServerCertificate;
 };
 
 

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -463,36 +463,33 @@ shaka.media.DrmEngine.prototype.attach = function(video) {
 
 
 /**
- * Create a promise that will be resolved after the server certificate
- * will be set.
+ * Sets the server certificate based on the current DrmInfo.
  *
- * @return {!Promise|null}
+ * @return {!Promise}
  */
-shaka.media.DrmEngine.prototype.setServerCertificate = function() {
+shaka.media.DrmEngine.prototype.setServerCertificate = async function() {
   goog.asserts.assert(this.initialized_,
     'Must call init() before setServerCertificate');
 
-  let setServerCertificate = null;
   if (this.mediaKeys_ &&
       this.currentDrmInfo_ &&
       this.currentDrmInfo_.serverCertificate &&
       this.currentDrmInfo_.serverCertificate.length) {
-    setServerCertificate = this.mediaKeys_.setServerCertificate(
-        this.currentDrmInfo_.serverCertificate).then(function(supported) {
+    try {
+      const supported = await this.mediaKeys_.setServerCertificate(
+          this.currentDrmInfo_.serverCertificate);
       if (!supported) {
         shaka.log.warning('Server certificates are not supported by the key' +
                           ' system.  The server certificate has been ignored.');
       }
-    }).catch(function(exception) {
+    } catch (exception) {
       return Promise.reject(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.DRM,
-          shaka.util.Error.Code.INVALID_SERVER_CERTIFICATE,
-          exception.message));
-    });
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.DRM,
+        shaka.util.Error.Code.INVALID_SERVER_CERTIFICATE,
+        exception.message));
+    }
   }
-
-  return setServerCertificate;
 };
 
 

--- a/lib/offline/session_deleter.js
+++ b/lib/offline/session_deleter.js
@@ -79,7 +79,7 @@ shaka.offline.SessionDeleter = class {
     }
 
     try {
-      drmEngine.setServerCertificate();
+      await drmEngine.setServerCertificate();
     } catch (e) {
       shaka.log.warning('Error setting server certificate', e);
       await drmEngine.destroy();

--- a/lib/offline/session_deleter.js
+++ b/lib/offline/session_deleter.js
@@ -70,9 +70,18 @@ shaka.offline.SessionDeleter = class {
       drmEngine.configure(config);
       await drmEngine.initForRemoval(
           bucket.info.keySystem, bucket.info.licenseUri,
+          bucket.info.serverCertificate,
           bucket.info.audioCapabilities, bucket.info.videoCapabilities);
     } catch (e) {
       shaka.log.warning('Error initializing EME', e);
+      await drmEngine.destroy();
+      return [];
+    }
+
+    try {
+      drmEngine.setServerCertificate();
+    } catch (e) {
+      shaka.log.warning('Error setting server certificate', e);
       await drmEngine.destroy();
       return [];
     }

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -814,7 +814,7 @@ shaka.offline.Storage.prototype.createDrmEngine = async function(
   const config = this.config_;
   drmEngine.configure(config.drm);
   await drmEngine.initForStorage(variants, config.offline.usePersistentLicense);
-  drmEngine.setServerCertificate();
+  await drmEngine.setServerCertificate();
   await drmEngine.createOrLoad();
 
   return drmEngine;

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -814,6 +814,7 @@ shaka.offline.Storage.prototype.createDrmEngine = async function(
   const config = this.config_;
   drmEngine.configure(config.drm);
   await drmEngine.initForStorage(variants, config.offline.usePersistentLicense);
+  drmEngine.setServerCertificate();
   await drmEngine.createOrLoad();
 
   return drmEngine;
@@ -1194,6 +1195,7 @@ shaka.offline.Storage.deleteLicenseFor_ = async function(
       sessionId: sessionId,
       keySystem: manifestDb.drmInfo.keySystem,
       licenseUri: manifestDb.drmInfo.licenseServerUri,
+      serverCertificate: manifestDb.drmInfo.serverCertificate,
       audioCapabilities: shaka.offline.Storage.getCapabilities_(
           manifestDb,
           /* isVideo */ false),


### PR DESCRIPTION
**Library**: Call setServerCertificate before store and delete operations, when serverCertificate exists:
In case of store(), it can be configured by the application.
In case of delete(), it is retrieved from the stored manifest.

**Demo application**: before store(), request and configure the certificate, when a certificateUri is given in asset.

Fixes #1623.