### PR TITLE
fix: add platform support verification to PiP polyfill

### DIFF
--- a/lib/polyfill/pip_webkit.js
+++ b/lib/polyfill/pip_webkit.js
@@ -47,6 +47,16 @@ shaka.polyfill.PiPWebkit = class {
       return;
     }
 
+    const video =
+      /** @type {!HTMLVideoElement} */ (document.createElement('video'));
+    const isPipPresentationModeSupported =
+      video.webkitSupportsPresentationMode('picture-in-picture');
+
+    if (!isPipPresentationModeSupported) {
+      // Webkit UA doesn't support picture-in-picture.
+      return;
+    }
+
     const PiPWebkit = shaka.polyfill.PiPWebkit;
     shaka.log.debug('PiPWebkit.install');
 


### PR DESCRIPTION
Add a check if platform supports picture-in-picture as in iOS the polyfill breaks native APIs, see #2199 for more details.

Please note:
Unable to use static string `shaka.polyfill.PiPWebkit.PIP_MODE_` as there's a mix of ES6 features and lack of static class members support so checks fail

fixes #2199