### PR TITLE
Fix the bug that UTCTiming is ignored even when autoCorrectDrift is off

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Sanborn Hilland <sanbornh@rogers.com>
 Sander Saares <sander@saares.eu>
 TalkTalk Plc <*@talktalkplc.com>
 Tomas Tichy <mr.tichyt@gmail.com>
+Tomohiro Matsuzawa <thmatuza75@hotmail.com>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -82,6 +82,7 @@ Tim Plummer <objelisks@google.com>
 Timothy Drews <tdrews@google.com>
 Tomas Bucher <collapsingtesseract@gmail.com>
 Tomas Tichy <mr.tichyt@gmail.com>
+Tomohiro Matsuzawa <thmatuza75@hotmail.com>
 Torbjörn Einarsson <torbjorn.einarsson@edgeware.tv>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 Vasanth Polipelli <vasanthap@google.com>

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -215,8 +215,10 @@ shaka.media.PresentationTimeline = class {
         (max, r) => { return Math.max(max, r.endTime - r.startTime); },
         this.maxSegmentDuration_);
 
-    this.maxSegmentEndTime_ =
-        Math.max(this.maxSegmentEndTime_, lastReferenceEndTime);
+    if (this.autoCorrectDrift_) {
+      this.maxSegmentEndTime_ =
+          Math.max(this.maxSegmentEndTime_, lastReferenceEndTime);
+    }
 
     if (this.presentationStartTime_ != null && this.autoCorrectDrift_) {
       // Since we have explicit segment end times, calculate a presentation

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -215,10 +215,8 @@ shaka.media.PresentationTimeline = class {
         (max, r) => { return Math.max(max, r.endTime - r.startTime); },
         this.maxSegmentDuration_);
 
-    if (this.autoCorrectDrift_) {
-      this.maxSegmentEndTime_ =
-          Math.max(this.maxSegmentEndTime_, lastReferenceEndTime);
-    }
+    this.maxSegmentEndTime_ =
+        Math.max(this.maxSegmentEndTime_, lastReferenceEndTime);
 
     if (this.presentationStartTime_ != null && this.autoCorrectDrift_) {
       // Since we have explicit segment end times, calculate a presentation
@@ -438,7 +436,7 @@ shaka.media.PresentationTimeline = class {
 
     // If we have explicit segment times, we're not using the presentation
     // start time.
-    if (this.maxSegmentEndTime_ != null) {
+    if (this.maxSegmentEndTime_ != null && this.autoCorrectDrift_) {
       return false;
     }
 


### PR DESCRIPTION
This is the fix for this issue.
https://github.com/google/shaka-player/issues/2411

`shaka.dash.DashParser.processManifest` is using the `presentationTimeline.usingPresentationStartTime()` to determine if it parses UTCTiming or not.

The `usingPresentationStartTime` always returns the false when maxSegmentEndTime_ is not null.

When the manifest has `SegmentTimeline`, it seems always setting a value to `maxSegmentEndTime_`.

I added the code not to set `maxSegmentEndTime_` when `autoCorrectDrift` is false.