### PR TITLE
Fix FairPlay license request

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Aaron Vaage <vaage@google.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
+Boris Cupac <borisrt2309@gmail.com>
 Bryan Huh <bhh1988@gmail.com>
 Chad Assareh <assareh@google.com>
 Chris Fillmore <fillmore.chris@gmail.com>

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1332,10 +1332,11 @@ shaka.media.DrmEngine.prototype.formatFairPlayRequest_ = function(request) {
   // The standard format for FairPlay seems to be to place the request into a
   // POST parameter (spc=).
   const originalPayload = new Uint8Array(request.body);
-  const base64Payload = shaka.util.Uint8ArrayUtils.toBase64(originalPayload);
+  const base64Payload = shaka.util.
+      Uint8ArrayUtils.toStandardBase64(originalPayload);
   const params = 'spc=' + base64Payload;
   request.headers['Content-Type'] = 'application/x-www-form-urlencoded';
-  request.body = shaka.util.StringUtils.toUTF8(params);
+  request.body = shaka.util.StringUtils.toUTF8(encodeURIComponent(params));
 };
 
 

--- a/lib/util/uint8array_utils.js
+++ b/lib/util/uint8array_utils.js
@@ -44,6 +44,26 @@ shaka.util.Uint8ArrayUtils.toBase64 = function(arr, padding) {
   return padding ? base64 : base64.replace(/=*$/, '');
 };
 
+/**
+ * Convert a Uint8Array to a base64 string. The output will be standard alphabet
+ * as opposed to "base64url" safe alphabet.
+ * @param {!Uint8Array} u8Arr
+ * @return {string}
+ * @export
+ */
+shaka.util.Uint8ArrayUtils.toStandardBase64 = function(u8Arr) {
+    const CHUNK_SIZE = 0x8000;
+    let index = 0;
+    const length = u8Arr.length;
+    let result = '';
+    let slice;
+    while (index < length) {
+        slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
+        result += String.fromCharCode.apply(null, slice);
+        index += CHUNK_SIZE;
+    }
+    return btoa(result);
+};
 
 /**
  * Convert a base64 string to a Uint8Array.  Accepts either the standard


### PR DESCRIPTION
This PR will fix an issue where the license request will fail in case that there are url unsafe characters in license request post body. It will make the post request parameters have spc=base64 structure instead spc:base64.