### PR TITLE
Add requestUri as a property on shaka.extern.Response

### DIFF
--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -110,6 +110,9 @@ shaka.extern.Request;
  * @property {string} uri
  *   The URI which was loaded.  Request filters and server redirects can cause
  *   this to be different from the original request URIs.
+ * @property {string} originalUri
+ *   The original URI passed to the browser for networking. This is before any
+ *   redirects, but after request filters are executed.
  * @property {ArrayBuffer} data
  *   The body of the response.
  * @property {!Object.<string, string>} headers

--- a/lib/net/data_uri_plugin.js
+++ b/lib/net/data_uri_plugin.js
@@ -47,6 +47,7 @@ shaka.net.DataUriPlugin = class {
       /** @type {shaka.extern.Response} */
       const response = {
         uri: uri,
+        originalUri: uri,
         data: parsed.data,
         headers: {
           'content-type': parsed.contentType,

--- a/lib/net/http_plugin_utils.js
+++ b/lib/net/http_plugin_utils.js
@@ -39,12 +39,10 @@ shaka.net.HttpPluginUtils = class {
   static makeResponse(headers, data, status, uri, responseURL, requestType) {
     if (status >= 200 && status <= 299 && status != 202) {
       // Most 2xx HTTP codes are success cases.
-      if (responseURL) {
-        uri = responseURL;
-      }
       /** @type {shaka.extern.Response} */
       const response = {
-        uri: uri,
+        uri: responseURL || uri,
+        originalUri: uri,
         data: data,
         headers: headers,
         fromCache: !!headers['x-shaka-from-cache'],

--- a/lib/offline/offline_scheme.js
+++ b/lib/offline/offline_scheme.js
@@ -68,6 +68,7 @@ shaka.offline.OfflineScheme = class {
     /** @type {shaka.extern.Response} */
     const response = {
       uri: uri,
+      originalUri: uri,
       data: new ArrayBuffer(0),
       headers: {'content-type': 'application/x-offline-manifest'},
     };

--- a/test/test/util/fake_networking_engine.js
+++ b/test/test/util/fake_networking_engine.js
@@ -120,6 +120,7 @@ shaka.test.FakeNetworkingEngine = class {
       /** @type {shaka.extern.Response} */
       const response = {
         uri: requestedUri,
+        originalUri: requestedUri,
         data: result,
         headers: headers,
       };

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -33,6 +33,7 @@ shaka.test.TestScheme = function(uri, request, requestType) {
     /** @type {shaka.extern.Response} */
     const response = {
       uri: uri,
+      originalUri: uri,
       data: new ArrayBuffer(0),
       headers: {'content-type': 'application/x-test-manifest'},
     };
@@ -76,7 +77,7 @@ shaka.test.TestScheme = function(uri, request, requestType) {
   }
 
   /** @type {shaka.extern.Response} */
-  const ret = {uri: uri, data: responseData, headers: {}};
+  const ret = {uri: uri, originalUri: uri, data: responseData, headers: {}};
   return shaka.util.AbortableOperation.completed(ret);
 };
 


### PR DESCRIPTION
This property tracks the original request uri, which would be
useful to know in the event of a redirect.

Issue #1971