### PR TITLE
Resolving the problem with subtitles viewing for multi-period live DA…

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -559,6 +559,7 @@ shaka.media.StreamingEngine.prototype.loadNewTextStream = async function(
     let needPeriodIndex = this.findPeriodContainingTime_(playheadTime);
 
     const state = this.createMediaState_(stream, needPeriodIndex);
+    state.resumeAt = this.getActivePeriod().startTime;
     this.mediaStates_.set(ContentType.TEXT, state);
     this.scheduleUpdate_(state, 0);
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1932,7 +1932,7 @@ shaka.Player.prototype.setTextTrackVisibility = async function(on) {
   const StreamUtils = shaka.util.StreamUtils;
 
   if (on) {
-    let period = this.streamingEngine_.getCurrentPeriod();
+    let period = this.streamingEngine_.getActivePeriod();
     let textStreams = StreamUtils.filterStreamsByLanguageAndRole(
         period.textStreams,
         this.currentTextLanguage_,


### PR DESCRIPTION
Resolving the problem with subtitles viewing for multi-period live DASH stream.
For issue [#1698](https://github.com/google/shaka-player/issues/1698)

For multi-period live DASH stream with subtitles when the "CC" button on Shaka player clicked: 
 - subtitles stop to appear for a few seconds or did not start at all;
 - for a few seconds later the playback will be stopped for about 10 to 30s then continue to play.

The problem is relate to the different video and text period numbers. 
The problem arises when we start to load the text from current period. 
We managed to improve the situation when we start to load the text from the active period. 
Another problem has arisen with the text stream updating after the start of subtitles loading. The period of playheadTime is compared with zero mediaState.resumeAt property. So we find the period of Text stream for playheadTime but it is less then the period of current Video stream. And we get an assertion failure here. 
To save the current period number we offer to set the resumeAt property of mediaState to the start time of the active period.
The described changes help solve the problem, but there is a delay before the subtitles appear. The delay value is the difference between the active and current periods time.

