### PR TITLE
Add getLoadMode function

### DIFF
--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -143,6 +143,7 @@ shaka.cast.CastUtils.PlayerGetterMethods = {
   'keySystem': 10,
   'seekRange': 1,
   'usingEmbeddedTextTrack': 2,
+  'getLoadMode': 10,
 };
 
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2448,6 +2448,17 @@ shaka.Player.prototype.resetConfiguration = function() {
 
 
 /**
+ * Get the current load mode.
+ *
+ * @return {shaka.Player.LoadMode}
+ * @export
+ */
+shaka.Player.prototype.getLoadMode = function() {
+  return this.loadMode_;
+};
+
+
+/**
  * Get the media element that the player is currently using to play loaded
  * content. If the player has not loaded content, this will return |null|.
  *
@@ -5305,6 +5316,7 @@ shaka.Player.prototype.wrapWalkerListenersWithPromise_ = function(listeners) {
  * content.
  *
  * @enum {number}
+ * @export
  */
 shaka.Player.LoadMode = {
   'DESTROYED': 0,


### PR DESCRIPTION
Add a new function called getLoadMode that returns the current load mode. The possibel response is:
DESTROYED, NOT_LOADED, MEDIA_SOURCE and SRC_EQUALS

This function is necessary for https://github.com/google/shaka-player/issues/1003 because AirPlay only works with SRC mode.