### PR TITLE
Set black background in fullscreen mode

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -35,6 +35,7 @@
 .fullscreen-container() {
   width: 100%;
   height: 100%;
+  background-color: black;
 }
 .shaka-video-container:fullscreen { .fullscreen-container(); }
 .shaka-video-container:-webkit-full-screen { .fullscreen-container(); }


### PR DESCRIPTION
## Issue

The background is white on Safari in full screen mode. For example:

<img width="1280" alt="screen shot 2019-02-08 at 3 50 26 pm" src="https://user-images.githubusercontent.com/615940/52489039-8a457100-2bc1-11e9-9823-5d21b5bc450a.png">

## Test case

1. Open the test page in Safari
1. Load the Angel stream
1. Enter full screen mode

### Expected

The background under the content is black.