### PR TITLE
Allow video to go complete fullscreen on Android

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -602,7 +602,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         if (document.pictureInPictureElement) {
           await document.exitPictureInPicture();
         }
-        await this.videoContainer_.requestFullscreen();
+        await this.videoContainer_.requestFullscreen({ "navigationUI": "hide" });
       } catch (error) {
         this.dispatchEvent(new shaka.util.FakeEvent('error', {
           detail: error,
@@ -949,7 +949,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
     if (screen.orientation.type.includes('landscape') &&
         !document.fullscreenElement) {
-      await this.videoContainer_.requestFullscreen();
+      await this.videoContainer_.requestFullscreen({ "navigationUI": "hide" });
     } else if (screen.orientation.type.includes('portrait') &&
         document.fullscreenElement) {
       await document.exitFullscreen();


### PR DESCRIPTION
Hide the navbar on Android devices with onscreen navigation.

Fixes #2324

Details about this fullscreen option can be found on Fullscreen API documentation:
https://developer.mozilla.org/en-US/docs/Web/API/FullscreenOptions/navigationUI