### PR TITLE
pass total size of pending request to shouldAbortCurrentRequest_

### DIFF
--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -166,6 +166,7 @@ shaka.extern.SchemePlugin;
  * time.
  * The third argument is the number of bytes remaining to be loaded in a
  * segment.
+ * The fourth argument is the total size of a segment in bytes.
  * @exportDoc
  */
 shaka.extern.ProgressUpdated;

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -155,7 +155,7 @@ shaka.extern.SchemePlugin;
 
 
 /**
- * @typedef {function(number, number, number)}
+ * @typedef {function(number, number, number, number)}
  *
  * @description
  * A callback function to handle progress event through networking engine in

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -674,7 +674,10 @@ shaka.media.StreamingEngine = class {
     // that since we just switched.
     const newSegment = this.getSegmentReferenceNeeded_(
         mediaState, presentationTime, bufferEnd, periodIndex);
-    let newSegmentSize = newSegment ? newSegment.getSize() : null;
+    let newSegmentSize =
+      (newSegment ? newSegment.getSize() : null) ||
+      mediaState.operation.getBytesTotal() ||
+      null;
     if (newSegmentSize == null) {
       return false;
     }

--- a/lib/net/http_fetch_plugin.js
+++ b/lib/net/http_fetch_plugin.js
@@ -130,6 +130,9 @@ shaka.net.HttpFetchPlugin = class {
       const contentLengthRaw = response.headers.get('Content-Length');
       const contentLength =
           contentLengthRaw ? parseInt(contentLengthRaw, 10) : 0;
+      if (contentLength > 0) {
+        progressUpdated(0, 0, contentLength, contentLength);
+      }
 
       const start = (controller) => {
         const push = async () => {
@@ -153,7 +156,7 @@ shaka.net.HttpFetchPlugin = class {
           // progressUpdated().
           if (currentTime - lastTime > 100 || readObj.done) {
             progressUpdated(currentTime - lastTime, loaded - lastLoaded,
-                contentLength - loaded);
+                contentLength - loaded, contentLength);
             lastLoaded = loaded;
             lastTime = currentTime;
           }

--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -105,7 +105,7 @@ shaka.net.HttpXHRPlugin = class {
         if (currentTime - lastTime > 100 ||
             (event.lengthComputable && event.loaded == event.total)) {
           progressUpdated(currentTime - lastTime, event.loaded - lastLoaded,
-              event.total - event.loaded);
+              event.total - event.loaded, event.total);
           lastLoaded = event.loaded;
           lastTime = currentTime;
         }

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -435,11 +435,12 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
           request,
           type,
           // The following function is passed to plugin.
-          (time, bytes, numBytesRemaining) => {
+          (time, bytes, numBytesRemaining, totalSize) => {
             if (this.onProgressUpdated_ && type == segment) {
               this.onProgressUpdated_(time, bytes);
               gotProgress = true;
               numBytesRemainingObj.setBytes(numBytesRemaining);
+              numBytesRemainingObj.setBytesTotal(totalSize);
             }
           });
     }).chain((response) => {
@@ -562,6 +563,8 @@ shaka.net.NetworkingEngine.NumBytesRemainingClass = class {
   constructor() {
     /** @private {number} */
     this.bytesToLoad_ = 0;
+    /** @private {number} */
+    this.totalBytes_ = 0;
   }
 
   /**
@@ -577,6 +580,20 @@ shaka.net.NetworkingEngine.NumBytesRemainingClass = class {
   getBytes() {
     return this.bytesToLoad_;
   }
+
+  /**
+   * @param {number} bytesToLoad
+   */
+  setBytesTotal(bytesToLoad) {
+    this.totalBytes_ = bytesToLoad;
+  }
+
+  /**
+   * @return {number}
+   */
+  getBytesTotal() {
+    return this.totalBytes_;
+  }
 };
 
 /**
@@ -588,36 +605,43 @@ shaka.net.NetworkingEngine.NumBytesRemainingClass = class {
  * @export
  */
 shaka.net.NetworkingEngine.PendingRequest =
