### PR TITLE
Fix download contents with Widevine and Playready in the manifest.

### DIFF
--- a/lib/offline/download_manager.js
+++ b/lib/offline/download_manager.js
@@ -27,7 +27,7 @@ shaka.offline.DownloadManager = class {
    *
    * @param {!shaka.net.NetworkingEngine} networkingEngine
    * @param {function(number, number)} onProgress
-   * @param {function(!Uint8Array)} onInitData
+   * @param {function(!Uint8Array, string)} onInitData
    */
   constructor(networkingEngine, onProgress, onInitData) {
     /** @private {shaka.net.NetworkingEngine} */
@@ -63,7 +63,7 @@ shaka.offline.DownloadManager = class {
      * A callback for when a segment has new PSSH data and we pass
      * on the initData to storage
      *
-     * @private {function(!Uint8Array)}
+     * @private {function(!Uint8Array, string)}
      */
     this.onInitData_ = onInitData;
 
@@ -112,8 +112,11 @@ shaka.offline.DownloadManager = class {
       if (isInitSegment) {
         const segmentBytes = shaka.util.BufferUtils.toUint8(response);
         const pssh = new shaka.util.Pssh(segmentBytes);
-        for (const elem of pssh.data) {
-          this.onInitData_(elem);
+        for (const key in pssh.data) {
+          const index = Number(key);
+          const data = pssh.data[index];
+          const systemId = pssh.systemIds[index];
+          this.onInitData_(data, systemId);
         }
       }
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -515,6 +515,13 @@ shaka.offline.Storage = class {
     });
     const needsInitData = isEncrypted && !includesInitData;
 
+    let currentSystemId = null;
+    if (needsInitData) {
+      const drmInfo = drmEngine.getDrmInfo();
+      currentSystemId =
+          shaka.offline.Storage.defaultSystemIds_.get(drmInfo.keySystem);
+    }
+
     /** @type {!shaka.offline.DownloadManager} */
     const downloader = new shaka.offline.DownloadManager(
         this.networkingEngine_,
@@ -525,13 +532,9 @@ shaka.offline.Storage = class {
           this.config_.offline.progressCallback(pendingContent, progress);
         },
         (initData, systemId) => {
-          if (needsInitData && this.config_.offline.usePersistentLicense) {
-            const drmInfo = drmEngine.getDrmInfo();
-            const currentSystemId =
-                shaka.offline.Storage.defaultSystemIds_.get(drmInfo.keySystem);
-            if (currentSystemId == systemId) {
-              drmEngine.newInitData('cenc', initData);
-            }
+          if (needsInitData && this.config_.offline.usePersistentLicense &&
+              currentSystemId == systemId) {
+            drmEngine.newInitData('cenc', initData);
           }
         });
 

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -524,9 +524,14 @@ shaka.offline.Storage = class {
           pendingContent.size = size;
           this.config_.offline.progressCallback(pendingContent, progress);
         },
-        (initData) => {
+        (initData, systemId) => {
           if (needsInitData && this.config_.offline.usePersistentLicense) {
-            drmEngine.newInitData('cenc', initData);
+            const drmInfo = drmEngine.getDrmInfo();
+            const currentSystemId =
+                shaka.offline.Storage.defaultSystemIds_.get(drmInfo.keySystem);
+            if (currentSystemId == systemId) {
+              drmEngine.newInitData('cenc', initData);
+            }
           }
         });
 
@@ -1413,5 +1418,11 @@ shaka.offline.Storage = class {
     }
   }
 };
+
+shaka.offline.Storage.defaultSystemIds_ = new Map()
+    .set('org.w3.clearkey', '1077efecc0b24d02ace33c1e52e2fb4b')
+    .set('com.widevine.alpha', 'edef8ba979d64acea3c827dcd51d21ed')
+    .set('com.microsoft.playready', '9a04f07998404286ab92e65be0885f95')
+    .set('com.adobe.primetime', 'f239e769efa348509c16a903c6932efb');
 
 shaka.Player.registerSupportPlugin('offline', shaka.offline.Storage.support);

--- a/lib/util/pssh.js
+++ b/lib/util/pssh.js
@@ -163,10 +163,3 @@ shaka.util.Pssh = class {
   }
 };
 
-
-shaka.util.Pssh.defaultSystemIds_ = new Map()
-    .set('org.w3.clearkey', '1077efecc0b24d02ace33c1e52e2fb4b')
-    .set('com.widevine.alpha', 'edef8ba979d64acea3c827dcd51d21ed')
-    .set('com.microsoft.playready', '9a04f07998404286ab92e65be0885f95')
-    .set('com.adobe.primetime', 'f239e769efa348509c16a903c6932efb');
-


### PR DESCRIPTION
The commit https://github.com/google/shaka-player/commit/c56fe7db1932f236989934bb095e161a48f82f61 introduce a regression in manifest with Playready and Widevine.
The commit doesn't filter initData that are not part of the current DRM selected for download.