### PR TITLE
Add isClockOffsetUpdated to presentationTimeline

### DIFF
--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -88,6 +88,9 @@ shaka.media.PresentationTimeline = function(
   this.clockOffset_ = 0;
 
   /** @private {boolean} */
+  this.clockOffsetUpdated_ = false;
+
+  /** @private {boolean} */
   this.static_ = true;
 
   /** @private {number} */
@@ -149,6 +152,15 @@ shaka.media.PresentationTimeline.prototype.getPresentationStartTime =
  */
 shaka.media.PresentationTimeline.prototype.setClockOffset = function(offset) {
   this.clockOffset_ = offset;
+  this.clockOffsetUpdated_ = true;
+};
+
+/**
+ * @return {boolean} True if the clock offset has been updated.
+ * @export
+ */
+shaka.media.PresentationTimeline.prototype.isClockOffsetUpdated = function() {
+  return this.clockOffsetUpdated_;
 };
 
 


### PR DESCRIPTION
G'day and thanks for ShakaPlayer, it's amazing!

In my case I have several MPEG-dash manifests, some of them contain UTCTiming, some not. If manifest I choose does not contain UTCTiming, I specify `clockSyncUri` via `configure`. The problem is to detect if manifest contains UTCTiming without extra HTTP-query. The pull request contains naive implementation. Which way is more correct in your opinion? Or, maybe the pull request could be merged? I'll appreciate any help or advice.