### PR TITLE
fix case where TTML data is an empty string

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -78,6 +78,10 @@ shaka.text.TtmlTextParser = class {
     const parser = new DOMParser();
     let xml = null;
 
+    // dont try to parse empty string as 
+    // DOMParser will not throw error but return an errored xml
+    if (str == '') return ret
+
     try {
       xml = parser.parseFromString(str, 'text/xml');
     } catch (exception) {

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -78,9 +78,11 @@ shaka.text.TtmlTextParser = class {
     const parser = new DOMParser();
     let xml = null;
 
-    // dont try to parse empty string as 
+    // dont try to parse empty string as
     // DOMParser will not throw error but return an errored xml
-    if (str == '') return ret
+    if (str == '') {
+      return ret;
+    }
 
     try {
       xml = parser.parseFromString(str, 'text/xml');

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -90,7 +90,6 @@ describe('TtmlTextParser', () => {
 
   it('rejects invalid ttml', () => {
     errorHelper(shaka.util.Error.Code.INVALID_XML, '<test></test>');
-    errorHelper(shaka.util.Error.Code.INVALID_XML, '');
   });
 
   it('rejects invalid time format', () => {

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -26,6 +26,12 @@ describe('TtmlTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
 
+  it('supports empty text string', () => {
+    verifyHelper([],
+        '',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+  });
+
   it('supports div with no cues but whitespace', () => {
     verifyHelper(
         [],


### PR DESCRIPTION
when using DOMParser parseFromString with an empty string it returns an errored XML document
the next part of the code is then executed and throw an unnecessary error