### PR TITLE
calculate approximate segment size based on bandwidth

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -676,6 +676,13 @@ shaka.media.StreamingEngine = class {
         mediaState, presentationTime, bufferEnd, periodIndex);
     let newSegmentSize = newSegment ? newSegment.getSize() : null;
     if (newSegmentSize == null) {
+      // compute approximate segment size using stream bandwidth
+      const duration = newSegment.getEndTime() - newSegment.getStartTime();
+      // bandwidth is in bits per second, and the size is in bytes
+      newSegmentSize = duration * mediaState.stream.bandwidth / 8;
+    }
+
+    if (isNaN(newSegmentSize)) {
       return false;
     }
 


### PR DESCRIPTION
The logic introduced in https://github.com/google/shaka-player/issues/1051 does not work for segment references created via `createFromTimeline_`  because their size in unknown from the manifest.

The stream I am using: https://strm.yandex.ru/kal/demo_channel/manifest.mpd
The problem can be reproduced this way:
1. play a stream on a good connection with abr enabled until quality rises to 1080p
2. throttle connection to 3g via devtools
3. abr switches quality, but 1080p chunk is still loading


rework of https://github.com/google/shaka-player/pull/2174 based on @joeyparrish [review](https://github.com/google/shaka-player/pull/2174#pullrequestreview-298451296)
