### PR TITLE
fix: Reference issue with SegmentReference createUris

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -406,14 +406,16 @@ shaka.dash.SegmentTemplate = class {
       // Consider the presentation time offset in segment uri computation
       const timeReplacement = unscaledStart +
           info.unscaledPresentationTimeOffset;
+      const repId = context.representation.id;
+      const bandwidth = context.bandwidth || null;
       const createUris =
           () => {
             goog.asserts.assert(
                 info.mediaTemplate,
                 'There should be a media template with a timeline');
             const mediaUri = MpdUtils.fillUriTemplate(
-                info.mediaTemplate, context.representation.id,
-                segmentReplacement, context.bandwidth || null, timeReplacement);
+                info.mediaTemplate, repId,
+                segmentReplacement, bandwidth || null, timeReplacement);
             return ManifestParserUtils
                 .resolveUris(context.representation.baseUris, [mediaUri])
                 .map((g) => {


### PR DESCRIPTION
When trying to play some of our manifest Shaka was creating wrong URIs for each representation due to reference issue. This PR fixes that and replicates how it's done inside `createInitSegment_`