### PR TITLE
Trim base64 subtitles in smpte:backgroundImage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,3 +51,4 @@ Tomas Tichy <mr.tichyt@gmail.com>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
+Adrián Gómez Llorente <adgllorente@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -84,3 +84,4 @@ Toshihiro Suzuki <t.suzuki326@gmail.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>
 Yohann Connell <robinconnell@google.com>
+Adrián Gómez Llorente <adgllorente@gmail.com>

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -461,7 +461,7 @@ shaka.text.TtmlTextParser = class {
     if (imageElement) {
       const backgroundImageType = imageElement.getAttribute('imagetype');
       const backgroundImageEncoding = imageElement.getAttribute('encoding');
-      const backgroundImageData = imageElement.textContent;
+      const backgroundImageData = imageElement.textContent.trim();
       if (backgroundImageType == 'PNG' &&
           backgroundImageEncoding == 'Base64' &&
           backgroundImageData) {


### PR DESCRIPTION
This PR fixes the issue #2028. It trims the textContent containing the base64 code of the subtitles.