### PR TITLE
UI: Seek bar doesn't work on iOS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Jonas Birmé <jonas.birme@eyevinn.se>
 Jozef Chúťka <jozefchutka@gmail.com>
 JW Player <*@jwplayer.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
+Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Mohamed Rashid <ge_rashid@hotmail.co.uk>
 Morten Hansen <mimo@mimo-design.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -52,6 +52,7 @@ Jozef Chúťka <jozefchutka@gmail.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matias Russitto <russitto@gmail.com>
+Matthias Van Parijs <matvp91@gmail.com>
 Mattias Wadman <mattias.wadman@gmail.com>
 Michelle Zhuo <michellezhuo@google.com>
 Miloš Rašić <milos.rasic@gmail.com>


### PR DESCRIPTION
Fixes #1918.

You're able to seek on iOS, but I'm not fully confident yet. Might be a good idea to extend the touchable surface in height in `shaka.ui.RangeElement`.