### PR TITLE
Revert "feature: Offline PSSH support for manifest that are missing inline init data"

### DIFF
--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -23,7 +23,6 @@ goog.require('shaka.offline.DownloadProgressEstimator');
 goog.require('shaka.util.Destroyer');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IDestroyable');
-goog.require('shaka.util.Pssh');
 
 
 /**
@@ -39,11 +38,11 @@ shaka.offline.DownloadManager = class {
    *
    * @param {!shaka.net.NetworkingEngine} networkingEngine
    * @param {function(number, number)} onProgress
-   * @param {function(!Uint8Array)} onInitData
    */
-  constructor(networkingEngine, onProgress, onInitData) {
+  constructor(networkingEngine, onProgress) {
     /** @private {shaka.net.NetworkingEngine} */
     this.networkingEngine_ = networkingEngine;
+
     /**
      * We group downloads. Within each group, the requests are executed in
      * series. Between groups, the requests are executed in parallel. We store
@@ -69,14 +68,6 @@ shaka.offline.DownloadManager = class {
      * @private {function(number, number)}
      */
     this.onProgress_ = onProgress;
-
-    /**
-     * A callback for when a segment has new PSSH data and we pass
-     * on the initData to storage
-     *
-     * @private {function(!Uint8Array)}
-     */
-    this.onInitData_ = onInitData;
 
     /** @private {shaka.offline.DownloadProgressEstimator} */
     this.estimator_ = new shaka.offline.DownloadProgressEstimator();
@@ -119,10 +110,6 @@ shaka.offline.DownloadManager = class {
       }
 
       // Update all our internal stats.
-      if (shaka.util.Pssh.containsPssh(new Uint8Array(response), true)) {
-        this.onInitData_(new Uint8Array(response));
-      }
-
       this.estimator_.close(id, response.byteLength);
       this.onProgress_(
           this.estimator_.getEstimatedProgress(),

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -520,11 +520,6 @@ shaka.offline.Storage = class {
           // update.
           pendingContent.size = size;
           this.config_.offline.progressCallback(pendingContent, progress);
-        },
-        (initData) => {
-          if (this.config_.offline.usePersistentLicense) {
-            this.updateInitData_(initData, drmEngine, manifest);
-          }
         });
 
     try {
@@ -532,39 +527,11 @@ shaka.offline.Storage = class {
           downloader, storage, drmEngine, manifest, uri, metadata);
 
       manifestDB.size = await downloader.waitToFinish();
-      manifestDB.drmEngine = drmEngine.getDrmInfo();
-      manifestDB.expiration = drmEngine.getExpiration();
-      const sessions = drmEngine.getSessionIds();
-      manifestDB.sessionIds = this.config_.offline.usePersistentLicense ?
-          sessions : [];
+
       return manifestDB;
     } finally {
       await downloader.destroy();
     }
-  }
-
-  /**
-   * Updates DrmEngine and variant drmInfos with new InitData
-   * we got from segments
-   * @param {!Uint8Array} initData
-   * @param {!shaka.media.DrmEngine} drmEngine
-   * @param {shaka.extern.Manifest} manifest
-   * @private
-   */
-  updateInitData_(initData, drmEngine, manifest) {
-    const normalisedInitData = shaka.util.Pssh.normaliseInitData(
-        initData, true);
-    drmEngine.newInitData('cenc', normalisedInitData);
-    const variants = shaka.util.Periods.getAllVariantsFrom(
-        manifest.periods);
-    for (const variant of variants) {
-      for (const drmInfos of variant.drmInfos) {
-        drmInfos.initData = [
-          {initDataType: 'cenc', initData: normalisedInitData},
-        ];
-      }
-    }
-    drmEngine.initForStorage(variants, true);
   }
 
   /**
@@ -936,6 +903,13 @@ shaka.offline.Storage = class {
     const sessions = drmEngine.getSessionIds();
 
     if (drmInfo && this.config_.offline.usePersistentLicense) {
+      if (!sessions.length) {
+        throw new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.STORAGE,
+            shaka.util.Error.Code.NO_INIT_DATA_FOR_OFFLINE,
+            originalManifestUri);
+      }
       // Don't store init data, since we have stored sessions.
       drmInfo.initData = [];
     }

--- a/lib/polyfill/patchedmediakeys_ms.js
+++ b/lib/polyfill/patchedmediakeys_ms.js
@@ -110,15 +110,77 @@ shaka.polyfill.PatchedMediaKeysMs = class {
       return;
     }
 
+    // Alias
+    const PatchedMediaKeysMs = shaka.polyfill.PatchedMediaKeysMs;
+
     // NOTE: Because "this" is a real EventTarget, on IE, the event we dispatch
     // here must also be a real Event.
     const event2 =
     /** @type {!CustomEvent} */ (document.createEvent('CustomEvent'));
     event2.initCustomEvent('encrypted', false, false, null);
     event2.initDataType = 'cenc';
-    event2.initData = shaka.util.Pssh.normaliseInitData(event.initData);
+    event2.initData = PatchedMediaKeysMs.normaliseInitData_(event.initData);
 
     this.dispatchEvent(event2);
+  }
+
+  /**
+   * Normalise the initData array. This is to apply browser specific
+   * work-arounds, e.g. removing duplicates which appears to occur
+   * intermittently when the native msneedkey event fires (i.e. event.initData
+   * contains dupes).
+   *
+   * @param {?Uint8Array} initData
+   * @private
+   * @return {?Uint8Array}
+   */
+  static normaliseInitData_(initData) {
+    if (!initData) {
+      return initData;
+    }
+
+    const pssh = new shaka.util.Pssh(initData);
+
+    // If there is only a single pssh, return the original array.
+    if (pssh.dataBoundaries.length <= 1) {
+      return initData;
+    }
+
+    const unfilteredInitDatas = [];
+    for (const dataBoundary of pssh.dataBoundaries) {
+      const currPssh = initData.subarray(
+          dataBoundary.start,
+          dataBoundary.end + 1); // End is exclusive, hence the +1.
+
+      unfilteredInitDatas.push(currPssh);
+    }
+
+    // Dedupe psshData.
+    const dedupedInitDatas = [];
+    for (const initData of unfilteredInitDatas) {
+      const found = dedupedInitDatas.some((x) => {
+        return shaka.util.Uint8ArrayUtils.equal(x, initData);
+      });
+
+      if (!found) {
+        dedupedInitDatas.push(initData);
+      }
+    }
+
+    let targetLength = 0;
+    for (const initData of dedupedInitDatas) {
+      targetLength += initData.length;
+    }
+
+    // Flatten the array of Uint8Arrays back into a single Uint8Array.
+    const normalisedInitData = new Uint8Array(targetLength);
+    let offset = 0;
+    for (const initData of dedupedInitDatas) {
+      normalisedInitData.set(initData, offset);
+      offset += initData.length;
+    }
+
+    return normalisedInitData;
   }
 };
 

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -31,12 +31,10 @@ goog.require('shaka.util.Uint8ArrayUtils');
 shaka.util.Pssh = class {
   /**
    * @param {!Uint8Array} psshBox
-   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
-   * @param {boolean=} supressWarning Supresses no Pssh box found warning
    * @throws {shaka.util.Error} if a PSSH box is truncated or contains a size
    *   field over 53 bits.
    */
-  constructor(psshBox, extractMoov, supressWarning) {
+  constructor(psshBox) {
     /**
      * In hex.
      * @type {!Array.<string>}
@@ -54,18 +52,12 @@ shaka.util.Pssh = class {
     * discrete pssh within |psshBox|
     * */
     this.dataBoundaries = [];
-    if (extractMoov) {
-      new shaka.util.Mp4Parser()
-          .box('moov', shaka.util.Mp4Parser.children)
-          .fullBox('pssh', (box) => this.parseBox_(box))
-          .parse(psshBox.buffer);
-    } else {
-      new shaka.util.Mp4Parser()
-          .fullBox('pssh', (box) => this.parseBox_(box))
-          .parse(psshBox.buffer);
-    }
 
-    if (this.dataBoundaries.length == 0 && !supressWarning) {
+    new shaka.util.Mp4Parser()
+        .fullBox('pssh', (box) => this.parseBox_(box))
+        .parse(psshBox.buffer);
+
+    if (this.dataBoundaries.length == 0) {
       shaka.log.warning('No pssh box found!');
     }
   }
@@ -116,68 +108,5 @@ shaka.util.Pssh = class {
     if (box.reader.getPosition() != box.reader.getLength()) {
       shaka.log.warning('Mismatch between box size and data size!');
     }
-  }
-
-  /**
-   * Check if inidata contains Pssh
-   * @param {!Uint8Array} initData
-   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
-   * @return {boolean}
-   */
-  static containsPssh(initData, extractMoov) {
-    const pssh = new shaka.util.Pssh(initData, extractMoov, true);
-    return pssh.dataBoundaries.length !== 0;
-  }
-
-  /**
-  * Normalise the initData array. This is to apply browser specific
-  * work-arounds, e.g. removing duplicates which appears to occur
-  * intermittently when the native msneedkey event fires (i.e. event.initData
-  * contains dupes).
-  *
-  * @param {!Uint8Array} initData
-  * @param {boolean=} extractMoov
-  * @return {!Uint8Array}
-  * */
-  static normaliseInitData(initData, extractMoov) {
-    if (!initData) {
-      return initData;
-    }
-
-    const pssh = new shaka.util.Pssh(initData, extractMoov);
-
-    // If there is only a single pssh, return the original array.
-    if (pssh.dataBoundaries.length <= 1) {
-      return initData;
-    }
-
-    const unfilteredInitDatas = [];
-    for (let i = 0; i < pssh.dataBoundaries.length; i++) {
-      const currPssh = initData.subarray(
-          // we skip the header of the moov atom
-          // Happens when there is a native msneedkey event
-          pssh.dataBoundaries[i].start + (extractMoov ? 8 : 0),
-          // End is exclusive, hence the +1.
-          pssh.dataBoundaries[i].end + 1 + (extractMoov ? 8 : 0));
-      unfilteredInitDatas.push(currPssh);
-    }
-
-    // Dedupe psshData.
-    const dedupedInitDatas = [...new Set(unfilteredInitDatas)];
-
-    let targetLength = 0;
-    for (let i = 0; i < dedupedInitDatas.length; i++) {
-      targetLength += dedupedInitDatas[i].length;
-    }
-
-    // Flatten the array of Uint8Arrays back into a single Uint8Array.
-    const normalisedInitData = new Uint8Array(targetLength);
-    let offset = 0;
-    for (let i = 0; i < dedupedInitDatas.length; i++) {
-      normalisedInitData.set(dedupedInitDatas[i], offset);
-      offset += dedupedInitDatas[i].length;
-    }
-
-    return normalisedInitData;
   }
 };

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -940,6 +940,30 @@ describe('Storage', () => {
           .toBeRejectedWith(expected);
     });
 
+    it('throws an error if DRM sessions are not ready', async () => {
+      const drmInfo = makeDrmInfo();
+      const noSessions = [];
+
+      // TODO(vaage): Is there a way we can set the session ids without
+      //              needing to overload an internal call in storage.
+      const drm = new shaka.test.FakeDrmEngine();
+      drm.setDrmInfo(drmInfo);
+      drm.setSessionIds(noSessions);
+
+      overrideDrmAndManifest(
+          storage,
+          drm,
+          makeManifestWithPerStreamBandwidth());
+
+      const expected = Util.jasmineError(new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.STORAGE,
+          shaka.util.Error.Code.NO_INIT_DATA_FOR_OFFLINE,
+          manifestWithPerStreamBandwidthUri));
+      await expectAsync(storage.store(manifestWithPerStreamBandwidthUri))
+          .toBeRejectedWith(expected);
+    });
+
     it('throws an error if destroyed mid-store', async () => {
       const manifest = makeManifestWithPerStreamBandwidth();
 


### PR DESCRIPTION
Reverts google/shaka-player#2042

The PR as it landed broke some test cases and functionality for storing persistent licenses, and it doesn't seem to work even for its intended use case.