### PR TITLE
Fix React Native createObjectURL polyfill incompatibility

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -94,6 +94,16 @@ shaka.media.MediaSourceEngine = function(
 
 
 /**
+ * Internal reference to window.URL.createObjectURL function to avoid
+ * compatibility issues with other libraries and frameworks such as React
+ * Native. For use in unit tests only, not meant for external use.
+ *
+ * @type {function(?):string}
+ */
+shaka.media.MediaSourceEngine.createObjectURL = window.URL.createObjectURL;
+
+
+/**
  * Create a MediaSource object, attach it to the video element, and return it.
  * Resolves the given promise when the MediaSource is ready.
  *
@@ -107,7 +117,7 @@ shaka.media.MediaSourceEngine.prototype.createMediaSource = function(p) {
 
   // Set up MediaSource on the video element.
   this.eventManager_.listenOnce(mediaSource, 'sourceopen', p.resolve);
-  this.video_.src = window.URL.createObjectURL(mediaSource);
+  this.video_.src = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
 
   return mediaSource;
 };

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -161,7 +161,8 @@ describe('MediaSourceEngine', function() {
   });
 
   describe('constructor', function() {
-    const originalCreateObjectURL = window.URL.createObjectURL;
+    const originalCreateObjectURL =
+      shaka.media.MediaSourceEngine.createObjectURL;
     const originalMediaSource = window.MediaSource;
     /** @type {jasmine.Spy} */
     let createObjectURLSpy;
@@ -176,7 +177,8 @@ describe('MediaSourceEngine', function() {
 
       createObjectURLSpy = jasmine.createSpy('createObjectURL');
       createObjectURLSpy.and.returnValue('blob:foo');
-      window.URL.createObjectURL = Util.spyFunc(createObjectURLSpy);
+      shaka.media.MediaSourceEngine.createObjectURL =
+        Util.spyFunc(createObjectURLSpy);
 
       let mediaSourceSpy = jasmine.createSpy('MediaSource').and.callFake(() => {
         return mockMediaSource;
@@ -187,7 +189,7 @@ describe('MediaSourceEngine', function() {
     });
 
     afterAll(function() {
-      window.URL.createObjectURL = originalCreateObjectURL;
+      shaka.media.MediaSourceEngine.createObjectURL = originalCreateObjectURL;
       window.MediaSource = originalMediaSource;
     });
 


### PR DESCRIPTION
React Native introduces its own polyfill for window.URL.createObjectURL which is not compatible with Shaka. Encapsulating a reference to the original function inside of the MediaSourceEngine circumvents this issue.

Issue #1842