### PR TITLE
Disable indexedDB support if a SecurityError is thrown

### DIFF
--- a/lib/polyfill/indexed_db.js
+++ b/lib/polyfill/indexed_db.js
@@ -41,12 +41,10 @@ shaka.polyfill.IndexedDB = class {
       try {
         window.indexedDB;
       } catch (e) {
-        if (e instanceof SecurityError) {
-          shaka.log.debug('Removing IndexedDB due to SecurityError');
-          delete window.indexedDB;
-          goog.asserts.assert(
-              !window.indexedDB, 'Failed to override window.indexedDB');
-        }
+        shaka.log.debug('Removing IndexedDB');
+        delete window.indexedDB;
+        goog.asserts.assert(
+            !window.indexedDB, 'Failed to override window.indexedDB');
       }
     }
   }

--- a/lib/polyfill/indexed_db.js
+++ b/lib/polyfill/indexed_db.js
@@ -41,7 +41,7 @@ shaka.polyfill.IndexedDB = class {
       try {
         window.indexedDB;
       } catch (e) {
-        if (!e instanceof SecurityError) {
+        if (e instanceof SecurityError) {
           shaka.log.debug('Removing IndexedDB due to SecurityError');
           delete window.indexedDB;
           goog.asserts.assert(

--- a/lib/polyfill/indexed_db.js
+++ b/lib/polyfill/indexed_db.js
@@ -37,6 +37,17 @@ shaka.polyfill.IndexedDB = class {
       delete window.indexedDB;
       goog.asserts.assert(
           !window.indexedDB, 'Failed to override window.indexedDB');
+    } else {
+      try {
+        window.indexedDB;
+      } catch (e) {
+        if (!e instanceof SecurityError) {
+          shaka.log.debug('Removing IndexedDB due to SecurityError');
+          delete window.indexedDB;
+          goog.asserts.assert(
+              !window.indexedDB, 'Failed to override window.indexedDB');
+        }
+      }
     }
   }
 };

--- a/lib/polyfill/indexed_db.js
+++ b/lib/polyfill/indexed_db.js
@@ -32,20 +32,27 @@ shaka.polyfill.IndexedDB = class {
   static install() {
     shaka.log.debug('IndexedDB.install');
 
+    let disableIDB = false;
     if (shaka.util.Platform.isChromecast()) {
       shaka.log.debug('Removing IndexedDB from ChromeCast');
+      disableIDB = true;
+    } else {
+      try {
+        // This is necessary to avoid Closure compiler over optimize this block and remove it
+        // if it looks like a noop
+        if (window.indexedDB) {
+          disableIDB = false;
+        }
+      } catch (e) {
+        shaka.log.debug('Removing IndexedDB due to an exception when accessing it');
+        disableIDB = true;
+      }
+    }
+
+    if (disableIDB) {
       delete window.indexedDB;
       goog.asserts.assert(
           !window.indexedDB, 'Failed to override window.indexedDB');
-    } else {
-      try {
-        window.indexedDB;
-      } catch (e) {
-        shaka.log.debug('Removing IndexedDB');
-        delete window.indexedDB;
-        goog.asserts.assert(
-            !window.indexedDB, 'Failed to override window.indexedDB');
-      }
     }
   }
 };

--- a/lib/polyfill/indexed_db.js
+++ b/lib/polyfill/indexed_db.js
@@ -38,13 +38,14 @@ shaka.polyfill.IndexedDB = class {
       disableIDB = true;
     } else {
       try {
-        // This is necessary to avoid Closure compiler over optimize this block and remove it
-        // if it looks like a noop
+        // This is necessary to avoid Closure compiler over optimize this
+        // block and remove it if it looks like a noop
         if (window.indexedDB) {
           disableIDB = false;
         }
       } catch (e) {
-        shaka.log.debug('Removing IndexedDB due to an exception when accessing it');
+        shaka.log.debug(
+            'Removing IndexedDB due to an exception when accessing it');
         disableIDB = true;
       }
     }


### PR DESCRIPTION
When using Shaka player inside an cross domain iframe in Firefox with 3rd party cookies blocked, `probeSupport` method throws a SecurityError.

The error is thrown in lib/offline/indexeddb/storage_mechanism.js:340, when accessing `window.indexedDB`.

The proposed solution removes `window.indexedDB` with a polyfill, using the same approach implemented for Chromecast.