### PR TITLE
feature: Offline PSSH support for manifest that are missing inline init data

### DIFF
--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -123,7 +123,7 @@ shaka.offline.DownloadManager = class {
       // Update initData
       if (isInitSegment) {
         const segmentBytes = shaka.util.BufferUtils.toUint8(response);
-        if (shaka.util.Pssh.containsPssh(segmentBytes, true)) {
+        if (shaka.util.Pssh.containsPssh(segmentBytes)) {
           this.onInitData_(segmentBytes);
         }
       }

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -19,9 +19,11 @@ goog.provide('shaka.offline.DownloadManager');
 
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.offline.DownloadProgressEstimator');
+goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Destroyer');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IDestroyable');
+goog.require('shaka.util.Pssh');
 
 
 /**
@@ -37,8 +39,9 @@ shaka.offline.DownloadManager = class {
    *
    * @param {!shaka.net.NetworkingEngine} networkingEngine
    * @param {function(number, number)} onProgress
+   * @param {function(!Uint8Array)} onInitData
    */
-  constructor(networkingEngine, onProgress) {
+  constructor(networkingEngine, onProgress, onInitData) {
     /** @private {shaka.net.NetworkingEngine} */
     this.networkingEngine_ = networkingEngine;
 
@@ -68,6 +71,14 @@ shaka.offline.DownloadManager = class {
      */
     this.onProgress_ = onProgress;
 
+    /**
+     * A callback for when a segment has new PSSH data and we pass
+     * on the initData to storage
+     *
+     * @private {function(!Uint8Array)}
+     */
+    this.onInitData_ = onInitData;
+
     /** @private {shaka.offline.DownloadProgressEstimator} */
     this.estimator_ = new shaka.offline.DownloadProgressEstimator();
   }
@@ -85,11 +96,12 @@ shaka.offline.DownloadManager = class {
    *    group will be created.
    * @param {shaka.extern.Request} request
    * @param {number} estimatedByteLength
+   * @param {boolean} initSegment
    * @param {function(BufferSource):!Promise} onDownloaded
    *   The callback for when this request has been downloaded. Downloading for
    *   |group| will pause until the promise returned by |onDownloaded| resolves.
    */
-  queue(groupId, request, estimatedByteLength, onDownloaded) {
+  queue(groupId, request, estimatedByteLength, initSegment, onDownloaded) {
     this.destroyer_.ensureNotDestroyed();
 
     const id = this.estimator_.open(estimatedByteLength);
@@ -106,6 +118,14 @@ shaka.offline.DownloadManager = class {
             shaka.util.Error.Severity.CRITICAL,
             shaka.util.Error.Category.STORAGE,
             shaka.util.Error.Code.OPERATION_ABORTED);
+      }
+
+      // Update initData
+      if (initSegment) {
+        const segmentBytes = shaka.util.BufferUtils.toUint8(response);
+        if (shaka.util.Pssh.containsPssh(segmentBytes, true)) {
+          this.onInitData_(segmentBytes);
+        }
       }
 
       // Update all our internal stats.

--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -96,12 +96,12 @@ shaka.offline.DownloadManager = class {
    *    group will be created.
    * @param {shaka.extern.Request} request
    * @param {number} estimatedByteLength
-   * @param {boolean} initSegment
+   * @param {boolean} isInitSegment
    * @param {function(BufferSource):!Promise} onDownloaded
    *   The callback for when this request has been downloaded. Downloading for
    *   |group| will pause until the promise returned by |onDownloaded| resolves.
    */
-  queue(groupId, request, estimatedByteLength, initSegment, onDownloaded) {
+  queue(groupId, request, estimatedByteLength, isInitSegment, onDownloaded) {
     this.destroyer_.ensureNotDestroyed();
 
     const id = this.estimator_.open(estimatedByteLength);
@@ -121,7 +121,7 @@ shaka.offline.DownloadManager = class {
       }
 
       // Update initData
-      if (initSegment) {
+      if (isInitSegment) {
         const segmentBytes = shaka.util.BufferUtils.toUint8(response);
         if (shaka.util.Pssh.containsPssh(segmentBytes, true)) {
           this.onInitData_(segmentBytes);

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -512,12 +512,15 @@ shaka.offline.Storage = class {
         uri, manifest, /* size */ 0, metadata);
 
     const isEncrypted = manifest.periods.some((period) => {
-      return period.variants.some((variant) => variant.drmInfos.length);
+      return period.variants.some((variant) => {
+        return variant.drmInfos && variant.drmInfos.length;
+      });
     });
     const includesInitData = manifest.periods.some((period) => {
       return period.variants.some((variant) => {
-        return variant.drmInfos.some((drmInfos) =>
-          drmInfos.initData.length);
+        return variant.drmInfos.some((drmInfos) => {
+          return drmInfos.initData && drmInfos.initData.length;
+        });
       });
     });
     const needsInitData = isEncrypted && !includesInitData;

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1081,7 +1081,7 @@ shaka.offline.Storage = class {
           downloadGroup,
           request,
           estimator.getInitSegmentEstimate(stream.id),
-          true,
+          /* isInitSegment */ true,
           async (data) => {
             const ids = await storage.addSegments([{data: data}]);
             this.segmentsFromStore_.push(ids[0]);
@@ -1100,7 +1100,7 @@ shaka.offline.Storage = class {
           downloadGroup,
           request,
           estimator.getSegmentEstimate(stream.id, segment),
-          false,
+          /* isInitSegment */ false,
           async (data) => {
             const ids = await storage.addSegments([{data: data}]);
             this.segmentsFromStore_.push(ids[0]);

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -339,7 +339,6 @@ shaka.offline.Storage = class {
           uri);
     }
 
-
     // Since we will need to use |drmEngine|, |activeHandle|, and |muxer| in the
     // catch/finally blocks, we need to define them out here. Since they may not
     // get initialized when we enter the catch/finally block, we need to assume
@@ -512,6 +511,17 @@ shaka.offline.Storage = class {
     const pendingContent = shaka.offline.StoredContentUtils.fromManifest(
         uri, manifest, /* size */ 0, metadata);
 
+    const isEncrypted = manifest.periods.some((period) => {
+      return period.variants.some((variant) => variant.drmInfos.length);
+    });
+    const includesInitData = manifest.periods.some((period) => {
+      return period.variants.some((variant) => {
+        return variant.drmInfos.some((drmInfos) =>
+          drmInfos.initData.length);
+      });
+    });
+    const needsInitData = isEncrypted && !includesInitData;
+
     /** @type {!shaka.offline.DownloadManager} */
     const downloader = new shaka.offline.DownloadManager(
         this.networkingEngine_,
@@ -520,6 +530,11 @@ shaka.offline.Storage = class {
           // update.
           pendingContent.size = size;
           this.config_.offline.progressCallback(pendingContent, progress);
+        },
+        (initData) => {
+          if (needsInitData && this.config_.offline.usePersistentLicense) {
+            this.updateInitData_(initData, drmEngine, manifest);
+          }
         });
 
     try {
@@ -527,11 +542,40 @@ shaka.offline.Storage = class {
           downloader, storage, drmEngine, manifest, uri, metadata);
 
       manifestDB.size = await downloader.waitToFinish();
+      manifestDB.expiration = drmEngine.getExpiration();
+      const sessions = drmEngine.getSessionIds();
+      manifestDB.sessionIds = this.config_.offline.usePersistentLicense ?
+          sessions : [];
 
       return manifestDB;
     } finally {
       await downloader.destroy();
     }
+  }
+
+  /**
+   * Updates DrmEngine and variant drmInfos with new InitData
+   * we got from segments
+   * @param {!Uint8Array} initData
+   * @param {!shaka.media.DrmEngine} drmEngine
+   * @param {shaka.extern.Manifest} manifest
+   * @private
+   */
+  updateInitData_(initData, drmEngine, manifest) {
+    const psshUtil = shaka.util.Pssh;
+    const drmInfo = drmEngine.getDrmInfo();
+    const pssh = psshUtil.getPsshFromInitData(initData, drmInfo.keySystem);
+    drmEngine.newInitData('cenc', pssh);
+    const variants = shaka.util.Periods.getAllVariantsFrom(
+        manifest.periods);
+    for (const variant of variants) {
+      for (const drmInfos of variant.drmInfos) {
+        drmInfos.initData = [
+          {initDataType: 'cenc', initData: pssh},
+        ];
+      }
+    }
+    drmEngine.initForStorage(variants, true);
   }
 
   /**
@@ -900,6 +944,12 @@ shaka.offline.Storage = class {
     });
 
     const usePersistentLicense = this.config_.offline.usePersistentLicense;
+    const drmInfo = drmEngine.getDrmInfo();
+
+    if (drmInfo && usePersistentLicense) {
+      // Don't store init data, since we have stored sessions.
+      drmInfo.initData = [];
+    }
 
     return {
       originalManifestUri: originalManifestUri,
@@ -908,7 +958,7 @@ shaka.offline.Storage = class {
       expiration: drmEngine.getExpiration(),
       periods: periods,
       sessionIds: usePersistentLicense ? drmEngine.getSessionIds() : [],
-      drmInfo: drmEngine.getDrmInfo(),
+      drmInfo: drmInfo,
       appMetadata: metadata,
     };
   }
@@ -1010,29 +1060,6 @@ shaka.offline.Storage = class {
     // Download each stream in parallel.
     const downloadGroup = stream.id;
 
-    shaka.offline.Storage.forEachSegment_(stream, startTime, (segment) => {
-      const request = shaka.util.Networking.createSegmentRequest(
-          segment.getUris(),
-          segment.startByte,
-          segment.endByte,
-          this.config_.streaming.retryParameters);
-
-      downloader.queue(
-          downloadGroup,
-          request,
-          estimator.getSegmentEstimate(stream.id, segment),
-          async (data) => {
-            const ids = await storage.addSegments([{data: data}]);
-            this.segmentsFromStore_.push(ids[0]);
-
-            streamDb.segments.push({
-              startTime: segment.startTime,
-              endTime: segment.endTime,
-              dataKey: ids[0],
-            });
-          });
-    });
-
     // Extract the init segment reference and PTO from the first segment.
     // Temporary, until the DB types are updated to match the manifest types.
     const firstPosition = stream.segmentIndex.find(startTime);
@@ -1054,12 +1081,37 @@ shaka.offline.Storage = class {
           downloadGroup,
           request,
           estimator.getInitSegmentEstimate(stream.id),
+          true,
           async (data) => {
             const ids = await storage.addSegments([{data: data}]);
             this.segmentsFromStore_.push(ids[0]);
             streamDb.initSegmentKey = ids[0];
           });
     }
+
+    shaka.offline.Storage.forEachSegment_(stream, startTime, (segment) => {
+      const request = shaka.util.Networking.createSegmentRequest(
+          segment.getUris(),
+          segment.startByte,
+          segment.endByte,
+          this.config_.streaming.retryParameters);
+
+      downloader.queue(
+          downloadGroup,
+          request,
+          estimator.getSegmentEstimate(stream.id, segment),
+          false,
+          async (data) => {
+            const ids = await storage.addSegments([{data: data}]);
+            this.segmentsFromStore_.push(ids[0]);
+
+            streamDb.segments.push({
+              startTime: segment.startTime,
+              endTime: segment.endTime,
+              dataKey: ids[0],
+            });
+          });
+    });
 
     return streamDb;
   }

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -899,20 +899,7 @@ shaka.offline.Storage = class {
           downloader, storage, estimator, drmEngine, manifest, period);
     });
 
-    const drmInfo = drmEngine.getDrmInfo();
-    const sessions = drmEngine.getSessionIds();
-
-    if (drmInfo && this.config_.offline.usePersistentLicense) {
-      if (!sessions.length) {
-        throw new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.STORAGE,
-            shaka.util.Error.Code.NO_INIT_DATA_FOR_OFFLINE,
-            originalManifestUri);
-      }
-      // Don't store init data, since we have stored sessions.
-      drmInfo.initData = [];
-    }
+    const usePersistentLicense = this.config_.offline.usePersistentLicense;
 
     return {
       originalManifestUri: originalManifestUri,
@@ -920,8 +907,8 @@ shaka.offline.Storage = class {
       size: 0,
       expiration: drmEngine.getExpiration(),
       periods: periods,
-      sessionIds: this.config_.offline.usePersistentLicense ? sessions : [],
-      drmInfo: drmInfo,
+      sessionIds: usePersistentLicense ? drmEngine.getSessionIds() : [],
+      drmInfo: drmEngine.getDrmInfo(),
       appMetadata: metadata,
     };
   }

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -871,13 +871,7 @@ shaka.util.Error.Code = {
    */
   'STORE_ALREADY_IN_PROGRESS': 9006,
 
-  /**
-   * The specified manifest is encrypted but does not specify any init data.
-   * Without init data specified in the manifest, the content will not be
-   * playable offline.
-   * <br> error.data[0] is the URI.
-   */
-  'NO_INIT_DATA_FOR_OFFLINE': 9007,
+  // RETIRED: 'NO_INIT_DATA_FOR_OFFLINE': 9007,
 
   /**
    * shaka.offline.Storage was constructed with a Player proxy instead of a

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -31,9 +31,9 @@ goog.require('shaka.util.Uint8ArrayUtils');
 shaka.util.Pssh = class {
   /**
    * @param {!Uint8Array} psshBox
-   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
+   * @param {boolean=} extractFromMoov boolean to extract pssh from moov atom
    */
-  constructor(psshBox, extractMoov) {
+  constructor(psshBox, extractFromMoov) {
     /**
      * In hex.
      * @type {!Array.<string>}
@@ -52,7 +52,7 @@ shaka.util.Pssh = class {
     * */
     this.dataBoundaries = [];
 
-    if (extractMoov) {
+    if (extractFromMoov) {
       new shaka.util.Mp4Parser()
           .box('moov', shaka.util.Mp4Parser.children)
           .fullBox('pssh', (box) => this.parseBox_(box))

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -47,19 +47,25 @@ shaka.util.Pssh = class {
     this.cencKeyIds = [];
 
     /*
-    * Array of tuples that define the startIndex + size for each
-    * discrete pssh within |psshBox|
-    * */
+     * Array of tuples that define the startIndex + size for each
+     * discrete pssh within |psshBox|
+     */
     this.dataBoundaries = [];
+
+    /**
+     * Array with the pssh founded.
+     * @type {!Array.<Uint8Array>}
+     */
+    this.data = [];
 
     if (extractFromMoov) {
       new shaka.util.Mp4Parser()
           .box('moov', shaka.util.Mp4Parser.children)
-          .fullBox('pssh', (box) => this.parseBox_(box, /* boxOffset */ 8))
+          .fullBox('pssh', (box) => this.parsePsshBox_(box))
           .parse(psshBox);
     } else {
       new shaka.util.Mp4Parser()
-          .fullBox('pssh', (box) => this.parseBox_(box, /* boxOffset */ 0))
+          .fullBox('pssh', (box) => this.parsePsshBox_(box))
           .parse(psshBox);
     }
 
@@ -71,10 +77,9 @@ shaka.util.Pssh = class {
 
   /**
    * @param {!shaka.extern.ParsedBox} box
-   * @param {number} boxOffset
    * @private
    */
-  parseBox_(box, boxOffset) {
+  parsePsshBox_(box) {
     goog.asserts.assert(
         box.version != null,
         'PSSH boxes are full boxes and must have a valid version');
@@ -88,7 +93,7 @@ shaka.util.Pssh = class {
       return;
     }
 
-    const systemId = shaka.util.Uint8ArrayUtils.toHex(box.reader.readBytes(16));
+    const systemId = box.reader.readBytes(16);
     const keyIds = [];
     if (box.version > 0) {
       const numKeyIds = box.reader.readUint32();
@@ -101,16 +106,18 @@ shaka.util.Pssh = class {
     }
 
     const dataSize = box.reader.readUint32();
-    box.reader.skip(dataSize);  // Ignore the data section.
+    const data = box.reader.readBytes(dataSize);
+    const pssh = shaka.util.Pssh.createPssh(data, systemId);
 
     // Now that everything has been successfully parsed from this box,
     // update member variables.
     this.cencKeyIds.push(...keyIds);
-    this.systemIds.push(systemId);
+    this.systemIds.push(shaka.util.Uint8ArrayUtils.toHex(systemId));
     this.dataBoundaries.push({
-      start: boxOffset + box.start,
-      end: boxOffset + box.start + box.size - 1,
+      start: box.start,
+      end: box.start + box.size - 1,
     });
+    this.data.push(pssh);
 
     if (box.reader.getPosition() != box.reader.getLength()) {
       shaka.log.warning('Mismatch between box size and data size!');
@@ -148,7 +155,7 @@ shaka.util.Pssh = class {
     psshBox.set(data, byteCursor);
     byteCursor += dataLength;
 
-    goog.asserts.assert(byteCursor === psshSize, 'MS PRO invalid length.');
+    goog.asserts.assert(byteCursor === psshSize, 'PSSH invalid length.');
     return psshBox;
   }
 
@@ -227,11 +234,10 @@ shaka.util.Pssh = class {
       return new Uint8Array(0);
     }
 
-    const pssh = initData.subarray(
-        psshInfo.dataBoundaries[index].start,
-        // End is exclusive, hence the +1.
-        psshInfo.dataBoundaries[index].end + 1);
-
+    const pssh = psshInfo.data[index];
+    if (!pssh) {
+      return new Uint8Array(0);
+    }
     return pssh;
   }
 };

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -31,9 +31,8 @@ goog.require('shaka.util.Uint8ArrayUtils');
 shaka.util.Pssh = class {
   /**
    * @param {!Uint8Array} psshBox
-   * @param {boolean=} extractFromMoov boolean to extract pssh from moov atom
    */
-  constructor(psshBox, extractFromMoov) {
+  constructor(psshBox) {
     /**
      * In hex.
      * @type {!Array.<string>}
@@ -58,16 +57,10 @@ shaka.util.Pssh = class {
      */
     this.data = [];
 
-    if (extractFromMoov) {
-      new shaka.util.Mp4Parser()
-          .box('moov', shaka.util.Mp4Parser.children)
-          .fullBox('pssh', (box) => this.parsePsshBox_(box))
-          .parse(psshBox);
-    } else {
-      new shaka.util.Mp4Parser()
-          .fullBox('pssh', (box) => this.parsePsshBox_(box))
-          .parse(psshBox);
-    }
+    new shaka.util.Mp4Parser()
+        .box('moov', shaka.util.Mp4Parser.children)
+        .fullBox('pssh', (box) => this.parsePsshBox_(box))
+        .parse(psshBox);
 
     if (this.dataBoundaries.length == 0) {
       shaka.log.warning('No pssh box found!');
@@ -163,11 +156,10 @@ shaka.util.Pssh = class {
   /**
    * Check if inidata contains Pssh
    * @param {!Uint8Array} initData
-   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
    * @return {boolean}
    */
-  static containsPssh(initData, extractMoov) {
-    const pssh = new shaka.util.Pssh(initData, extractMoov);
+  static containsPssh(initData) {
+    const pssh = new shaka.util.Pssh(initData);
     return pssh.dataBoundaries.length !== 0;
   }
 
@@ -226,7 +218,7 @@ shaka.util.Pssh = class {
    */
   static getPsshFromInitData(initData, keySystem) {
     const systemId = shaka.util.Pssh.defaultSystemIds_.get(keySystem);
-    const psshInfo = new shaka.util.Pssh(initData, true);
+    const psshInfo = new shaka.util.Pssh(initData);
 
     const index = psshInfo.systemIds.indexOf(systemId);
     // If the index is -1 we can not found the correct pssh

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -228,7 +228,10 @@ shaka.util.Pssh = class {
 
     const pssh = psshInfo.data[index];
     if (!pssh) {
-      return new Uint8Array(0);
+      throw new shaka.util.Error(
+          shaka.util.Error.Severity.CRITICAL,
+          shaka.util.Error.Category.DRM,
+          shaka.util.Error.Code.ENCRYPTED_CONTENT_WITHOUT_DRM_INFO);
     }
     return pssh;
   }

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -55,11 +55,11 @@ shaka.util.Pssh = class {
     if (extractFromMoov) {
       new shaka.util.Mp4Parser()
           .box('moov', shaka.util.Mp4Parser.children)
-          .fullBox('pssh', (box) => this.parseBox_(box))
+          .fullBox('pssh', (box) => this.parseBox_(box, /* boxOffset */ 8))
           .parse(psshBox);
     } else {
       new shaka.util.Mp4Parser()
-          .fullBox('pssh', (box) => this.parseBox_(box))
+          .fullBox('pssh', (box) => this.parseBox_(box, /* boxOffset */ 0))
           .parse(psshBox);
     }
 
@@ -73,7 +73,7 @@ shaka.util.Pssh = class {
    * @param {!shaka.extern.ParsedBox} box
    * @private
    */
-  parseBox_(box) {
+  parseBox_(box, boxOffset) {
     goog.asserts.assert(
         box.version != null,
         'PSSH boxes are full boxes and must have a valid version');
@@ -107,8 +107,8 @@ shaka.util.Pssh = class {
     this.cencKeyIds.push(...keyIds);
     this.systemIds.push(systemId);
     this.dataBoundaries.push({
-      start: box.start,
-      end: box.start + box.size - 1,
+      start: boxOffset + box.start,
+      end: boxOffset + box.start + box.size - 1,
     });
 
     if (box.reader.getPosition() != box.reader.getLength()) {
@@ -226,11 +226,10 @@ shaka.util.Pssh = class {
       return initData;
     }
 
-    // 8 due to moov header
     const pssh = initData.subarray(
-        psshInfo.dataBoundaries[index].start + 8,
+        psshInfo.dataBoundaries[index].start,
         // End is exclusive, hence the +1.
-        psshInfo.dataBoundaries[index].end + 1 + 8);
+        psshInfo.dataBoundaries[index].end + 1);
 
     return pssh;
   }

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -153,16 +153,27 @@ shaka.util.Pssh = class {
 
 
   /**
+   * Check if inidata contains Pssh
+   * @param {!Uint8Array} initData
+   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
+   * @return {boolean}
+   */
+  static containsPssh(initData, extractMoov) {
+    const pssh = new shaka.util.Pssh(initData, extractMoov);
+    return pssh.dataBoundaries.length !== 0;
+  }
+
+
+  /**
    * Normalise the initData array. This is to apply browser specific
    * work-arounds, e.g. removing duplicates which appears to occur
    * intermittently when the native msneedkey event fires (i.e. event.initData
    * contains dupes).
    *
    * @param {!Uint8Array} initData
-   * @param {boolean=} extractMoov
    * @return {!Uint8Array}
    */
-  static normaliseInitData(initData, extractMoov) {
+  static normaliseInitData(initData) {
     if (!initData) {
       return initData;
     }
@@ -177,11 +188,8 @@ shaka.util.Pssh = class {
     const unfilteredInitDatas = [];
     for (const dataBoundary of pssh.dataBoundaries) {
       const currPssh = initData.subarray(
-          // we skip the header of the moov atom
-          // Happens when there is a native msneedkey event
-          dataBoundary.start + (extractMoov ? 8 : 0),
-          // End is exclusive, hence the +1.
-          dataBoundary.end + 1 + (extractMoov ? 8 : 0));
+          dataBoundary.start,
+          dataBoundary.end + 1); // End is exclusive, hence the +1.
       unfilteredInitDatas.push(currPssh);
     }
 
@@ -200,4 +208,43 @@ shaka.util.Pssh = class {
 
     return shaka.util.Uint8ArrayUtils.concat(...dedupedInitDatas);
   }
+
+  /**
+   * Get a pssh from the given keySystem and moov.
+   *
+   * @param {!Uint8Array} initData
+   * @param {string} keySystem
+   * @return {!Uint8Array}
+   */
+  static getPsshFromInitData(initData, keySystem) {
+    const systemId = shaka.util.Pssh.defaultSystemIds_.get(keySystem);
+    const psshInfo = new shaka.util.Pssh(initData, true);
+
+    // If there is only a single pssh, return the original array.
+    if (psshInfo.dataBoundaries.length <= 1) {
+      return initData;
+    }
+
+    const index = psshInfo.systemIds.indexOf(systemId);
+    // If the index is -1 we can not found the correct pssh
+    if (index === -1) {
+      return initData;
+    }
+
+    // 8 due to moov header
+    const pssh = initData.subarray(
+        psshInfo.dataBoundaries[index].start + 8,
+        // End is exclusive, hence the +1.
+        psshInfo.dataBoundaries[index].end + 1 + 8);
+
+    return pssh;
+  }
 };
+
+
+shaka.util.Pssh.defaultSystemIds_ = new Map()
+    .set('org.w3.clearkey', '1077efecc0b24d02ace33c1e52e2fb4b')
+    .set('com.widevine.alpha', 'edef8ba979d64acea3c827dcd51d21ed')
+    .set('com.microsoft.playready', '9a04f07998404286ab92e65be0885f95')
+    .set('com.adobe.primetime', 'f239e769efa348509c16a903c6932efb');
+

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -224,7 +224,7 @@ shaka.util.Pssh = class {
     const index = psshInfo.systemIds.indexOf(systemId);
     // If the index is -1 we can not found the correct pssh
     if (index === -1) {
-      return initData;
+      return new Uint8Array(0);
     }
 
     const pssh = initData.subarray(

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -86,6 +86,9 @@ shaka.util.Pssh = class {
       return;
     }
 
+    const fullData = box.reader.readBytes(box.reader.getLength());
+    box.reader.seek(0);
+
     const systemId = box.reader.readBytes(16);
     const keyIds = [];
     if (box.version > 0) {
@@ -99,8 +102,22 @@ shaka.util.Pssh = class {
     }
 
     const dataSize = box.reader.readUint32();
-    const data = box.reader.readBytes(dataSize);
-    const pssh = shaka.util.Pssh.createPssh(data, systemId);
+    box.reader.skip(dataSize);  // Ignore the data section.
+
+    // PSSH construction
+    const psshSize = 0x4 + 0x4 + 0x4 + fullData.length;
+    /** @type {!Uint8Array} */
+    const psshBox = new Uint8Array(psshSize);
+    /** @type {!DataView} */
+    const psshData = shaka.util.BufferUtils.toDataView(psshBox);
+    let byteCursor = 0;
+    psshData.setUint32(byteCursor, psshSize);
+    byteCursor += 0x4;
+    psshData.setUint32(byteCursor, 0x70737368);  // 'pssh'
+    byteCursor += 0x4;
+    psshData.setUint32(byteCursor, box.version);  // flags (version)
+    byteCursor += 0x4;
+    psshBox.set(fullData, byteCursor);
 
     // Now that everything has been successfully parsed from this box,
     // update member variables.
@@ -110,7 +127,7 @@ shaka.util.Pssh = class {
       start: box.start,
       end: box.start + box.size - 1,
     });
-    this.data.push(pssh);
+    this.data.push(psshBox);
 
     if (box.reader.getPosition() != box.reader.getLength()) {
       shaka.log.warning('Mismatch between box size and data size!');

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -220,11 +220,6 @@ shaka.util.Pssh = class {
     const systemId = shaka.util.Pssh.defaultSystemIds_.get(keySystem);
     const psshInfo = new shaka.util.Pssh(initData, true);
 
-    // If there is only a single pssh, return the original array.
-    if (psshInfo.dataBoundaries.length <= 1) {
-      return initData;
-    }
-
     const index = psshInfo.systemIds.indexOf(systemId);
     // If the index is -1 we can not found the correct pssh
     if (index === -1) {

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -53,7 +53,7 @@ shaka.util.Pssh = class {
     this.dataBoundaries = [];
 
     /**
-     * Array with the pssh founded.
+     * Array with the pssh boxes found.
      * @type {!Array.<Uint8Array>}
      */
     this.data = [];

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -71,6 +71,7 @@ shaka.util.Pssh = class {
 
   /**
    * @param {!shaka.extern.ParsedBox} box
+   * @param {number} boxOffset
    * @private
    */
   parseBox_(box, boxOffset) {

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -31,8 +31,9 @@ goog.require('shaka.util.Uint8ArrayUtils');
 shaka.util.Pssh = class {
   /**
    * @param {!Uint8Array} psshBox
+   * @param {boolean=} extractMoov boolean to extract pssh from moov atom
    */
-  constructor(psshBox) {
+  constructor(psshBox, extractMoov) {
     /**
      * In hex.
      * @type {!Array.<string>}
@@ -51,9 +52,16 @@ shaka.util.Pssh = class {
     * */
     this.dataBoundaries = [];
 
-    new shaka.util.Mp4Parser()
-        .fullBox('pssh', (box) => this.parseBox_(box))
-        .parse(psshBox);
+    if (extractMoov) {
+      new shaka.util.Mp4Parser()
+          .box('moov', shaka.util.Mp4Parser.children)
+          .fullBox('pssh', (box) => this.parseBox_(box))
+          .parse(psshBox);
+    } else {
+      new shaka.util.Mp4Parser()
+          .fullBox('pssh', (box) => this.parseBox_(box))
+          .parse(psshBox);
+    }
 
     if (this.dataBoundaries.length == 0) {
       shaka.log.warning('No pssh box found!');
@@ -151,9 +159,10 @@ shaka.util.Pssh = class {
    * contains dupes).
    *
    * @param {!Uint8Array} initData
+   * @param {boolean=} extractMoov
    * @return {!Uint8Array}
    */
-  static normaliseInitData(initData) {
+  static normaliseInitData(initData, extractMoov) {
     if (!initData) {
       return initData;
     }
@@ -168,9 +177,11 @@ shaka.util.Pssh = class {
     const unfilteredInitDatas = [];
     for (const dataBoundary of pssh.dataBoundaries) {
       const currPssh = initData.subarray(
-          dataBoundary.start,
-          dataBoundary.end + 1); // End is exclusive, hence the +1.
-
+          // we skip the header of the moov atom
+          // Happens when there is a native msneedkey event
+          dataBoundary.start + (extractMoov ? 8 : 0),
+          // End is exclusive, hence the +1.
+          dataBoundary.end + 1 + (extractMoov ? 8 : 0));
       unfilteredInitDatas.push(currPssh);
     }
 

--- a/test/offline/storage_integration.js
+++ b/test/offline/storage_integration.js
@@ -948,30 +948,6 @@ describe('Storage', () => {
           .toBeRejectedWith(expected);
     });
 
-    it('throws an error if DRM sessions are not ready', async () => {
-      const drmInfo = makeDrmInfo();
-      const noSessions = [];
-
-      // TODO(vaage): Is there a way we can set the session ids without
-      //              needing to overload an internal call in storage.
-      const drm = new shaka.test.FakeDrmEngine();
-      drm.setDrmInfo(drmInfo);
-      drm.setSessionIds(noSessions);
-
-      overrideDrmAndManifest(
-          storage,
-          drm,
-          makeManifestWithPerStreamBandwidth());
-
-      const expected = Util.jasmineError(new shaka.util.Error(
-          shaka.util.Error.Severity.CRITICAL,
-          shaka.util.Error.Category.STORAGE,
-          shaka.util.Error.Code.NO_INIT_DATA_FOR_OFFLINE,
-          manifestWithPerStreamBandwidthUri));
-      await expectAsync(storage.store(manifestWithPerStreamBandwidthUri))
-          .toBeRejectedWith(expected);
-    });
-
     it('throws an error if destroyed mid-store', async () => {
       const manifest = makeManifestWithPerStreamBandwidth();
 


### PR DESCRIPTION
This is a PR for the same thing as #2042 for solving issue #1531 . I took the comments from #2042 and created a solution based on that with the issues resolved.

I test different type of contents and all works. However I know that the bot doesn't test on machine with persistent support, please review it manually also.