### PR TITLE
Ensure all goog.define calls are assigned

### DIFF
--- a/lib/debug/log.js
+++ b/lib/debug/log.js
@@ -118,7 +118,7 @@ shaka.log.Level = {
 /**
  * @define {number} the maximum log level.
  */
-goog.define('shaka.log.MAX_LOG_LEVEL', 3);
+shaka.log.MAX_LOG_LEVEL = goog.define('shaka.log.MAX_LOG_LEVEL', 3);
 
 
 // IE8 has no console unless it is opened in advance.


### PR DESCRIPTION
In uncompiled mode, goog.define stopped exporting its value as a side effect 4 months ago, and Closure Compiler has now made it an error to not assign the result.