-    class extends shaka.util.AbortableOperation {
-      /**
-       * @param {!Promise} promise
-       *   A Promise which represents the underlying operation.  It is resolved
-       *   when the operation is complete, and rejected if the operation fails
-       *   or is aborted.  Aborted operations should be rejected with a
-       *   shaka.util.Error object using the error code OPERATION_ABORTED.
-       * @param {function():!Promise} onAbort
-       *   Will be called by this object to abort the underlying operation.
-       *   This is not cancelation, and will not necessarily result in any work
-       *   being undone.  abort() should return a Promise which is resolved when
-       *   the underlying operation has been aborted.  The returned Promise
-       *   should never be rejected.
-       * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
-       *   numBytesRemainingObj
-       */
-      constructor(promise, onAbort, numBytesRemainingObj) {
-        super(promise, onAbort);
+  class extends shaka.util.AbortableOperation {
+    /**
+     * @param {!Promise} promise
+     *   A Promise which represents the underlying operation.  It is resolved
+     *   when the operation is complete, and rejected if the operation fails
+     *   or is aborted.  Aborted operations should be rejected with a
+     *   shaka.util.Error object using the error code OPERATION_ABORTED.
+     * @param {function():!Promise} onAbort
+     *   Will be called by this object to abort the underlying operation.
+     *   This is not cancelation, and will not necessarily result in any work
+     *   being undone.  abort() should return a Promise which is resolved when
+     *   the underlying operation has been aborted.  The returned Promise
+     *   should never be rejected.
+     * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
+     *   numBytesRemainingObj
+     */
+    constructor(promise, onAbort, numBytesRemainingObj) {
+      super(promise, onAbort);
 
-        /** @private {shaka.net.NetworkingEngine.NumBytesRemainingClass} */
-        this.bytesRemaining_ = numBytesRemainingObj;
-      }
+      /** @private {shaka.net.NetworkingEngine.NumBytesRemainingClass} */
+      this.bytesRemaining_ = numBytesRemainingObj;
+    }
 
-      /**
-       * @return {number}
-       */
-      getBytesRemaining() {
-        return this.bytesRemaining_.getBytes();
-      }
-    };
+    /**
+     * @return {number}
+     */
+    getBytesRemaining() {
+      return this.bytesRemaining_.getBytes();
+    }
+
+    /**
+   * @return {number}
+   */
+    getBytesTotal() {
+      return this.bytesRemaining_.getBytesTotal();
+    }
+  };
 
 /**
  * Request types.  Allows a filter to decide which requests to read/alter.

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -605,43 +605,43 @@ shaka.net.NetworkingEngine.NumBytesRemainingClass = class {
  * @export
  */
 shaka.net.NetworkingEngine.PendingRequest =
-  class extends shaka.util.AbortableOperation {
-    /**
-     * @param {!Promise} promise
-     *   A Promise which represents the underlying operation.  It is resolved
-     *   when the operation is complete, and rejected if the operation fails
-     *   or is aborted.  Aborted operations should be rejected with a
-     *   shaka.util.Error object using the error code OPERATION_ABORTED.
-     * @param {function():!Promise} onAbort
-     *   Will be called by this object to abort the underlying operation.
-     *   This is not cancelation, and will not necessarily result in any work
-     *   being undone.  abort() should return a Promise which is resolved when
-     *   the underlying operation has been aborted.  The returned Promise
-     *   should never be rejected.
-     * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
-     *   numBytesRemainingObj
-     */
-    constructor(promise, onAbort, numBytesRemainingObj) {
-      super(promise, onAbort);
+    class extends shaka.util.AbortableOperation {
+      /**
+       * @param {!Promise} promise
+       *   A Promise which represents the underlying operation.  It is resolved
+       *   when the operation is complete, and rejected if the operation fails
+       *   or is aborted.  Aborted operations should be rejected with a
+       *   shaka.util.Error object using the error code OPERATION_ABORTED.
+       * @param {function():!Promise} onAbort
+       *   Will be called by this object to abort the underlying operation.
+       *   This is not cancelation, and will not necessarily result in any work
+       *   being undone.  abort() should return a Promise which is resolved when
+       *   the underlying operation has been aborted.  The returned Promise
+       *   should never be rejected.
+       * @param {shaka.net.NetworkingEngine.NumBytesRemainingClass}
+       *   numBytesRemainingObj
+       */
+      constructor(promise, onAbort, numBytesRemainingObj) {
+        super(promise, onAbort);
 
-      /** @private {shaka.net.NetworkingEngine.NumBytesRemainingClass} */
-      this.bytesRemaining_ = numBytesRemainingObj;
-    }
+        /** @private {shaka.net.NetworkingEngine.NumBytesRemainingClass} */
+        this.bytesRemaining_ = numBytesRemainingObj;
+      }
 
-    /**
-     * @return {number}
-     */
-    getBytesRemaining() {
-      return this.bytesRemaining_.getBytes();
-    }
+      /**
+       * @return {number}
+       */
+      getBytesRemaining() {
+        return this.bytesRemaining_.getBytes();
+      }
 
-    /**
-   * @return {number}
-   */
-    getBytesTotal() {
-      return this.bytesRemaining_.getBytesTotal();
-    }
-  };
+      /**
+       * @return {number}
+       */
+      getBytesTotal() {
+        return this.bytesRemaining_.getBytesTotal();
+      }
+    };
 
 /**
  * Request types.  Allows a filter to decide which requests to read/alter.


### PR DESCRIPTION
The logic introduced in https://github.com/google/shaka-player/issues/1051 does not work for segment references created via `createFromTimeline_`  because their size in unknown from the manifest.

In this PR we pass a size of a segment from xhr/fetch via `progressUpdated` and use this value `shouldAbortCurrentRequest_` as a `newSegmentSize`.


The stream I am using: https://strm.yandex.ru/kal/demo_channel/manifest.mpd

The problem can be reproduced this way:
1. play a stream on a good connection with abr enabled until quality rises to 1080p
2. throttle connection to 3g via devtools
3. abr will downgrade stream quality, but the segments will still be fetched from 1080p