### PR TITLE
Fix return value for keySystem() and getExpiration() with src=

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2593,8 +2593,8 @@ shaka.Player.prototype.seekRange = function() {
 
 /**
  * Get the key system currently used by EME. If EME is not being used, this will
- * return an empty string. If the player has not loaded content or is still
- * loading content, this will return an empty string.
+ * return an empty string. If the player is idle or has not initialized EME yet,
+ * this will return an empty string.
  *
  * @return {string}
  * @export
@@ -2620,8 +2620,8 @@ shaka.Player.prototype.drmInfo = function() {
 /**
  * Get the next known expiration time for any EME session. If the session never
  * expires, this will return |Infinity|. If there are no EME sessions, this will
- * return |Infinity|. If the player has not loaded content or is still loading
- * content, this will return |Infinity|.
+ * return |Infinity|. If the player is idle or has not initialized EME yet, this
+ * will return |Infinity|.
  *
  * @return {number}
  * @export

--- a/lib/player.js
+++ b/lib/player.js
@@ -2600,9 +2600,7 @@ shaka.Player.prototype.seekRange = function() {
  * @export
  */
 shaka.Player.prototype.keySystem = function() {
-  return this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE ?
-         this.drmEngine_.keySystem() :
-         '';
+  return this.drmEngine_ ? this.drmEngine_.keySystem() : '';
 };
 
 
@@ -2629,9 +2627,7 @@ shaka.Player.prototype.drmInfo = function() {
  * @export
  */
 shaka.Player.prototype.getExpiration = function() {
-  return this.loadMode_ == shaka.Player.LoadMode.MEDIA_SOURCE ?
-         this.drmEngine_.getExpiration() :
-         Infinity;
+  return this.drmEngine_ ? this.drmEngine_.getExpiration() : Infinity;
 };
 
 


### PR DESCRIPTION
Fix return value for keySystem() and getExpiration() with src=

This shouldn't depend on the load state.