### PR TITLE
Add support for HLS tags with both value and attributes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,7 @@ Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matias Russitto <russitto@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Michelle Zhuo <michellezhuo@google.com>
+Miloš Rašić <milos.rasic@gmail.com>
 Morten Hansen <mimo@mimo-design.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>

--- a/lib/hls/hls_classes.js
+++ b/lib/hls/hls_classes.js
@@ -75,15 +75,6 @@ shaka.hls.PlaylistType = {
  * @struct
  */
 shaka.hls.Tag = function(id, name, attributes, value = null) {
-  goog.asserts.assert(
-      (attributes.length == 0 && value) ||
-      (attributes.length > 0 && !value) ||
-      (attributes.length == 0 && !value),
-      'Tags can only take the form ' +
-      '(1) <NAME>:<VALUE> ' +
-      '(2) <NAME>:<ATTRIBUTE_LIST> ' +
-      ' (3) <NAME>');
-
   /** @const {number} */
   this.id = id;
 

--- a/lib/hls/hls_classes.js
+++ b/lib/hls/hls_classes.js
@@ -106,24 +106,32 @@ shaka.hls.Tag.prototype.toString = function() {
    * @return {string}
    */
   let attrToStr = function(attr) {
-    return attr.name + '="' + attr.value + '"';
+    const isNumericAttr = !isNaN(Number(attr.value));
+
+    const value = (isNumericAttr ? attr.value : '"' + attr.value + '"');
+
+    return attr.name + '=' + value;
   };
 
 
-  // A valid tag can only follow 1 of 3 patterns.
+  // A valid tag can only follow 1 of 4 patterns.
   //  1) <NAME>:<VALUE>
   //  2) <NAME>:<ATTRIBUTE LIST>
   //  3) <NAME>
+  //  4) <NAME>:<VALUE>,<ATTRIBUTE_LIST>
+
+  let tagStr = '#' + this.name;
+  const appendages = this.attributes ? this.attributes.map(attrToStr) : [];
 
   if (this.value) {
-    return '#' + this.name + ':' + this.value;
+    appendages.unshift(this.value);
   }
 
-  if (this.attributes.length > 0) {
-    return '#' + this.name + ':' + this.attributes.map(attrToStr).join(',');
+  if (appendages.length > 0) {
+    tagStr += ':' + appendages.join(',');
   }
 
-  return '#' + this.name;
+  return tagStr;
 };
 
 

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -196,11 +196,10 @@ shaka.hls.ManifestTextParser.parseTag = function(id, word) {
     An attribute's format is 'AttributeName=AttributeValue'.
     The parsing logic goes like this:
      1. Everything before ':' is a name (we ignore '#').
-     2. Everything after ':' is a list of items,
-          first one being either value or attribute, and the rest attributes
-     3. Everything after should be parsed as attributes if it contains '=',
-          only the first item may be a value
-     4. If there is no ":", it's a simple tag with no attributes and no value */
+     2. Everything after ':' is a list of comma-seprated items,
+          2a. The first item might be a value, if it does not contain '='.
+          2b. Otherwise, items are attributes.
+     3. If there is no ":", it's a simple tag with no attributes and no value */
   const blocks = word.match(/^#(EXT[^:]*)(?::(.*))?$/);
   if (!blocks) {
     throw new shaka.util.Error(
@@ -218,6 +217,16 @@ shaka.hls.ManifestTextParser.parseTag = function(id, word) {
     const parser = new shaka.util.TextParser(data);
     let blockAttrs;
 
+    // Regex: any number of non-equals-sign characters at the beginning
+    // terminated by comma or end of line
+    const valueRegex = /^([^,=]+)(?:,|$)/g;
+
+    const blockValue = parser.readRegex(valueRegex);
+
+    if (blockValue) {
+      value = blockValue[1];
+    }
+
     // Regex:
     // 1. Key name ([1])
     // 2. Equals sign
@@ -229,16 +238,6 @@ shaka.hls.ManifestTextParser.parseTag = function(id, word) {
     //   a. A comma
     //   b. End of line
     const attributeRegex = /([^=]+)=(?:"([^"]*)"|([^",]*))(?:,|$)/g;
-
-    // Regex: any number of non-equals-sign characters at the beginning
-    // terminated by comma or end of line
-    const valueRegex = /^([^,=]+)(?:,|$)/g;
-
-    const blockValue = parser.readRegex(valueRegex);
-
-    if (blockValue) {
-      value = blockValue[1];
-    }
 
     while ((blockAttrs = parser.readRegex(attributeRegex))) {
       const attrName = blockAttrs[1];

--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -192,14 +192,16 @@ shaka.hls.ManifestTextParser.prototype.parseTag_ = function(word) {
  */
 shaka.hls.ManifestTextParser.parseTag = function(id, word) {
   /* HLS tags start with '#EXT'. A tag can have a set of attributes
-    (#EXT-<tagname>:<attribute list>) or a value (#EXT-<tagname>:<value>).
+    (#EXT-<tagname>:<attribute list>) and/or a value (#EXT-<tagname>:<value>).
     An attribute's format is 'AttributeName=AttributeValue'.
     The parsing logic goes like this:
      1. Everything before ':' is a name (we ignore '#').
-     2. Everything after should be parsed as attributes if it contains '='.
-     3. Otherwise, this is a value.
+     2. Everything after ':' is a list of items,
+          first one being either value or attribute, and the rest attributes
+     3. Everything after should be parsed as attributes if it contains '=',
+          only the first item may be a value
      4. If there is no ":", it's a simple tag with no attributes and no value */
-  let blocks = word.match(/^#(EXT[^:]*)(?::(.*))?$/);
+  const blocks = word.match(/^#(EXT[^:]*)(?::(.*))?$/);
   if (!blocks) {
     throw new shaka.util.Error(
         shaka.util.Error.Severity.CRITICAL,
@@ -207,12 +209,13 @@ shaka.hls.ManifestTextParser.parseTag = function(id, word) {
         shaka.util.Error.Code.INVALID_HLS_TAG,
         word);
   }
-  let name = blocks[1];
-  let data = blocks[2];
-  let attributes = [];
+  const name = blocks[1];
+  const data = blocks[2];
+  const attributes = [];
+  let value;
 
-  if (data && data.includes('=')) {
-    let parser = new shaka.util.TextParser(data);
+  if (data) {
+    const parser = new shaka.util.TextParser(data);
     let blockAttrs;
 
     // Regex:
@@ -225,18 +228,27 @@ shaka.hls.ManifestTextParser.parseTag = function(id, word) {
     // 4. Either:
     //   a. A comma
     //   b. End of line
-    const regex = /([^=]+)=(?:"([^"]*)"|([^",]*))(?:,|$)/g;
-    while ((blockAttrs = parser.readRegex(regex))) {
-      let attrName = blockAttrs[1];
-      let attrValue = blockAttrs[2] || blockAttrs[3];
-      let attribute = new shaka.hls.Attribute(attrName, attrValue);
+    const attributeRegex = /([^=]+)=(?:"([^"]*)"|([^",]*))(?:,|$)/g;
+
+    // Regex: any number of non-equals-sign characters at the beginning
+    // terminated by comma or end of line
+    const valueRegex = /^([^,=]+)(?:,|$)/g;
+
+    const blockValue = parser.readRegex(valueRegex);
+
+    if (blockValue) {
+      value = blockValue[1];
+    }
+
+    while ((blockAttrs = parser.readRegex(attributeRegex))) {
+      const attrName = blockAttrs[1];
+      const attrValue = blockAttrs[2] || blockAttrs[3];
+      const attribute = new shaka.hls.Attribute(attrName, attrValue);
       attributes.push(attribute);
     }
-  } else if (data) {
-    return new shaka.hls.Tag(id, name, attributes, data);
   }
 
-  return new shaka.hls.Tag(id, name, attributes);
+  return new shaka.hls.Tag(id, name, attributes, value);
 };
 
 

--- a/test/hls/manifest_text_parser_unit.js
+++ b/test/hls/manifest_text_parser_unit.js
@@ -321,6 +321,36 @@ describe('ManifestTextParser', function() {
           'https://test/manifest.m3u8');
     });
 
+    it('handles tags with both value and attributes', function() {
+      verifyPlaylist(
+          {
+            type: shaka.hls.PlaylistType.MEDIA,
+            tags: [
+              new shaka.hls.Tag(/* id */ 0, 'EXT-X-MEDIA-SEQUENCE', [], '1'),
+            ],
+            segments: [
+              new shaka.hls.Segment('https://test/test.mp4',
+                  [
+                    new shaka.hls.Tag(
+                      /* id */ 2,
+                      'EXTINF',
+                      [new shaka.hls.Attribute('pid', '180')],
+                      '5.99467'
+                    ),
+                  ]),
+            ],
+          },
+
+          // playlist text:
+          '#EXTM3U\n' +
+          '#EXT-X-MEDIA-SEQUENCE:1\n' +
+          '#EXTINF:5.99467,pid=180\n' +
+          'https://test/test.mp4\n',
+
+          // manifest URI:
+          'https://test/manifest.m3u8');
+    });
+
     it('handles manifests with a segment tag before a playlist tag', () => {
       verifyPlaylist(
           {

--- a/test/hls/manifest_text_parser_unit.js
+++ b/test/hls/manifest_text_parser_unit.js
@@ -293,6 +293,12 @@ describe('ManifestTextParser', function() {
       let tag = shaka.hls.ManifestTextParser.parseTag(0, text);
       expect(text).toEqual(tag.toString());
     });
+
+    it('recreates valid tag with both value and attributes', function() {
+      const text = '#EXTINF:5.99467,pid=180';
+      let tag = shaka.hls.ManifestTextParser.parseTag(0, text);
+      expect(text).toEqual(tag.toString());
+    });
   });
 
   describe('parseSegments', function() {


### PR DESCRIPTION
Fixes the problem reported in #1808 

HLS parser wrongly assumes that a tag may have either a value or attributes, not both.

The RFC doesn't describe a general tag format or even give a name to what's called tag value in the Shaka Player codebase, but it clearly gives the format of EXTINF tag:

`#EXTINF:<duration>,[<title>]`

This PR makes the following changes:

* Removes either value or attributes validation from `shaka.hls.Tag`
* Simplifies branching and adds a check for value in the list of attributes in `shaka.hls.ManifestTextParser.parseTag()`
* Removes misuse of `let` in `shaka.hls.ManifestTextParser.parseTag()`, most local variables are never reassigned and can be `const`
* Adds a test case to guard against regression