### PR TITLE
Add lower case codec string for IMSC1 Text profile

### DIFF
--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -80,4 +80,11 @@ shaka.text.Mp4TtmlParser = class {
 shaka.text.TextEngine.registerParser(
     'application/mp4; codecs="stpp"', shaka.text.Mp4TtmlParser);
 shaka.text.TextEngine.registerParser(
+    'application/mp4; codecs="stpp.ttml.im1t"', shaka.text.Mp4TtmlParser);
+// Legacy codec string uses capital "TTML", i.e.: prior to HLS rfc8216bis:
+//   Note that if a Variant Stream specifies one or more Renditions that
+//   include IMSC subtitles, the CODECS attribute MUST indicate this with a
+//   format identifier such as "stpp.ttml.im1t".
+// (https://tools.ietf.org/html/draft-pantos-hls-rfc8216bis-05#section-4.4.5.2)
+shaka.text.TextEngine.registerParser(
     'application/mp4; codecs="stpp.TTML.im1t"', shaka.text.Mp4TtmlParser);

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -1311,7 +1311,7 @@ describe('HlsParser', () => {
       '#EXTM3U\n',
       '#EXT-X-MEDIA:TYPE=SUBTITLES,GROUP-ID="sub1",LANGUAGE="eng",',
       'URI="text"\n',
-      '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1,stpp.TTML.im1t",',
+      '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1,stpp.ttml.im1t",',
       'RESOLUTION=960x540,FRAME-RATE=60,SUBTITLES="sub1"\n',
       'video\n',
     ].join('');
@@ -1333,7 +1333,7 @@ describe('HlsParser', () => {
         });
         period.addPartialTextStream((stream) => {
           stream.language = 'en';
-          stream.mime('application/mp4', 'stpp.TTML.im1t');
+          stream.mime('application/mp4', 'stpp.ttml.im1t');
         });
       });
     });


### PR DESCRIPTION
Fixes #2378
 - register TTML handler for `stpp.ttml.im1t` codec
 - adjusted HLS test case to comply with rfc8216bis section 4.4.5.2
This change keeps the legacy support for codec string `stpp.TTML.im1t`. Note that while unit tests pass without this, there is good reason to assume that there is still plenty content out there using the legacy content string.

To test:
 - HLS: https://demo.unified-streaming.com/video/tears-of-steel/master_hls_fmp4_clear.m3u8
 - DASH: https://demo.unified-streaming.com/video/tears-of-steel/tears-of-steel-ttml.ism/.mpd