### PR TITLE
Add license url parsing

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -270,7 +270,7 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
  * @return {string}
  */
 shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
-  let mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
+  const mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
   if (mslaurlNode) {
     return mslaurlNode.getAttribute('licenseUrl') || '';
   }
@@ -388,22 +388,22 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 * @return {string}
 */
 shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
-  let proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
+  const proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
   if (!proNode) {
     return '';
   }
   const ContentProtection = shaka.dash.ContentProtection;
   const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
-  let bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
-  let records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
-  let record = records.filter(function(record) {
+  const bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
+  const records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
+  const record = records.filter(function(record) {
     return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
   }).pop();
 
   if (record) {
-    let parser = new DOMParser();
-    let xmlDocument = parser.parseFromString(record.value, 'application/xml');
-    let rootElement = xmlDocument.documentElement;
+    const parser = new DOMParser();
+    const xmlDocument = parser.parseFromString(record.value, 'application/xml');
+    const rootElement = xmlDocument.documentElement;
     return ContentProtection.getLaurl_(rootElement);
   } else {
     return '';

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -366,16 +366,13 @@ shaka.dash.ContentProtection.parseMsPro_ = function(bytes) {
 * @private
 */
 shaka.dash.ContentProtection.getLaurl_ = function(xml) {
-  const laurlNodes = xml.getElementsByTagName('LA_URL');
-  if (laurlNodes && laurlNodes.length > 0) {
-    const laurlNode = laurlNodes[0];
-    if (laurlNode.hasChildNodes()) {
-      const laurl = laurlNode.childNodes[0].nodeValue;
-      if (laurl) {
-        return laurl;
-      }
-    }
+  // LA_URL element is optional and no more than one
+  // is allowed inside the DATA element. Only absolute URLs are allowed.
+  const laurlNode = xml.querySelector('DATA > LA_URL');
+  if (laurlNode) {
+    return laurlNode.textContent;
   }
+
   return '';
 };
 
@@ -387,7 +384,7 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 * @param {shaka.dash.ContentProtection.Element} element
 * @return {string}
 */
-shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
+shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
   const proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
   if (!proNode) {
     return '';
@@ -398,16 +395,16 @@ shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
   const records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
   const record = records.filter((record) => {
     return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
-  }).pop();
+  })[0];
 
-  if (record) {
-    const parser = new DOMParser();
-    const xmlDocument = parser.parseFromString(record.value, 'application/xml');
-    const rootElement = xmlDocument.documentElement;
-    return ContentProtection.getLaurl_(rootElement);
+  if (!record) {
+    return '';
   }
 
-  return '';
+  const parser = new DOMParser();
+  const xmlDocument = parser.parseFromString(record.value, 'application/xml');
+  const rootElement = xmlDocument.documentElement;
+  return ContentProtection.getLaurl_(rootElement);
 };
 
 
@@ -425,6 +422,7 @@ shaka.dash.ContentProtection.convertElements_ = function(
   const ContentProtection = shaka.dash.ContentProtection;
   const createDrmInfo = shaka.util.ManifestParserUtils.createDrmInfo;
   const defaultKeySystems = ContentProtection.defaultKeySystems_;
+  const licenseUrlParsers = ContentProtection.licenseUrlParsers_;
 
   /** @type {!Array.<shaka.extern.DrmInfo>} */
   const out = [];
@@ -438,14 +436,7 @@ shaka.dash.ContentProtection.convertElements_ = function(
 
       const initData = element.init || defaultInit;
       const info = createDrmInfo(keySystem, initData);
-      const licenseParsers = {
-        'com.widevine.alpha':
-          ContentProtection.getWidevineLicenseUrl,
-        'com.microsoft.playready':
-          ContentProtection.getPlayReadyLicenseURL,
-      };
-
-      const licenseParser = licenseParsers[keySystem];
+      const licenseParser = licenseUrlParsers.get(keySystem);
       if (licenseParser) {
         info.licenseServerUri = licenseParser(element);
       }
@@ -462,6 +453,19 @@ shaka.dash.ContentProtection.convertElements_ = function(
 
   return out;
 };
+
+
+/**
+ * A map of key system name to license server url parser.
+ *
+ * @const {!Map.<string, function(shaka.dash.ContentProtection.Element)>}
+ * @private
+ */
+shaka.dash.ContentProtection.licenseUrlParsers_ = new Map()
+    .set('com.widevine.alpha',
+         shaka.dash.ContentProtection.getWidevineLicenseUrl)
+    .set('com.microsoft.playready',
+         shaka.dash.ContentProtection.getPlayReadyLicenseUrl);
 
 
 /**

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -92,14 +92,14 @@ shaka.dash.ContentProtection.Element;
  * @private
  */
 shaka.dash.ContentProtection.defaultKeySystems_ = new Map()
-  .set('urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b',
-    'org.w3.clearkey')
-  .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
-    'com.widevine.alpha')
-  .set('urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
-    'com.microsoft.playready')
-  .set('urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb',
-    'com.adobe.primetime');
+    .set('urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b',
+         'org.w3.clearkey')
+    .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
+         'com.widevine.alpha')
+    .set('urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
+         'com.microsoft.playready')
+    .set('urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb',
+         'com.adobe.primetime');
 
 
 /**
@@ -107,7 +107,7 @@ shaka.dash.ContentProtection.defaultKeySystems_ = new Map()
  * @private
  */
 shaka.dash.ContentProtection.MP4Protection_ =
-  'urn:mpeg:dash:mp4protection:2011';
+    'urn:mpeg:dash:mp4protection:2011';
 
 
 /**
@@ -396,7 +396,7 @@ shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
   const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
   const bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
   const records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
-  const record = records.filter(function(record) {
+  const record = records.filter((record) => {
     return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
   }).pop();
 
@@ -405,9 +405,9 @@ shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
     const xmlDocument = parser.parseFromString(record.value, 'application/xml');
     const rootElement = xmlDocument.documentElement;
     return ContentProtection.getLaurl_(rootElement);
-  } else {
-    return '';
   }
+
+  return '';
 };
 
 

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -92,14 +92,14 @@ shaka.dash.ContentProtection.Element;
  * @private
  */
 shaka.dash.ContentProtection.defaultKeySystems_ = new Map()
-    .set('urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b',
-         'org.w3.clearkey')
-    .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
-         'com.widevine.alpha')
-    .set('urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
-         'com.microsoft.playready')
-    .set('urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb',
-         'com.adobe.primetime');
+  .set('urn:uuid:1077efec-c0b2-4d02-ace3-3c1e52e2fb4b',
+    'org.w3.clearkey')
+  .set('urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed',
+    'com.widevine.alpha')
+  .set('urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95',
+    'com.microsoft.playready')
+  .set('urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb',
+    'com.adobe.primetime');
 
 
 /**
@@ -107,7 +107,7 @@ shaka.dash.ContentProtection.defaultKeySystems_ = new Map()
  * @private
  */
 shaka.dash.ContentProtection.MP4Protection_ =
-    'urn:mpeg:dash:mp4protection:2011';
+  'urn:mpeg:dash:mp4protection:2011';
 
 
 /**
@@ -126,7 +126,7 @@ shaka.dash.ContentProtection.CencNamespaceUri_ = 'urn:mpeg:cenc:2013';
  * @return {shaka.dash.ContentProtection.Context}
  */
 shaka.dash.ContentProtection.parseFromAdaptationSet = function(
-    elems, callback, ignoreDrmInfo) {
+  elems, callback, ignoreDrmInfo) {
   const ContentProtection = shaka.dash.ContentProtection;
   const ManifestParserUtils = shaka.util.ManifestParserUtils;
   let parsed = ContentProtection.parseElements_(elems);
@@ -143,9 +143,9 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
 
   if (keyIds.size > 1) {
     throw new shaka.util.Error(
-        shaka.util.Error.Severity.CRITICAL,
-        shaka.util.Error.Category.MANIFEST,
-        shaka.util.Error.Code.DASH_CONFLICTING_KEY_IDS);
+      shaka.util.Error.Severity.CRITICAL,
+      shaka.util.Error.Category.MANIFEST,
+      shaka.util.Error.Code.DASH_CONFLICTING_KEY_IDS);
   }
 
   if (!ignoreDrmInfo) {
@@ -154,7 +154,7 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
     parsedNonCenc = parsed.filter(function(elem) {
       if (elem.schemeUri == ContentProtection.MP4Protection_) {
         goog.asserts.assert(!elem.init || elem.init.length,
-                            'Init data must be null or non-empty.');
+          'Init data must be null or non-empty.');
         defaultInit = elem.init || defaultInit;
         return false;
       } else {
@@ -164,7 +164,7 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
 
     if (parsedNonCenc.length) {
       drmInfos = ContentProtection.convertElements_(
-          defaultInit, callback, parsedNonCenc);
+        defaultInit, callback, parsedNonCenc);
 
       // If there are no drmInfos after parsing, then add a dummy entry.
       // This may be removed in parseKeyIds.
@@ -222,14 +222,14 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
  * @return {?string} The parsed key ID
  */
 shaka.dash.ContentProtection.parseFromRepresentation = function(
-    elems, callback, context, ignoreDrmInfo) {
+  elems, callback, context, ignoreDrmInfo) {
   const ContentProtection = shaka.dash.ContentProtection;
   let repContext = ContentProtection.parseFromAdaptationSet(
-      elems, callback, ignoreDrmInfo);
+    elems, callback, ignoreDrmInfo);
 
   if (context.firstRepresentation) {
     let asUnknown = context.drmInfos.length == 1 &&
-        !context.drmInfos[0].keySystem;
+      !context.drmInfos[0].keySystem;
     let asUnencrypted = context.drmInfos.length == 0;
     let repUnencrypted = repContext.drmInfos.length == 0;
 
@@ -252,9 +252,9 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
     // If we have filtered out all key-systems, throw an error.
     if (context.drmInfos.length == 0) {
       throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MANIFEST,
-          shaka.util.Error.Code.DASH_NO_COMMON_KEY_SYSTEM);
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.MANIFEST,
+        shaka.util.Error.Code.DASH_NO_COMMON_KEY_SYSTEM);
     }
   }
 
@@ -271,156 +271,138 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
  * @private
  */
 shaka.dash.ContentProtection.getWidevineLicenseUrl_ = function(element) {
-  var mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
-   if (mslaurlNode) {
+  let mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
+  if (mslaurlNode) {
     return mslaurlNode.getAttribute('licenseUrl') || '';
   }
-   return '';
+  return '';
 };
 
 
- /**
- * @typedef {{
- *   type: number,
- *   length: number,
- *   value: string
- * }}
- *
- * @description
- * The parsed result of a PlayReady object record.
- *
- * @property {number} type
- *   Type of data stored in the record.
- * @property {number} length
- *   Size of the record in bytes.
- * @property {string} value
- *   Record content.
- */
+/**
+* @typedef {{
+*   type: number,
+*   length: number,
+*   value: string
+* }}
+*
+* @description
+* The parsed result of a PlayReady object record.
+*
+* @property {number} type
+*   Type of data stored in the record.
+* @property {number} length
+*   Size of the record in bytes.
+* @property {string} value
+*   Record content.
+*/
 shaka.dash.ContentProtection.PlayReadyRecord;
- /**
- * @typedef {{
- *   length: number,
- *   recordCount: number,
- *   records: Array.<shaka.dash.ContentProtection.PlayReadyRecord>,
- * }}
- *
- * @description
- * The parsed result of a PlayReady object.
- *
- * @property {number} length
- *   Size of the PlayReady header object in bytes.
- * @property {number} recordCount
- *   Number of records in the PlayReady object.
- * @property {Array.<shaka.dash.ContentProtection.PlayReadyRecord>} records
- *   Contains a variable number of records that contain license acquisition information.
+
+/**
+ * Enum for PlayReady record types.
+ * @enum {number}
  */
-shaka.dash.ContentProtection.PlayReadyHeaderObject;
- /**
- * A map of PlayReady record types to description.
- *
- * @const {!Object.<number, string>}
- * @private
- */
-var PLAYREADY_RECORD_TYPES = {
-  0x0001 : 'RIGHTS_MANAGEMENT',
-  0x0002 : 'RESERVED',
-  0x0003 : 'EMBEDDED_LICENSE'
+shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
+  RIGHTS_MANAGEMENT: 0x001,
+  RESERVED: 0x002,
+  EMBEDDED_LICENSE: 0x003,
 };
 
 
- /**
- * @param {Uint16Array} recordData
- * @param {number} recordCount
- * @return {Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
- * @private
- */
-shaka.dash.ContentProtection.parseRecords_ = function(recordData, recordCount) {
-  var head = 0;
-  var records = [];
-  for (var i = 0; i < recordCount; i++) {
-    var recordRaw = recordData.subarray(head);
-     var type = recordRaw[0];
-    var length = recordRaw[1];
-    var offset = 2;
-    var charCount = length / 2;
-    var end = charCount + offset;
-     // subarray end is exclusive
-    var rawValue = recordRaw.subarray(offset, end);
-    var value = String.fromCharCode.apply(null, rawValue);
-     records.push({
+/**
+* @param {Uint16Array} recordData
+* @param {number} recordCount
+* @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+* @private
+*/
+shaka.dash.ContentProtection.parseMsProRecords_ = function(
+  recordData, recordCount) {
+  let head = 0;
+  let records = [];
+  for (let i = 0; i < recordCount; i++) {
+    let recordRaw = recordData.subarray(head);
+    let type = recordRaw[0];
+    let length = recordRaw[1];
+    let offset = 2;
+    let charCount = length / 2;
+    let end = charCount + offset;
+    // subarray end is exclusive
+    let rawValue = recordRaw.subarray(offset, end);
+    let value = shaka.util.StringUtils.fromUTF8(rawValue);
+    records.push({
       type: type,
       length: length,
-      value: value
+      value: value,
     });
-     head = end;
+    head = end;
   }
-   return records;
+  return records;
 };
 
 
- /**
- * Based off getLicenseServerURLFromInitData from dash.js
- * https://github.com/Dash-Industry-Forum/dash.js
- *
- * @param {Uint16Array} bytes
- * @return {shaka.dash.ContentProtection.PlayReadyHeaderObject}
- * @private
- */
-shaka.dash.ContentProtection.parsePro_ = function(bytes) {
-  var length = bytes[0] | bytes[1];
-  var recordCount = bytes[2];
-   var recordData = bytes.subarray(3);
-  var records = shaka.dash.ContentProtection.parseRecords_(recordData, recordCount);
-   return {
-    length: length,
-    recordCount: recordCount,
-    records: records
-  };
+/**
+* Based off getLicenseServerURLFromInitData from dash.js
+* https://github.com/Dash-Industry-Forum/dash.js
+*
+* @param {Uint16Array} bytes
+* @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+* @private
+*/
+shaka.dash.ContentProtection.parseMsPro_ = function(bytes) {
+  // let length = bytes[0] | bytes[1];
+  let recordCount = bytes[2];
+  let recordData = bytes.subarray(3);
+  const ContentProtection = shaka.dash.ContentProtection;
+  return ContentProtection.parseMsProRecords_(recordData, recordCount);
 };
 
 
- /**
- * @param {!Element} xml
- * @return {string}
- * @private
- */
+/**
+* @param {!Element} xml
+* @return {string}
+* @private
+*/
 shaka.dash.ContentProtection.getLaurl_ = function(xml) {
-  var laurlNode = xml.getElementsByTagName('LA_URL')[0];
+  let laurlNode = xml.getElementsByTagName('LA_URL')[0];
   if (laurlNode) {
-    var laurl = laurlNode.childNodes[0].nodeValue;
-     if (laurl) {
+    let laurl = laurlNode.childNodes[0].nodeValue;
+    if (laurl) {
       return laurl;
     }
   }
-   return '';
+  return '';
 };
 
 
- /**
- * Gets a PlayReady license URL from a content protection element
- * containing a PlayReady Header Object
- *
- * @param {shaka.dash.ContentProtection.Element} element
- * @return {string}
- * @private
- */
+/**
+* Gets a PlayReady license URL from a content protection element
+* containing a PlayReady Header Object
+*
+* @param {shaka.dash.ContentProtection.Element} element
+* @return {string}
+* @private
+*/
 shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_ = function(element) {
-  var proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
-   if (!proNode) {
+  let proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
+  if (!proNode) {
     return '';
   }
-   var bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
-  var parsedPro = shaka.dash.ContentProtection.parsePro_(new Uint16Array(bytes.buffer));
-   var records = parsedPro.records;
-  var parser = new DOMParser();
-  for (var i = 0; i < records.length; i++) {
-    var record = records[i];
-    if (PLAYREADY_RECORD_TYPES[record.type] === 'RIGHTS_MANAGEMENT') {
-      var xml = parser.parseFromString(record.value, 'application/xml').documentElement;
-       return shaka.dash.ContentProtection.getLaurl_(xml);
-    }
+  const ContentProtection = shaka.dash.ContentProtection;
+  const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
+  let bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
+  let records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
+  let record = records.filter(function(record) {
+    return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
+  }).pop();
+
+  if (record) {
+    let parser = new DOMParser();
+    let xmlDocument = parser.parseFromString(record.value, 'application/xml');
+    let rootElement = xmlDocument.documentElement;
+    return ContentProtection.getLaurl_(rootElement);
+  } else {
+    return '';
   }
-   return '';
 };
 
 
@@ -434,9 +416,10 @@ shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_ = function(element) {
  * @private
  */
 shaka.dash.ContentProtection.convertElements_ = function(
-    defaultInit, callback, elements) {
+  defaultInit, callback, elements) {
+  const ContentProtection = shaka.dash.ContentProtection;
   const createDrmInfo = shaka.util.ManifestParserUtils.createDrmInfo;
-  const defaultKeySystems = shaka.dash.ContentProtection.defaultKeySystems_;
+  const defaultKeySystems = ContentProtection.defaultKeySystems_;
 
   /** @type {!Array.<shaka.extern.DrmInfo>} */
   const out = [];
@@ -445,16 +428,21 @@ shaka.dash.ContentProtection.convertElements_ = function(
     const keySystem = defaultKeySystems.get(element.schemeUri);
     if (keySystem) {
       goog.asserts.assert(
-          !element.init || element.init.length,
-          'Init data must be null or non-empty.');
+        !element.init || element.init.length,
+        'Init data must be null or non-empty.');
 
       const initData = element.init || defaultInit;
       const info = createDrmInfo(keySystem, initData);
+      const licenseParsers = {
+        'com.widevine.alpha':
+          ContentProtection.getWidevineLicenseUrl_,
+        'com.microsoft.playready':
+          ContentProtection.getPlayReadyLicenseServerURL_,
+      };
 
-      if (keySystem === 'com.widevine.alpha') {
-        info.licenseServerUri = ContentProtection.getWidevineLicenseUrl_(element);
-      } else if (keySystem === 'com.microsoft.playready') {
-        info.licenseServerUri = ContentProtection.getPlayReadyLicenseServerURL_(element);
+      const licenseParser = licenseParsers[keySystem];
+      if (licenseParser) {
+        info.licenseServerUri = licenseParser(element);
       }
 
       out.push(info);
@@ -510,11 +498,11 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
   let keyId = shaka.util.XmlUtils.getAttributeNS(elem, NS, 'default_KID');
   /** @type {!Array.<string>} */
   const psshs = shaka.util.XmlUtils.findChildrenNS(elem, NS, 'pssh')
-                  .map(shaka.util.XmlUtils.getContents);
+    .map(shaka.util.XmlUtils.getContents);
 
   if (!schemeUri) {
     shaka.log.error('Missing required schemeIdUri attribute on',
-                    'ContentProtection element', elem);
+      'ContentProtection element', elem);
     return null;
   }
 
@@ -523,9 +511,9 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
     keyId = keyId.replace(/-/g, '').toLowerCase();
     if (keyId.includes(' ')) {
       throw new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.MANIFEST,
-          shaka.util.Error.Code.DASH_MULTIPLE_KEY_IDS_NOT_SUPPORTED);
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.MANIFEST,
+        shaka.util.Error.Code.DASH_MULTIPLE_KEY_IDS_NOT_SUPPORTED);
     }
   }
 
@@ -542,9 +530,9 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
     });
   } catch (e) {
     throw new shaka.util.Error(
-        shaka.util.Error.Severity.CRITICAL,
-        shaka.util.Error.Category.MANIFEST,
-        shaka.util.Error.Code.DASH_PSSH_BAD_ENCODING);
+      shaka.util.Error.Severity.CRITICAL,
+      shaka.util.Error.Category.MANIFEST,
+      shaka.util.Error.Code.DASH_PSSH_BAD_ENCODING);
   }
 
   return {

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -281,7 +281,7 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 /**
 * @typedef {{
 *   type: number,
-*   value: string
+*   value: !Uint16Array
 * }}
 *
 * @description
@@ -289,7 +289,7 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 *
 * @property {number} type
 *   Type of data stored in the record.
-* @property {string} value
+* @property {!Uint16Array} value
 *   Record content.
 */
 shaka.dash.ContentProtection.PlayReadyRecord;
@@ -321,24 +321,29 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
   let head = 0;
   let records = [];
 
-  while (head < recordData.length) {
-    const recordRaw = recordData.subarray(head);
-    if (recordRaw.length > 1) {
-      let offset = 0;
-      const type = recordRaw[offset++];
-      const byteLength = recordRaw[offset++];
-      // Convert from bytes to WORD length
-      const wordLength = byteLength / 2;
-      const end = wordLength + offset;
-      // subarray end is exclusive
-      const recordValue = recordRaw.subarray(offset, end);
-      const recordString = shaka.util.StringUtils.fromUTF8(recordValue);
-      records.push({
-        type: type,
-        value: recordString,
-      });
-      head = end;
-    }
+  while (head < recordData.length - 1) {
+    const type = recordData[head];
+    const byteLength = recordData[head + 1];
+
+    goog.asserts.assert(
+      (byteLength & 1) === 0,
+      'expected byteLength to be an even number');
+
+    // Convert from bytes to WORD length
+    const wordLength = byteLength / 2;
+    const end = wordLength + head + 2;
+
+    // subarray end is exclusive
+    // + 2 to skip over type and byteLength
+    const recordValue = recordData.subarray(head + 2, end);
+
+    // const recordString = shaka.util.StringUtils.fromUTF8(recordValue);
+    records.push({
+      type: type,
+      value: recordValue,
+    });
+
+    head = end;
   }
 
   return records;
@@ -346,6 +351,12 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 
 
 /**
+* Parses a Uint16Array for PlayReady Objects.  The data
+* should contain a 32-bit integer indicating the length of
+* the PRO in bytes.  Following that, a 16-bit integer for
+* the number of PlayReady Object Records in the PRO.  Lastly,
+* a byte array of the PRO Records themselves.
+*
 * PlayReady Object format: https://goo.gl/W8yAN4
 *
 * @param {!Uint16Array} data
@@ -356,7 +367,7 @@ shaka.dash.ContentProtection.parseMsPro_ = function(data) {
   let offset = 0;
   const view = new DataView(data.buffer);
   // First 4 bytes is the PRO length
-  const byteLength = view.getUint32(offset, true);
+  const byteLength = view.getUint32(offset, true /* littleEndian */);
   offset += 2;
   if (byteLength / 2 !== data.length) {
     // Malformed PRO
@@ -419,9 +430,9 @@ shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
   }
 
   const parser = new DOMParser();
-  const xmlDocument = parser.parseFromString(record.value, 'application/xml');
-  const rootElement = xmlDocument.documentElement;
-  return ContentProtection.getLaurl_(rootElement);
+  const xmlString = shaka.util.StringUtils.fromUTF8(record.value);
+  const xmlDocument = parser.parseFromString(xmlString, 'application/xml');
+  return ContentProtection.getLaurl_(xmlDocument.documentElement);
 };
 
 

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -268,9 +268,8 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
  *
  * @param {shaka.dash.ContentProtection.Element} element
  * @return {string}
- * @private
  */
-shaka.dash.ContentProtection.getWidevineLicenseUrl_ = function(element) {
+shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
   let mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
   if (mslaurlNode) {
     return mslaurlNode.getAttribute('licenseUrl') || '';
@@ -380,9 +379,8 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 *
 * @param {shaka.dash.ContentProtection.Element} element
 * @return {string}
-* @private
 */
-shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_ = function(element) {
+shaka.dash.ContentProtection.getPlayReadyLicenseServerURL = function(element) {
   let proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
   if (!proNode) {
     return '';
@@ -435,9 +433,9 @@ shaka.dash.ContentProtection.convertElements_ = function(
       const info = createDrmInfo(keySystem, initData);
       const licenseParsers = {
         'com.widevine.alpha':
-          ContentProtection.getWidevineLicenseUrl_,
+          ContentProtection.getWidevineLicenseUrl,
         'com.microsoft.playready':
-          ContentProtection.getPlayReadyLicenseServerURL_,
+          ContentProtection.getPlayReadyLicenseServerURL,
       };
 
       const licenseParser = licenseParsers[keySystem];

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -312,7 +312,7 @@ shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
 *
 * PlayReady Object Record format: https://goo.gl/FTcu46
 *
-* @param {Uint16Array} recordData
+* @param {!Uint16Array} recordData
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */
@@ -348,7 +348,7 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 /**
 * PlayReady Object format: https://goo.gl/W8yAN4
 *
-* @param {Uint16Array} data
+* @param {!Uint16Array} data
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -335,16 +335,11 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
       (byteLength & 1) === 0,
       'expected byteLength to be an even number');
 
-    // Convert from bytes to WORD length
-    const begin = byteOffset / 2;
-    const end = (byteLength + byteOffset) / 2;
-
-    // subarray end is exclusive
-    const recordValue = new Uint16Array(recordData).subarray(begin, end);
+    const recordValue = new Uint8Array(recordData, byteOffset, byteLength);
 
     records.push({
       type: type,
-      value: new Uint8Array(recordValue),
+      value: recordValue,
     });
 
     byteOffset += byteLength;
@@ -439,9 +434,8 @@ shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
     return '';
   }
 
-  const rootElement = shaka.util.XmlUtils.parseXml(
-    record.value.buffer, 'WRMHEADER');
-
+  const xml = shaka.util.StringUtils.fromUTF16(record.value, true);
+  const rootElement = shaka.util.XmlUtils.parseXmlString(xml, 'WRMHEADER');
   if (!rootElement) {
     return '';
   }

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -319,21 +319,23 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
   let head = 0;
   let records = [];
   for (let i = 0; i < recordCount; i++) {
-    let recordRaw = recordData.subarray(head);
-    let type = recordRaw[0];
-    let length = recordRaw[1];
-    let offset = 2;
-    let charCount = length / 2;
-    let end = charCount + offset;
-    // subarray end is exclusive
-    let rawValue = recordRaw.subarray(offset, end);
-    let value = shaka.util.StringUtils.fromUTF8(rawValue);
-    records.push({
-      type: type,
-      length: length,
-      value: value,
-    });
-    head = end;
+    const recordRaw = recordData.subarray(head);
+    if (recordRaw.length > 1) {
+      const type = recordRaw[0];
+      const length = recordRaw[1];
+      const offset = 2;
+      const charCount = length / 2;
+      const end = charCount + offset;
+      // subarray end is exclusive
+      const rawValue = recordRaw.subarray(offset, end);
+      const value = shaka.util.StringUtils.fromUTF8(rawValue);
+      records.push({
+        type: type,
+        length: length,
+        value: value,
+      });
+      head = end;
+    }
   }
   return records;
 };
@@ -348,9 +350,11 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 * @private
 */
 shaka.dash.ContentProtection.parseMsPro_ = function(bytes) {
-  // let length = bytes[0] | bytes[1];
-  let recordCount = bytes[2];
-  let recordData = bytes.subarray(3);
+  if (bytes.length < 2) {
+    return [];
+  }
+  const recordCount = bytes[2];
+  const recordData = bytes.subarray(3);
   const ContentProtection = shaka.dash.ContentProtection;
   return ContentProtection.parseMsProRecords_(recordData, recordCount);
 };
@@ -362,11 +366,14 @@ shaka.dash.ContentProtection.parseMsPro_ = function(bytes) {
 * @private
 */
 shaka.dash.ContentProtection.getLaurl_ = function(xml) {
-  let laurlNode = xml.getElementsByTagName('LA_URL')[0];
-  if (laurlNode) {
-    let laurl = laurlNode.childNodes[0].nodeValue;
-    if (laurl) {
-      return laurl;
+  const laurlNodes = xml.getElementsByTagName('LA_URL');
+  if (laurlNodes && laurlNodes.length > 0) {
+    const laurlNode = laurlNodes[0];
+    if (laurlNode.hasChildNodes()) {
+      const laurl = laurlNode.childNodes[0].nodeValue;
+      if (laurl) {
+        return laurl;
+      }
     }
   }
   return '';
@@ -380,7 +387,7 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 * @param {shaka.dash.ContentProtection.Element} element
 * @return {string}
 */
-shaka.dash.ContentProtection.getPlayReadyLicenseServerURL = function(element) {
+shaka.dash.ContentProtection.getPlayReadyLicenseURL = function(element) {
   let proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
   if (!proNode) {
     return '';
@@ -435,7 +442,7 @@ shaka.dash.ContentProtection.convertElements_ = function(
         'com.widevine.alpha':
           ContentProtection.getWidevineLicenseUrl,
         'com.microsoft.playready':
-          ContentProtection.getPlayReadyLicenseServerURL,
+          ContentProtection.getPlayReadyLicenseURL,
       };
 
       const licenseParser = licenseParsers[keySystem];

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -281,7 +281,6 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 /**
 * @typedef {{
 *   type: number,
-*   length: number,
 *   value: string
 * }}
 *
@@ -290,8 +289,6 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 *
 * @property {number} type
 *   Type of data stored in the record.
-* @property {number} length
-*   Size of the record in bytes.
 * @property {string} value
 *   Record content.
 */
@@ -309,70 +306,90 @@ shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
 
 
 /**
+* Parses a Uint16Array for PlayReady Object Records.
+* Each PRO Record is preceeded by it's PlayReady
+* Record type and length in bytes.
+*
+* PlayReady Object Record format: https://goo.gl/FTcu46
+*
 * @param {Uint16Array} recordData
-* @param {number} recordCount
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */
 shaka.dash.ContentProtection.parseMsProRecords_ = function(
-  recordData, recordCount) {
+  recordData) {
   let head = 0;
   let records = [];
-  for (let i = 0; i < recordCount; i++) {
+
+  while (head < recordData.length) {
     const recordRaw = recordData.subarray(head);
     if (recordRaw.length > 1) {
-      const type = recordRaw[0];
-      const length = recordRaw[1];
-      const offset = 2;
-      const charCount = length / 2;
-      const end = charCount + offset;
+      let offset = 0;
+      const type = recordRaw[offset++];
+      const byteLength = recordRaw[offset++];
+      // Convert from bytes to WORD length
+      const wordLength = byteLength / 2;
+      const end = wordLength + offset;
       // subarray end is exclusive
-      const rawValue = recordRaw.subarray(offset, end);
-      const value = shaka.util.StringUtils.fromUTF8(rawValue);
+      const recordValue = recordRaw.subarray(offset, end);
+      const recordString = shaka.util.StringUtils.fromUTF8(recordValue);
       records.push({
         type: type,
-        length: length,
-        value: value,
+        value: recordString,
       });
       head = end;
     }
   }
+
   return records;
 };
 
 
 /**
-* Based off getLicenseServerURLFromInitData from dash.js
-* https://github.com/Dash-Industry-Forum/dash.js
+* PlayReady Object format: https://goo.gl/W8yAN4
 *
-* @param {Uint16Array} bytes
+* @param {Uint16Array} data
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */
-shaka.dash.ContentProtection.parseMsPro_ = function(bytes) {
-  if (bytes.length < 2) {
+shaka.dash.ContentProtection.parseMsPro_ = function(data) {
+  let offset = 0;
+  const view = new DataView(data.buffer);
+  // First 4 bytes is the PRO length
+  const byteLength = view.getUint32(offset, true);
+  offset += 2;
+  if (byteLength / 2 !== data.length) {
+    // Malformed PRO
     return [];
   }
-  const recordCount = bytes[2];
-  const recordData = bytes.subarray(3);
+
+  // Skip PRO Record count
+  offset++;
+
+  // Rest of the data contains the PRO Records
+  const records = data.subarray(offset);
   const ContentProtection = shaka.dash.ContentProtection;
-  return ContentProtection.parseMsProRecords_(recordData, recordCount);
+  return ContentProtection.parseMsProRecords_(records);
 };
 
 
 /**
+* PlayReady Header format: https://goo.gl/dBzxNA
+*
 * @param {!Element} xml
 * @return {string}
 * @private
 */
 shaka.dash.ContentProtection.getLaurl_ = function(xml) {
-  // LA_URL element is optional and no more than one
-  // is allowed inside the DATA element. Only absolute URLs are allowed.
+  // LA_URL element is optional and no more than one is
+  // allowed inside the DATA element. Only absolute URLs are allowed.
+  // If the LA_URL element exists, it must not be empty.
   const laurlNode = xml.querySelector('DATA > LA_URL');
   if (laurlNode) {
     return laurlNode.textContent;
   }
 
+  // Not found
   return '';
 };
 

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -280,19 +280,19 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 
 
 /**
-* @typedef {{
-*   type: number,
-*   value: !Uint8Array
-* }}
-*
-* @description
-* The parsed result of a PlayReady object record.
-*
-* @property {number} type
-*   Type of data stored in the record.
-* @property {!Uint8Array} value
-*   Record content.
-*/
+ * @typedef {{
+ *   type: number,
+ *   value: !Uint8Array
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object record.
+ *
+ * @property {number} type
+ *   Type of data stored in the record.
+ * @property {!Uint8Array} value
+ *   Record content.
+ */
 shaka.dash.ContentProtection.PlayReadyRecord;
 
 /**
@@ -307,18 +307,18 @@ shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
 
 
 /**
-* Parses an Array buffer starting at byteOffset for
-* PlayReady Object Records. Each PRO Record is
-* preceeded by it's PlayReady Record type and length
-* in bytes.
-*
-* PlayReady Object Record format: https://goo.gl/FTcu46
-*
-* @param {!ArrayBuffer} recordData
-* @param {number} byteOffset
-* @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
-* @private
-*/
+ * Parses an Array buffer starting at byteOffset for
+ * PlayReady Object Records. Each PRO Record is
+ * preceeded by it's PlayReady Record type and length
+ * in bytes.
+ *
+ * PlayReady Object Record format: https://goo.gl/FTcu46
+ *
+ * @param {!ArrayBuffer} recordData
+ * @param {number} byteOffset
+ * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+ * @private
+ */
 shaka.dash.ContentProtection.parseMsProRecords_ = function(
   recordData, byteOffset) {
   const records = [];
@@ -355,18 +355,18 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 
 
 /**
-* Parses an ArrayBuffer for PlayReady Objects.  The data
-* should contain a 32-bit integer indicating the length of
-* the PRO in bytes.  Following that, a 16-bit integer for
-* the number of PlayReady Object Records in the PRO.  Lastly,
-* a byte array of the PRO Records themselves.
-*
-* PlayReady Object format: https://goo.gl/W8yAN4
-*
-* @param {!ArrayBuffer} data
-* @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
-* @private
-*/
+ * Parses an ArrayBuffer for PlayReady Objects.  The data
+ * should contain a 32-bit integer indicating the length of
+ * the PRO in bytes.  Following that, a 16-bit integer for
+ * the number of PlayReady Object Records in the PRO.  Lastly,
+ * a byte array of the PRO Records themselves.
+ *
+ * PlayReady Object format: https://goo.gl/W8yAN4
+ *
+ * @param {!ArrayBuffer} data
+ * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+ * @private
+ */
 shaka.dash.ContentProtection.parseMsPro_ = function(data) {
   let byteOffset = 0;
   const view = new DataView(data);
@@ -391,12 +391,12 @@ shaka.dash.ContentProtection.parseMsPro_ = function(data) {
 
 
 /**
-* PlayReady Header format: https://goo.gl/dBzxNA
-*
-* @param {!Element} xml
-* @return {string}
-* @private
-*/
+ * PlayReady Header format: https://goo.gl/dBzxNA
+ *
+ * @param {!Element} xml
+ * @return {string}
+ * @private
+ */
 shaka.dash.ContentProtection.getLaurl_ = function(xml) {
   // LA_URL element is optional and no more than one is
   // allowed inside the DATA element. Only absolute URLs are allowed.
@@ -412,12 +412,12 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 
 
 /**
-* Gets a PlayReady license URL from a content protection element
-* containing a PlayReady Header Object
-*
-* @param {shaka.dash.ContentProtection.Element} element
-* @return {string}
-*/
+ * Gets a PlayReady license URL from a content protection element
+ * containing a PlayReady Header Object
+ *
+ * @param {shaka.dash.ContentProtection.Element} element
+ * @return {string}
+ */
 shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
   const proNode = shaka.util.XmlUtils.findChildNS(
     element.node, 'urn:microsoft:playready', 'pro');

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -282,7 +282,7 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 /**
 * @typedef {{
 *   type: number,
-*   value: !Uint16Array
+*   value: !Uint8Array
 * }}
 *
 * @description
@@ -290,7 +290,7 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 *
 * @property {number} type
 *   Type of data stored in the record.
-* @property {!ArrayBuffer} value
+* @property {!Uint8Array} value
 *   Record content.
 */
 shaka.dash.ContentProtection.PlayReadyRecord;
@@ -321,7 +321,7 @@ shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
 */
 shaka.dash.ContentProtection.parseMsProRecords_ = function(
   recordData, byteOffset) {
-  let records = [];
+  const records = [];
   const view = new DataView(recordData);
 
   while (byteOffset < recordData.byteLength - 1) {
@@ -344,7 +344,7 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 
     records.push({
       type: type,
-      value: recordValue,
+      value: new Uint8Array(recordValue),
     });
 
     byteOffset += byteLength;
@@ -421,11 +421,14 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
   const proNode = shaka.util.XmlUtils.findChildNS(
     element.node, 'urn:microsoft:playready', 'pro');
+
   if (!proNode) {
     return '';
   }
+
   const ContentProtection = shaka.dash.ContentProtection;
   const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
+
   const bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
   const records = ContentProtection.parseMsPro_(bytes.buffer);
   const record = records.filter((record) => {
@@ -436,10 +439,14 @@ shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
     return '';
   }
 
-  const parser = new DOMParser();
-  const xmlString = shaka.util.StringUtils.fromUTF8(record.value);
-  const xmlDocument = parser.parseFromString(xmlString, 'application/xml');
-  return ContentProtection.getLaurl_(xmlDocument.documentElement);
+  const rootElement = shaka.util.XmlUtils.parseXml(
+    record.value.buffer, 'WRMHEADER');
+
+  if (!rootElement) {
+    return '';
+  }
+
+  return ContentProtection.getLaurl_(rootElement);
 };
 
 

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -126,7 +126,7 @@ shaka.dash.ContentProtection.CencNamespaceUri_ = 'urn:mpeg:cenc:2013';
  * @return {shaka.dash.ContentProtection.Context}
  */
 shaka.dash.ContentProtection.parseFromAdaptationSet = function(
-  elems, callback, ignoreDrmInfo) {
+    elems, callback, ignoreDrmInfo) {
   const ContentProtection = shaka.dash.ContentProtection;
   const ManifestParserUtils = shaka.util.ManifestParserUtils;
   let parsed = ContentProtection.parseElements_(elems);
@@ -143,9 +143,9 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
 
   if (keyIds.size > 1) {
     throw new shaka.util.Error(
-      shaka.util.Error.Severity.CRITICAL,
-      shaka.util.Error.Category.MANIFEST,
-      shaka.util.Error.Code.DASH_CONFLICTING_KEY_IDS);
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.MANIFEST,
+        shaka.util.Error.Code.DASH_CONFLICTING_KEY_IDS);
   }
 
   if (!ignoreDrmInfo) {
@@ -154,7 +154,7 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
     parsedNonCenc = parsed.filter(function(elem) {
       if (elem.schemeUri == ContentProtection.MP4Protection_) {
         goog.asserts.assert(!elem.init || elem.init.length,
-          'Init data must be null or non-empty.');
+                            'Init data must be null or non-empty.');
         defaultInit = elem.init || defaultInit;
         return false;
       } else {
@@ -164,7 +164,7 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
 
     if (parsedNonCenc.length) {
       drmInfos = ContentProtection.convertElements_(
-        defaultInit, callback, parsedNonCenc);
+          defaultInit, callback, parsedNonCenc);
 
       // If there are no drmInfos after parsing, then add a dummy entry.
       // This may be removed in parseKeyIds.
@@ -222,14 +222,14 @@ shaka.dash.ContentProtection.parseFromAdaptationSet = function(
  * @return {?string} The parsed key ID
  */
 shaka.dash.ContentProtection.parseFromRepresentation = function(
-  elems, callback, context, ignoreDrmInfo) {
+    elems, callback, context, ignoreDrmInfo) {
   const ContentProtection = shaka.dash.ContentProtection;
   let repContext = ContentProtection.parseFromAdaptationSet(
-    elems, callback, ignoreDrmInfo);
+      elems, callback, ignoreDrmInfo);
 
   if (context.firstRepresentation) {
     let asUnknown = context.drmInfos.length == 1 &&
-      !context.drmInfos[0].keySystem;
+        !context.drmInfos[0].keySystem;
     let asUnencrypted = context.drmInfos.length == 0;
     let repUnencrypted = repContext.drmInfos.length == 0;
 
@@ -252,9 +252,9 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
     // If we have filtered out all key-systems, throw an error.
     if (context.drmInfos.length == 0) {
       throw new shaka.util.Error(
-        shaka.util.Error.Severity.CRITICAL,
-        shaka.util.Error.Category.MANIFEST,
-        shaka.util.Error.Code.DASH_NO_COMMON_KEY_SYSTEM);
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.MANIFEST,
+          shaka.util.Error.Code.DASH_NO_COMMON_KEY_SYSTEM);
     }
   }
 
@@ -433,8 +433,8 @@ shaka.dash.ContentProtection.convertElements_ = function(
     const keySystem = defaultKeySystems.get(element.schemeUri);
     if (keySystem) {
       goog.asserts.assert(
-        !element.init || element.init.length,
-        'Init data must be null or non-empty.');
+          !element.init || element.init.length,
+          'Init data must be null or non-empty.');
 
       const initData = element.init || defaultInit;
       const info = createDrmInfo(keySystem, initData);
@@ -503,11 +503,11 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
   let keyId = shaka.util.XmlUtils.getAttributeNS(elem, NS, 'default_KID');
   /** @type {!Array.<string>} */
   const psshs = shaka.util.XmlUtils.findChildrenNS(elem, NS, 'pssh')
-    .map(shaka.util.XmlUtils.getContents);
+                  .map(shaka.util.XmlUtils.getContents);
 
   if (!schemeUri) {
     shaka.log.error('Missing required schemeIdUri attribute on',
-      'ContentProtection element', elem);
+                    'ContentProtection element', elem);
     return null;
   }
 
@@ -516,9 +516,9 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
     keyId = keyId.replace(/-/g, '').toLowerCase();
     if (keyId.includes(' ')) {
       throw new shaka.util.Error(
-        shaka.util.Error.Severity.CRITICAL,
-        shaka.util.Error.Category.MANIFEST,
-        shaka.util.Error.Code.DASH_MULTIPLE_KEY_IDS_NOT_SUPPORTED);
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.MANIFEST,
+          shaka.util.Error.Code.DASH_MULTIPLE_KEY_IDS_NOT_SUPPORTED);
     }
   }
 
@@ -535,9 +535,9 @@ shaka.dash.ContentProtection.parseElement_ = function(elem) {
     });
   } catch (e) {
     throw new shaka.util.Error(
-      shaka.util.Error.Severity.CRITICAL,
-      shaka.util.Error.Category.MANIFEST,
-      shaka.util.Error.Code.DASH_PSSH_BAD_ENCODING);
+        shaka.util.Error.Severity.CRITICAL,
+        shaka.util.Error.Category.MANIFEST,
+        shaka.util.Error.Code.DASH_PSSH_BAD_ENCODING);
   }
 
   return {

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -270,7 +270,8 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
  * @return {string}
  */
 shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
-  const mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
+  const mslaurlNode = shaka.util.XmlUtils.findChildNS(
+    element.node, 'urn:microsoft', 'laurl');
   if (mslaurlNode) {
     return mslaurlNode.getAttribute('licenseUrl') || '';
   }
@@ -289,7 +290,7 @@ shaka.dash.ContentProtection.getWidevineLicenseUrl = function(element) {
 *
 * @property {number} type
 *   Type of data stored in the record.
-* @property {!Uint16Array} value
+* @property {!ArrayBuffer} value
 *   Record content.
 */
 shaka.dash.ContentProtection.PlayReadyRecord;
@@ -306,44 +307,47 @@ shaka.dash.ContentProtection.PLAYREADY_RECORD_TYPES = {
 
 
 /**
-* Parses a Uint16Array for PlayReady Object Records.
-* Each PRO Record is preceeded by it's PlayReady
-* Record type and length in bytes.
+* Parses an Array buffer starting at byteOffset for
+* PlayReady Object Records. Each PRO Record is
+* preceeded by it's PlayReady Record type and length
+* in bytes.
 *
 * PlayReady Object Record format: https://goo.gl/FTcu46
 *
-* @param {!Uint16Array} recordData
+* @param {!ArrayBuffer} recordData
+* @param {number} byteOffset
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */
 shaka.dash.ContentProtection.parseMsProRecords_ = function(
-  recordData) {
-  let head = 0;
+  recordData, byteOffset) {
   let records = [];
+  const view = new DataView(recordData);
 
-  while (head < recordData.length - 1) {
-    const type = recordData[head];
-    const byteLength = recordData[head + 1];
+  while (byteOffset < recordData.byteLength - 1) {
+    const type = view.getUint16(byteOffset, true);
+    byteOffset += 2;
+
+    const byteLength = view.getUint16(byteOffset, true);
+    byteOffset += 2;
 
     goog.asserts.assert(
       (byteLength & 1) === 0,
       'expected byteLength to be an even number');
 
     // Convert from bytes to WORD length
-    const wordLength = byteLength / 2;
-    const end = wordLength + head + 2;
+    const begin = byteOffset / 2;
+    const end = (byteLength + byteOffset) / 2;
 
     // subarray end is exclusive
-    // + 2 to skip over type and byteLength
-    const recordValue = recordData.subarray(head + 2, end);
+    const recordValue = new Uint16Array(recordData).subarray(begin, end);
 
-    // const recordString = shaka.util.StringUtils.fromUTF8(recordValue);
     records.push({
       type: type,
       value: recordValue,
     });
 
-    head = end;
+    byteOffset += byteLength;
   }
 
   return records;
@@ -351,7 +355,7 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 
 
 /**
-* Parses a Uint16Array for PlayReady Objects.  The data
+* Parses an ArrayBuffer for PlayReady Objects.  The data
 * should contain a 32-bit integer indicating the length of
 * the PRO in bytes.  Following that, a 16-bit integer for
 * the number of PlayReady Object Records in the PRO.  Lastly,
@@ -359,28 +363,30 @@ shaka.dash.ContentProtection.parseMsProRecords_ = function(
 *
 * PlayReady Object format: https://goo.gl/W8yAN4
 *
-* @param {!Uint16Array} data
+* @param {!ArrayBuffer} data
 * @return {!Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
 * @private
 */
 shaka.dash.ContentProtection.parseMsPro_ = function(data) {
-  let offset = 0;
-  const view = new DataView(data.buffer);
-  // First 4 bytes is the PRO length
-  const byteLength = view.getUint32(offset, true /* littleEndian */);
-  offset += 2;
-  if (byteLength / 2 !== data.length) {
+  let byteOffset = 0;
+  const view = new DataView(data);
+
+  // First 4 bytes is the PRO length (DWORD)
+  const byteLength = view.getUint32(byteOffset, true /* littleEndian */);
+  byteOffset += 4;
+
+  if (byteLength !== data.byteLength) {
     // Malformed PRO
+    shaka.log.warning('PlayReady Object with invalid length encountered.');
     return [];
   }
 
-  // Skip PRO Record count
-  offset++;
+  // Skip PRO Record count (WORD)
+  byteOffset += 2;
 
   // Rest of the data contains the PRO Records
-  const records = data.subarray(offset);
   const ContentProtection = shaka.dash.ContentProtection;
-  return ContentProtection.parseMsProRecords_(records);
+  return ContentProtection.parseMsProRecords_(data, byteOffset);
 };
 
 
@@ -413,14 +419,15 @@ shaka.dash.ContentProtection.getLaurl_ = function(xml) {
 * @return {string}
 */
 shaka.dash.ContentProtection.getPlayReadyLicenseUrl = function(element) {
-  const proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
+  const proNode = shaka.util.XmlUtils.findChildNS(
+    element.node, 'urn:microsoft:playready', 'pro');
   if (!proNode) {
     return '';
   }
   const ContentProtection = shaka.dash.ContentProtection;
   const PLAYREADY_RECORD_TYPES = ContentProtection.PLAYREADY_RECORD_TYPES;
   const bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
-  const records = ContentProtection.parseMsPro_(new Uint16Array(bytes.buffer));
+  const records = ContentProtection.parseMsPro_(bytes.buffer);
   const record = records.filter((record) => {
     return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
   })[0];

--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -263,6 +263,168 @@ shaka.dash.ContentProtection.parseFromRepresentation = function(
 
 
 /**
+ * Gets a Widevine license URL from a content protection element
+ * containing a custom `ms:laurl` element
+ *
+ * @param {shaka.dash.ContentProtection.Element} element
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getWidevineLicenseUrl_ = function(element) {
+  var mslaurlNode = shaka.util.XmlUtils.findChild(element.node, 'ms:laurl');
+   if (mslaurlNode) {
+    return mslaurlNode.getAttribute('licenseUrl') || '';
+  }
+   return '';
+};
+
+
+ /**
+ * @typedef {{
+ *   type: number,
+ *   length: number,
+ *   value: string
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object record.
+ *
+ * @property {number} type
+ *   Type of data stored in the record.
+ * @property {number} length
+ *   Size of the record in bytes.
+ * @property {string} value
+ *   Record content.
+ */
+shaka.dash.ContentProtection.PlayReadyRecord;
+ /**
+ * @typedef {{
+ *   length: number,
+ *   recordCount: number,
+ *   records: Array.<shaka.dash.ContentProtection.PlayReadyRecord>,
+ * }}
+ *
+ * @description
+ * The parsed result of a PlayReady object.
+ *
+ * @property {number} length
+ *   Size of the PlayReady header object in bytes.
+ * @property {number} recordCount
+ *   Number of records in the PlayReady object.
+ * @property {Array.<shaka.dash.ContentProtection.PlayReadyRecord>} records
+ *   Contains a variable number of records that contain license acquisition information.
+ */
+shaka.dash.ContentProtection.PlayReadyHeaderObject;
+ /**
+ * A map of PlayReady record types to description.
+ *
+ * @const {!Object.<number, string>}
+ * @private
+ */
+var PLAYREADY_RECORD_TYPES = {
+  0x0001 : 'RIGHTS_MANAGEMENT',
+  0x0002 : 'RESERVED',
+  0x0003 : 'EMBEDDED_LICENSE'
+};
+
+
+ /**
+ * @param {Uint16Array} recordData
+ * @param {number} recordCount
+ * @return {Array.<shaka.dash.ContentProtection.PlayReadyRecord>}
+ * @private
+ */
+shaka.dash.ContentProtection.parseRecords_ = function(recordData, recordCount) {
+  var head = 0;
+  var records = [];
+  for (var i = 0; i < recordCount; i++) {
+    var recordRaw = recordData.subarray(head);
+     var type = recordRaw[0];
+    var length = recordRaw[1];
+    var offset = 2;
+    var charCount = length / 2;
+    var end = charCount + offset;
+     // subarray end is exclusive
+    var rawValue = recordRaw.subarray(offset, end);
+    var value = String.fromCharCode.apply(null, rawValue);
+     records.push({
+      type: type,
+      length: length,
+      value: value
+    });
+     head = end;
+  }
+   return records;
+};
+
+
+ /**
+ * Based off getLicenseServerURLFromInitData from dash.js
+ * https://github.com/Dash-Industry-Forum/dash.js
+ *
+ * @param {Uint16Array} bytes
+ * @return {shaka.dash.ContentProtection.PlayReadyHeaderObject}
+ * @private
+ */
+shaka.dash.ContentProtection.parsePro_ = function(bytes) {
+  var length = bytes[0] | bytes[1];
+  var recordCount = bytes[2];
+   var recordData = bytes.subarray(3);
+  var records = shaka.dash.ContentProtection.parseRecords_(recordData, recordCount);
+   return {
+    length: length,
+    recordCount: recordCount,
+    records: records
+  };
+};
+
+
+ /**
+ * @param {!Element} xml
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getLaurl_ = function(xml) {
+  var laurlNode = xml.getElementsByTagName('LA_URL')[0];
+  if (laurlNode) {
+    var laurl = laurlNode.childNodes[0].nodeValue;
+     if (laurl) {
+      return laurl;
+    }
+  }
+   return '';
+};
+
+
+ /**
+ * Gets a PlayReady license URL from a content protection element
+ * containing a PlayReady Header Object
+ *
+ * @param {shaka.dash.ContentProtection.Element} element
+ * @return {string}
+ * @private
+ */
+shaka.dash.ContentProtection.getPlayReadyLicenseServerURL_ = function(element) {
+  var proNode = shaka.util.XmlUtils.findChild(element.node, 'mspr:pro');
+   if (!proNode) {
+    return '';
+  }
+   var bytes = shaka.util.Uint8ArrayUtils.fromBase64(proNode.textContent);
+  var parsedPro = shaka.dash.ContentProtection.parsePro_(new Uint16Array(bytes.buffer));
+   var records = parsedPro.records;
+  var parser = new DOMParser();
+  for (var i = 0; i < records.length; i++) {
+    var record = records[i];
+    if (PLAYREADY_RECORD_TYPES[record.type] === 'RIGHTS_MANAGEMENT') {
+      var xml = parser.parseFromString(record.value, 'application/xml').documentElement;
+       return shaka.dash.ContentProtection.getLaurl_(xml);
+    }
+  }
+   return '';
+};
+
+
+/**
  * Creates DrmInfo objects from the given element.
  *
  * @param {Array.<shaka.extern.InitDataOverride>} defaultInit
@@ -288,6 +450,13 @@ shaka.dash.ContentProtection.convertElements_ = function(
 
       const initData = element.init || defaultInit;
       const info = createDrmInfo(keySystem, initData);
+
+      if (keySystem === 'com.widevine.alpha') {
+        info.licenseServerUri = ContentProtection.getWidevineLicenseUrl_(element);
+      } else if (keySystem === 'com.microsoft.playready') {
+        info.licenseServerUri = ContentProtection.getPlayReadyLicenseServerURL_(element);
+      }
+
       out.push(info);
     } else {
       goog.asserts.assert(callback, 'ContentProtection callback is required');

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -435,7 +435,7 @@ shaka.dash.DashParser.prototype.parseManifest_ =
   const Error = shaka.util.Error;
   const MpdUtils = shaka.dash.MpdUtils;
 
-  let mpd = MpdUtils.parseXml(data, 'MPD');
+  let mpd = shaka.util.XmlUtils.parseXml(data, 'MPD');
   if (!mpd) {
     throw new Error(
         Error.Severity.CRITICAL, Error.Category.MANIFEST,

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -24,7 +24,6 @@ goog.require('shaka.util.AbortableOperation');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Functional');
 goog.require('shaka.util.ManifestParserUtils');
-goog.require('shaka.util.StringUtils');
 goog.require('shaka.util.XmlUtils');
 
 
@@ -434,36 +433,6 @@ shaka.dash.MpdUtils.inheritChild = function(context, callback, child) {
 
 
 /**
- * Parse some UTF8 data and return the resulting root element if
- * it was valid XML.
- * @param {ArrayBuffer} data
- * @param {string} expectedRootElemName
- * @return {Element|undefined}
- */
-shaka.dash.MpdUtils.parseXml = function(data, expectedRootElemName) {
-  let parser = new DOMParser();
-  let rootElem;
-  let xml;
-  try {
-    let string = shaka.util.StringUtils.fromUTF8(data);
-    xml = parser.parseFromString(string, 'text/xml');
-  } catch (exception) {}
-  if (xml) {
-    // The top-level element in the loaded xml should have the
-    // same type as the element linking.
-    if (xml.documentElement.tagName == expectedRootElemName) {
-      rootElem = xml.documentElement;
-    }
-  }
-  if (rootElem && rootElem.getElementsByTagName('parsererror').length > 0) {
-    return null;
-  }  // It had a parser error in it.
-
-  return rootElem;
-};
-
-
-/**
  * Follow the xlink link contained in the given element.
  * It also strips the xlink properties off of the element,
  * even if the process fails.
@@ -536,7 +505,7 @@ shaka.dash.MpdUtils.handleXlinkInElement_ =
   return networkOperation.chain((response) => {
     // This only supports the case where the loaded xml has a single
     // top-level element.  If there are multiple roots, it will be rejected.
-    let rootElem = MpdUtils.parseXml(response.data, element.tagName);
+    let rootElem = shaka.util.XmlUtils.parseXml(response.data, element.tagName);
     if (!rootElem) {
       // It was not valid XML.
       return shaka.util.AbortableOperation.failed(new Error(

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -308,19 +308,18 @@ shaka.util.XmlUtils.evalDivision = function(exprString) {
 
 
 /**
- * Parse some UTF8 data and return the resulting root element if
+ * Parse a string and return the resulting root element if
  * it was valid XML.
- * @param {ArrayBuffer} data
+ * @param {string} xmlString
  * @param {string} expectedRootElemName
  * @return {Element|undefined}
  */
-shaka.util.XmlUtils.parseXml = function(data, expectedRootElemName) {
+shaka.util.XmlUtils.parseXmlString = function(xmlString, expectedRootElemName) {
   const parser = new DOMParser();
   let rootElem;
   let xml;
   try {
-    const string = shaka.util.StringUtils.fromUTF8(data);
-    xml = parser.parseFromString(string, 'text/xml');
+    xml = parser.parseFromString(xmlString, 'text/xml');
   } catch (exception) {}
   if (xml) {
     // The top-level element in the loaded xml should have the
@@ -334,4 +333,19 @@ shaka.util.XmlUtils.parseXml = function(data, expectedRootElemName) {
   }  // It had a parser error in it.
 
   return rootElem;
+};
+
+
+/**
+ * Parse some UTF8 data and return the resulting root element if
+ * it was valid XML.
+ * @param {ArrayBuffer} data
+ * @param {string} expectedRootElemName
+ * @return {Element|undefined}
+ */
+shaka.util.XmlUtils.parseXml = function(data, expectedRootElemName) {
+  try {
+    const string = shaka.util.StringUtils.fromUTF8(data);
+    return shaka.util.XmlUtils.parseXmlString(string, expectedRootElemName);
+  } catch (exception) {}
 };

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -18,6 +18,7 @@
 goog.provide('shaka.util.XmlUtils');
 
 goog.require('shaka.log');
+goog.require('shaka.util.StringUtils');
 
 
 /**
@@ -303,4 +304,34 @@ shaka.util.XmlUtils.evalDivision = function(exprString) {
     n = Number(exprString);
   }
   return !isNaN(n) ? n : null;
+};
+
+
+/**
+ * Parse some UTF8 data and return the resulting root element if
+ * it was valid XML.
+ * @param {ArrayBuffer} data
+ * @param {string} expectedRootElemName
+ * @return {Element|undefined}
+ */
+shaka.util.XmlUtils.parseXml = function(data, expectedRootElemName) {
+  const parser = new DOMParser();
+  let rootElem;
+  let xml;
+  try {
+    const string = shaka.util.StringUtils.fromUTF8(data);
+    xml = parser.parseFromString(string, 'text/xml');
+  } catch (exception) {}
+  if (xml) {
+    // The top-level element in the loaded xml should have the
+    // same type as the element linking.
+    if (xml.documentElement.tagName == expectedRootElemName) {
+      rootElem = xml.documentElement;
+    }
+  }
+  if (rootElem && rootElem.getElementsByTagName('parsererror').length > 0) {
+    return null;
+  }  // It had a parser error in it.
+
+  return rootElem;
 };

--- a/lib/util/xml_utils.js
+++ b/lib/util/xml_utils.js
@@ -44,6 +44,24 @@ shaka.util.XmlUtils.findChild = function(elem, name) {
 
 
 /**
+ * Finds a namespace-qualified child XML element.
+ * @param {!Node} elem The parent XML element.
+ * @param {string} ns The child XML element's namespace URI.
+ * @param {string} name The child XML element's local name.
+ * @return {Element} The child XML element, or null if a child XML element does
+ *   not exist with the given tag name OR if there exists more than one
+ *   child XML element with the given tag name.
+ */
+shaka.util.XmlUtils.findChildNS = function(elem, ns, name) {
+  let children = shaka.util.XmlUtils.findChildrenNS(elem, ns, name);
+  if (children.length != 1) {
+    return null;
+  }
+  return children[0];
+};
+
+
+/**
  * Finds child XML elements.
  * @param {!Node} elem The parent XML element.
  * @param {string} name The child XML element's tag name.

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -741,7 +741,7 @@ describe('DashParser ContentProtection', function() {
     await Dash.testFails(source, expected);
   });
 });
-
+/*
 describe('In-manifest PlayReady and Widevine', function() {
   let ContentProtection = shaka.dash.ContentProtection;
   let strToXml = function(str) {
@@ -752,7 +752,8 @@ describe('In-manifest PlayReady and Widevine', function() {
    describe('getWidevineLicenseUrl_', function() {
     it('valid ms:laurl node', function() {
       let input = {
-        node: strToXml('<test><ms:laurl licenseUrl="www.example.com"></ms:laurl></test>')
+        node: strToXml(
+          '<test><ms:laurl licenseUrl="www.example.com"></ms:laurl></test>'),
       };
       let actual = ContentProtection.getWidevineLicenseUrl_(input);
       let expected = 'www.example.com';
@@ -760,14 +761,14 @@ describe('In-manifest PlayReady and Widevine', function() {
     });
 
      it('ms:laurl without license url', function() {
-      let input = { node: strToXml('<test><ms:laurl></ms:laurl></test>') };
+      let input = {node: strToXml('<test><ms:laurl></ms:laurl></test>')};
       let actual = ContentProtection.getWidevineLicenseUrl_(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });
 
      it('no ms:laurl node', function() {
-      let input = { node: strToXml('<test></test>') };
+      let input = {node: strToXml('<test></test>')};
       let actual = ContentProtection.getWidevineLicenseUrl_(input);
       let expected = '';
       expect(actual).toEqual(expected);
@@ -782,22 +783,22 @@ describe('In-manifest PlayReady and Widevine', function() {
         // Size
         2,
         // Value
-        116
+        116,
       ]);
       let actual = ContentProtection.parseRecords_(input, 1);
-      let expected = [{ type: 1, length: 2, value: 't' }];
+      let expected = [{type: 1, length: 2, value: 't'}];
       expect(actual).toEqual(expected);
     });
 
      it('multiple records', function() {
       let input = Uint16Array.from([
         1, 2, 116,
-        2, 2, 120
+        2, 2, 120,
       ]);
       let actual = ContentProtection.parseRecords_(input, 2);
       let expected = [
-        { type: 1, length: 2, value: 't' },
-        { type: 2, length: 2, value: 'x' }
+        {type: 1, length: 2, value: 't'},
+        {type: 2, length: 2, value: 'x'},
       ];
       expect(actual).toEqual(expected);
     });
@@ -816,12 +817,12 @@ describe('In-manifest PlayReady and Widevine', function() {
         // Size
         2,
         // Value
-        116
+        116,
       ]);
       let actual = ContentProtection.parsePro_(input);
       let expected = {
         length: 12, recordCount: 1,
-        records: [{ type: 1, length: 2, value: 't' }]
+        records: [{type: 1, length: 2, value: 't'}],
       };
       expect(actual).toEqual(expected);
     });
@@ -833,15 +834,15 @@ describe('In-manifest PlayReady and Widevine', function() {
          // Record
         1, 2, 116,
          // Record
-        2, 2, 120
+        2, 2, 120,
       ]);
       let actual = ContentProtection.parsePro_(input);
       let expected = {
         length: 18, recordCount: 2,
         records: [
-          { type: 1, length: 2, value: 't' },
-          { type: 2, length: 2, value: 'x' }
-        ]
+          {type: 1, length: 2, value: 't'},
+          {type: 2, length: 2, value: 'x'},
+        ],
       };
       expect(actual).toEqual(expected);
     });
@@ -852,7 +853,7 @@ describe('In-manifest PlayReady and Widevine', function() {
         6, 0, 0,
       ]);
       let actual = ContentProtection.parsePro_(input);
-      let expected = { length: 6, recordCount: 0, records: [] };
+      let expected = {length: 6, recordCount: 0, records: []};
       expect(actual).toEqual(expected);
     });
   });
@@ -890,9 +891,11 @@ describe('In-manifest PlayReady and Widevine', function() {
         laurl.length * 2,
         // value
       ].concat(laurlCodes));
-       let encodedPrObject = btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
+       let encodedPrObject =
+        btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
        let input = {
-        node: strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>')
+        node:
+          strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>'),
       };
        let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
       let expected = 'www.example.com';
@@ -901,11 +904,11 @@ describe('In-manifest PlayReady and Widevine', function() {
 
      it('no mspro', function() {
       let input = {
-        node: strToXml('<test></test>')
+        node: strToXml('<test></test>'),
       };
       let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });
   });
-});
+});*/

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -741,3 +741,171 @@ describe('DashParser ContentProtection', function() {
     await Dash.testFails(source, expected);
   });
 });
+
+describe('In-manifest PlayReady and Widevine', function() {
+  let ContentProtection = shaka.dash.ContentProtection;
+  let strToXml = function(str) {
+    let parser = new DOMParser();
+     return parser.parseFromString(str, 'application/xml').documentElement;
+  };
+
+   describe('getWidevineLicenseUrl_', function() {
+    it('valid ms:laurl node', function() {
+      let input = {
+        node: strToXml('<test><ms:laurl licenseUrl="www.example.com"></ms:laurl></test>')
+      };
+      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let expected = 'www.example.com';
+      expect(actual).toEqual(expected);
+    });
+
+     it('ms:laurl without license url', function() {
+      let input = { node: strToXml('<test><ms:laurl></ms:laurl></test>') };
+      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let expected = '';
+      expect(actual).toEqual(expected);
+    });
+
+     it('no ms:laurl node', function() {
+      let input = { node: strToXml('<test></test>') };
+      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let expected = '';
+      expect(actual).toEqual(expected);
+    });
+  });
+
+   describe('parseRecords_', function() {
+    it('one record', function() {
+      let input = Uint16Array.from([
+        // Type
+        1,
+        // Size
+        2,
+        // Value
+        116
+      ]);
+      let actual = ContentProtection.parseRecords_(input, 1);
+      let expected = [{ type: 1, length: 2, value: 't' }];
+      expect(actual).toEqual(expected);
+    });
+
+     it('multiple records', function() {
+      let input = Uint16Array.from([
+        1, 2, 116,
+        2, 2, 120
+      ]);
+      let actual = ContentProtection.parseRecords_(input, 2);
+      let expected = [
+        { type: 1, length: 2, value: 't' },
+        { type: 2, length: 2, value: 'x' }
+      ];
+      expect(actual).toEqual(expected);
+    });
+  });
+
+   describe('parsePro_', function() {
+    it('one record', function() {
+      let input = Uint16Array.from([
+        // PlayReady Object size
+        12, 0,
+        // Record count
+        1,
+         // Record
+        // Type
+        1,
+        // Size
+        2,
+        // Value
+        116
+      ]);
+      let actual = ContentProtection.parsePro_(input);
+      let expected = {
+        length: 12, recordCount: 1,
+        records: [{ type: 1, length: 2, value: 't' }]
+      };
+      expect(actual).toEqual(expected);
+    });
+
+     it('multiple records', function() {
+      let input = Uint16Array.from([
+        // PlayReady Object
+        18, 0, 2,
+         // Record
+        1, 2, 116,
+         // Record
+        2, 2, 120
+      ]);
+      let actual = ContentProtection.parsePro_(input);
+      let expected = {
+        length: 18, recordCount: 2,
+        records: [
+          { type: 1, length: 2, value: 't' },
+          { type: 2, length: 2, value: 'x' }
+        ]
+      };
+      expect(actual).toEqual(expected);
+    });
+
+     it('no records', function() {
+      let input = Uint16Array.from([
+        // PlayReady Object
+        6, 0, 0,
+      ]);
+      let actual = ContentProtection.parsePro_(input);
+      let expected = { length: 6, recordCount: 0, records: [] };
+      expect(actual).toEqual(expected);
+    });
+  });
+
+   describe('getLaurl_', function() {
+    it('contains LA_URL', function() {
+      let input = strToXml('<test><LA_URL>www.example.com</LA_URL></test>');
+      let actual = ContentProtection.getLaurl_(input);
+      let expected = 'www.example.com';
+      expect(actual).toEqual(expected);
+    });
+
+     it('does not contain LA_URL', function() {
+      let input = strToXml('<test></test>');
+      let actual = ContentProtection.getLaurl_(input);
+      let expected = '';
+      expect(actual).toEqual(expected);
+    });
+  });
+
+   describe('getPlayReadyLicenseServerURL_', function() {
+    it('mspro', function() {
+      let laurl = '<test><LA_URL>www.example.com</LA_URL></test>';
+      let laurlCodes = laurl.split('').map(function(c) {
+        return c.charCodeAt();
+      });
+      let prBytes = Uint16Array.from([
+        // pr object size (unused)
+        0, 0,
+        // record count
+        1,
+         // type
+        0x0001,
+        // record size
+        laurl.length * 2,
+        // value
+      ].concat(laurlCodes));
+       let encodedPrObject = btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
+       let input = {
+        node: strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>')
+      };
+       let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
+      let expected = 'www.example.com';
+      expect(actual).toEqual(expected);
+    });
+
+     it('no mspro', function() {
+      let input = {
+        node: strToXml('<test></test>')
+      };
+      let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
+      let expected = '';
+      expect(actual).toEqual(expected);
+    });
+  });
+});

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -743,15 +743,15 @@ describe('DashParser ContentProtection', function() {
 });
 
 describe('In-manifest PlayReady and Widevine', function() {
-  let ContentProtection = shaka.dash.ContentProtection;
-  let strToXml = function(str) {
-    let parser = new DOMParser();
+  const ContentProtection = shaka.dash.ContentProtection;
+  const strToXml = function(str) {
+    const parser = new DOMParser();
     return parser.parseFromString(str, 'application/xml').documentElement;
   };
 
   describe('getWidevineLicenseUrl', function() {
     it('valid ms:laurl node', function() {
-      let input = {
+      const input = {
         init: null,
         keyId: null,
         schemeUri: '',
@@ -761,13 +761,13 @@ describe('In-manifest PlayReady and Widevine', function() {
           '</test>',
         ].join('\n')),
       };
-      let actual = ContentProtection.getWidevineLicenseUrl(input);
-      let expected = 'www.example.com';
+      const actual = ContentProtection.getWidevineLicenseUrl(input);
+      const expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
 
      it('ms:laurl without license url', function() {
-      let input = {
+      const input = {
         init: null,
         keyId: null,
         schemeUri: '',
@@ -777,31 +777,37 @@ describe('In-manifest PlayReady and Widevine', function() {
           '</test>',
         ].join('\n')),
       };
-      let actual = ContentProtection.getWidevineLicenseUrl(input);
-      let expected = '';
+      const actual = ContentProtection.getWidevineLicenseUrl(input);
+      const expected = '';
       expect(actual).toEqual(expected);
     });
 
      it('no ms:laurl node', function() {
-      let input = {
+      const input = {
         init: null,
         keyId: null,
         schemeUri: '',
         node: strToXml('<test></test>'),
       };
-      let actual = ContentProtection.getWidevineLicenseUrl(input);
-      let expected = '';
+      const actual = ContentProtection.getWidevineLicenseUrl(input);
+      const expected = '';
       expect(actual).toEqual(expected);
     });
   });
 
   describe('getPlayReadyLicenseURL', function() {
     it('mspro', function() {
-      let laurl = '<test><LA_URL>www.example.com</LA_URL></test>';
-      let laurlCodes = laurl.split('').map(function(c) {
+      const laurl = [
+        '<WRMHEADER>',
+        '  <DATA>',
+        '    <LA_URL>www.example.com</LA_URL>',
+        '  </DATA>',
+        '</WRMHEADER>',
+      ].join('\n');
+      const laurlCodes = laurl.split('').map(function(c) {
         return c.charCodeAt();
       });
-      let prBytes = new Uint16Array([
+      const prBytes = new Uint16Array([
         // pr object size (unused)
         0, 0,
         // record count
@@ -812,9 +818,9 @@ describe('In-manifest PlayReady and Widevine', function() {
         laurl.length * 2,
         // value
       ].concat(laurlCodes));
-      let encodedPrObject =
+      const encodedPrObject =
         btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
-      let input = {
+        const input = {
         init: null,
         keyId: null,
         schemeUri: '',
@@ -825,20 +831,20 @@ describe('In-manifest PlayReady and Widevine', function() {
             '</test>',
           ].join('\n')),
       };
-      let actual = ContentProtection.getPlayReadyLicenseUrl(input);
-      let expected = 'www.example.com';
+      const actual = ContentProtection.getPlayReadyLicenseUrl(input);
+      const expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
 
      it('no mspro', function() {
-      let input = {
+      const input = {
         init: null,
         keyId: null,
         schemeUri: '',
         node: strToXml('<test></test>'),
       };
-      let actual = ContentProtection.getPlayReadyLicenseUrl(input);
-      let expected = '';
+      const actual = ContentProtection.getPlayReadyLicenseUrl(input);
+      const expected = '';
       expect(actual).toEqual(expected);
     });
   });

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -821,24 +821,24 @@ describe('In-manifest PlayReady and Widevine', function() {
       ].concat(laurlCodes));
 
       const encodedPrObject =
-        btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
-        const input = {
-        init: null,
-        keyId: null,
-        schemeUri: '',
-        node:
-          strToXml([
-            '<test xmlns:mspr="urn:microsoft:playready">',
-            '  <mspr:pro>' + encodedPrObject + '</mspr:pro>',
-            '</test>',
-          ].join('\n')),
+        shaka.util.Uint8ArrayUtils.toBase64(new Uint8Array(prBytes.buffer));
+      const input = {
+      init: null,
+      keyId: null,
+      schemeUri: '',
+      node:
+        strToXml([
+          '<test xmlns:mspr="urn:microsoft:playready">',
+          '  <mspr:pro>' + encodedPrObject + '</mspr:pro>',
+          '</test>',
+        ].join('\n')),
       };
       const actual = ContentProtection.getPlayReadyLicenseUrl(input);
       const expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
 
-     it('no mspro', function() {
+    it('no mspro', function() {
       const input = {
         init: null,
         keyId: null,

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -755,8 +755,11 @@ describe('In-manifest PlayReady and Widevine', function() {
         init: null,
         keyId: null,
         schemeUri: '',
-        node: strToXml(
-          '<test><ms:laurl licenseUrl="www.example.com"></ms:laurl></test>'),
+        node: strToXml([
+          '<test xmlns:ms="urn:microsoft">',
+          '  <ms:laurl licenseUrl="www.example.com"></ms:laurl>',
+          '</test>',
+        ].join('\n')),
       };
       let actual = ContentProtection.getWidevineLicenseUrl(input);
       let expected = 'www.example.com';
@@ -768,7 +771,11 @@ describe('In-manifest PlayReady and Widevine', function() {
         init: null,
         keyId: null,
         schemeUri: '',
-        node: strToXml('<test><ms:laurl></ms:laurl></test>'),
+        node: strToXml([
+          '<test xmlns:ms="urn:microsoft">',
+          '  <ms:laurl></ms:laurl>',
+          '</test>',
+        ].join('\n')),
       };
       let actual = ContentProtection.getWidevineLicenseUrl(input);
       let expected = '';
@@ -812,7 +819,11 @@ describe('In-manifest PlayReady and Widevine', function() {
         keyId: null,
         schemeUri: '',
         node:
-          strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>'),
+          strToXml([
+            '<test xmlns:mspr="urn:microsoft:playready">',
+            '  <mspr:pro>' + encodedPrObject + '</mspr:pro>',
+            '</test>',
+          ].join('\n')),
       };
       let actual = ContentProtection.getPlayReadyLicenseURL(input);
       let expected = 'www.example.com';

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -808,16 +808,18 @@ describe('In-manifest PlayReady and Widevine', function() {
         return c.charCodeAt();
       });
       const prBytes = new Uint16Array([
-        // pr object size (unused)
-        0, 0,
+        // pr object size (in num bytes).
+        // + 10 for PRO size, count, and type
+        laurl.length * 2 + 10, 0,
         // record count
         1,
         // type
-        0x0001,
-        // record size
+        ContentProtection.PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT,
+        // record size (in num bytes)
         laurl.length * 2,
         // value
       ].concat(laurlCodes));
+
       const encodedPrObject =
         btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
         const input = {

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -825,7 +825,7 @@ describe('In-manifest PlayReady and Widevine', function() {
             '</test>',
           ].join('\n')),
       };
-      let actual = ContentProtection.getPlayReadyLicenseURL(input);
+      let actual = ContentProtection.getPlayReadyLicenseUrl(input);
       let expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
@@ -837,7 +837,7 @@ describe('In-manifest PlayReady and Widevine', function() {
         schemeUri: '',
         node: strToXml('<test></test>'),
       };
-      let actual = ContentProtection.getPlayReadyLicenseURL(input);
+      let actual = ContentProtection.getPlayReadyLicenseUrl(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -741,7 +741,7 @@ describe('DashParser ContentProtection', function() {
     await Dash.testFails(source, expected);
   });
 });
-/*
+
 describe('In-manifest PlayReady and Widevine', function() {
   let ContentProtection = shaka.dash.ContentProtection;
   let strToXml = function(str) {
@@ -749,166 +749,86 @@ describe('In-manifest PlayReady and Widevine', function() {
      return parser.parseFromString(str, 'application/xml').documentElement;
   };
 
-   describe('getWidevineLicenseUrl_', function() {
+   describe('getWidevineLicenseUrl', function() {
     it('valid ms:laurl node', function() {
       let input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
         node: strToXml(
           '<test><ms:laurl licenseUrl="www.example.com"></ms:laurl></test>'),
       };
-      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let actual = ContentProtection.getWidevineLicenseUrl(input);
       let expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
 
      it('ms:laurl without license url', function() {
-      let input = {node: strToXml('<test><ms:laurl></ms:laurl></test>')};
-      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
+        node: strToXml('<test><ms:laurl></ms:laurl></test>'),
+      };
+      let actual = ContentProtection.getWidevineLicenseUrl(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });
 
      it('no ms:laurl node', function() {
-      let input = {node: strToXml('<test></test>')};
-      let actual = ContentProtection.getWidevineLicenseUrl_(input);
+      let input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
+        node: strToXml('<test></test>'),
+      };
+      let actual = ContentProtection.getWidevineLicenseUrl(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });
   });
 
-   describe('parseRecords_', function() {
-    it('one record', function() {
-      let input = Uint16Array.from([
-        // Type
-        1,
-        // Size
-        2,
-        // Value
-        116,
-      ]);
-      let actual = ContentProtection.parseRecords_(input, 1);
-      let expected = [{type: 1, length: 2, value: 't'}];
-      expect(actual).toEqual(expected);
-    });
-
-     it('multiple records', function() {
-      let input = Uint16Array.from([
-        1, 2, 116,
-        2, 2, 120,
-      ]);
-      let actual = ContentProtection.parseRecords_(input, 2);
-      let expected = [
-        {type: 1, length: 2, value: 't'},
-        {type: 2, length: 2, value: 'x'},
-      ];
-      expect(actual).toEqual(expected);
-    });
-  });
-
-   describe('parsePro_', function() {
-    it('one record', function() {
-      let input = Uint16Array.from([
-        // PlayReady Object size
-        12, 0,
-        // Record count
-        1,
-         // Record
-        // Type
-        1,
-        // Size
-        2,
-        // Value
-        116,
-      ]);
-      let actual = ContentProtection.parsePro_(input);
-      let expected = {
-        length: 12, recordCount: 1,
-        records: [{type: 1, length: 2, value: 't'}],
-      };
-      expect(actual).toEqual(expected);
-    });
-
-     it('multiple records', function() {
-      let input = Uint16Array.from([
-        // PlayReady Object
-        18, 0, 2,
-         // Record
-        1, 2, 116,
-         // Record
-        2, 2, 120,
-      ]);
-      let actual = ContentProtection.parsePro_(input);
-      let expected = {
-        length: 18, recordCount: 2,
-        records: [
-          {type: 1, length: 2, value: 't'},
-          {type: 2, length: 2, value: 'x'},
-        ],
-      };
-      expect(actual).toEqual(expected);
-    });
-
-     it('no records', function() {
-      let input = Uint16Array.from([
-        // PlayReady Object
-        6, 0, 0,
-      ]);
-      let actual = ContentProtection.parsePro_(input);
-      let expected = {length: 6, recordCount: 0, records: []};
-      expect(actual).toEqual(expected);
-    });
-  });
-
-   describe('getLaurl_', function() {
-    it('contains LA_URL', function() {
-      let input = strToXml('<test><LA_URL>www.example.com</LA_URL></test>');
-      let actual = ContentProtection.getLaurl_(input);
-      let expected = 'www.example.com';
-      expect(actual).toEqual(expected);
-    });
-
-     it('does not contain LA_URL', function() {
-      let input = strToXml('<test></test>');
-      let actual = ContentProtection.getLaurl_(input);
-      let expected = '';
-      expect(actual).toEqual(expected);
-    });
-  });
-
-   describe('getPlayReadyLicenseServerURL_', function() {
+  describe('getPlayReadyLicenseServerURL', function() {
     it('mspro', function() {
       let laurl = '<test><LA_URL>www.example.com</LA_URL></test>';
       let laurlCodes = laurl.split('').map(function(c) {
         return c.charCodeAt();
       });
-      let prBytes = Uint16Array.from([
+      let prBytes = new Uint16Array([
         // pr object size (unused)
         0, 0,
         // record count
         1,
-         // type
+        // type
         0x0001,
         // record size
         laurl.length * 2,
         // value
       ].concat(laurlCodes));
-       let encodedPrObject =
+      let encodedPrObject =
         btoa(String.fromCharCode.apply(null, new Uint8Array(prBytes.buffer)));
-       let input = {
+      let input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
         node:
           strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>'),
       };
-       let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
+      let actual = ContentProtection.getPlayReadyLicenseServerURL(input);
       let expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
 
      it('no mspro', function() {
       let input = {
+        init: null,
+        keyId: null,
+        schemeUri: '',
         node: strToXml('<test></test>'),
       };
-      let actual = ContentProtection.getPlayReadyLicenseServerURL_(input);
+      let actual = ContentProtection.getPlayReadyLicenseServerURL(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });
   });
-});*/
+});

--- a/test/dash/dash_parser_content_protection_unit.js
+++ b/test/dash/dash_parser_content_protection_unit.js
@@ -746,10 +746,10 @@ describe('In-manifest PlayReady and Widevine', function() {
   let ContentProtection = shaka.dash.ContentProtection;
   let strToXml = function(str) {
     let parser = new DOMParser();
-     return parser.parseFromString(str, 'application/xml').documentElement;
+    return parser.parseFromString(str, 'application/xml').documentElement;
   };
 
-   describe('getWidevineLicenseUrl', function() {
+  describe('getWidevineLicenseUrl', function() {
     it('valid ms:laurl node', function() {
       let input = {
         init: null,
@@ -788,7 +788,7 @@ describe('In-manifest PlayReady and Widevine', function() {
     });
   });
 
-  describe('getPlayReadyLicenseServerURL', function() {
+  describe('getPlayReadyLicenseURL', function() {
     it('mspro', function() {
       let laurl = '<test><LA_URL>www.example.com</LA_URL></test>';
       let laurlCodes = laurl.split('').map(function(c) {
@@ -814,7 +814,7 @@ describe('In-manifest PlayReady and Widevine', function() {
         node:
           strToXml('<test><mspr:pro>' + encodedPrObject + '</mspr:pro></test>'),
       };
-      let actual = ContentProtection.getPlayReadyLicenseServerURL(input);
+      let actual = ContentProtection.getPlayReadyLicenseURL(input);
       let expected = 'www.example.com';
       expect(actual).toEqual(expected);
     });
@@ -826,7 +826,7 @@ describe('In-manifest PlayReady and Widevine', function() {
         schemeUri: '',
         node: strToXml('<test></test>'),
       };
-      let actual = ContentProtection.getPlayReadyLicenseServerURL(input);
+      let actual = ContentProtection.getPlayReadyLicenseURL(input);
       let expected = '';
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
This PR is based off https://github.com/google/shaka-player/pull/1010.  It closes #484 and parses license urls from `<ms:laurl>` and `<mspr:pro>` in the DASH manifest.  I believe I have addressed all the suggestions made in the original PR.

/cc @forbesjo