### PR TITLE
fix ttml background image support

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -246,9 +246,17 @@ shaka.text.TtmlTextParser = class {
 
     if (
       cueElement.nodeType != Node.ELEMENT_NODE ||
-      // Disregards empty elements without time attributes
+      /* Disregards empty elements without time attributes nor content
+       * <p begin="..." smpte:backgroundImage="..." /> will go through,
+       *    as some information could be holded by its attributes
+       * <p />, <div></div> won't,
+       *    as they don't have means to be displayed into a playback sequence
+       */
       (hasNoTimeAttributes && isTextContentEmpty) ||
-      // Let nested cues without time attributes through
+      /*
+       * Let nested cue without time attributes through:
+       *    time attributes are holded by its parent
+       */
       (hasNoTimeAttributes && !isNested)
     ) {
       return null;

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -239,17 +239,17 @@ shaka.text.TtmlTextParser = class {
       return cue;
     }
 
-    // Disregard empty elements:
-    // TTML allows for empty elements like <div></div>.
-    // If cueElement has neither time attributes, nor
-    // non-whitespace text, don't try to make a cue out of it.
-    if (
-      /^[\s\n]*$/.test(cueElement.textContent) ||
-      (
-        !isNested &&
+    const isTextContentEmpty = /^[\s\n]*$/.test(cueElement.textContent);
+    const hasNoTimeAttributes = cueElement.nodeType == Node.ELEMENT_NODE &&
         !cueElement.hasAttribute('begin') &&
-        !cueElement.hasAttribute('end')
-      )
+        !cueElement.hasAttribute('end');
+
+    if (
+      cueElement.nodeType != Node.ELEMENT_NODE ||
+      // Disregards empty elements without time attributes
+      (hasNoTimeAttributes && isTextContentEmpty) ||
+      // Let nested cues without time attributes through
+      (hasNoTimeAttributes && !isNested)
     ) {
       return null;
     }

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -674,6 +674,49 @@ describe('TtmlTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
 
+  it('should let empty paragraphs with begin or end attributes through', () => {
+    verifyHelper(
+        [
+          {startTime: 62.05, endTime: 3723.2, payload: ''},
+        ],
+        '<tt>' +
+        '<body>' +
+        '<div>' +
+        '<p begin="01:02.05" end="01:02:03.200" />' +
+        '<p></p>' +
+        '</div>' +
+        '</body>' +
+        '</tt>',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+  });
+
+  it('supports smpte:backgroundImage attribute', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 62.05,
+            endTime: 3723.2,
+            payload: '',
+            backgroundImage: 'data:image/png;base64,base64EncodedImage',
+          },
+        ],
+        '<tt ' +
+        'xmlns:ttm="http://www.w3.org/ns/ttml#metadata" ' +
+        'xmlns:smpte="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt">' +
+        '<metadata>' +
+        '<smpte:image imagetype="PNG" encoding="Base64" xml:id="img_0">' +
+        'base64EncodedImage</smpte:image>' +
+        '</metadata>' +
+        '<body>' +
+        '<div>' +
+        '<p begin="01:02.05" end="01:02:03.200" ' +
+        'smpte:backgroundImage="#img_0" />' +
+        '</div>' +
+        '</body>' +
+        '</tt>',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+  });
+
   it('inserts newline characters into <br> tags', () => {
     verifyHelper(
         [


### PR DESCRIPTION
Since #1962, any nodes with begin or end attributes with empty content would not be interpreted as cues (`<p begin="xx" end="xxx" smpte:backgroundImage="yyy" />` for example)

This PR fixes this. 

To test: Live sim TTML Image Subtitles embedded (VoD)