### PR TITLE
Add loaded event to the player

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -159,6 +159,15 @@ goog.require('shaka.util.Timer');
 
 
 /**
+ * @event shaka.Player.LoadedEvent
+ * @description Fired when the player ends the load.
+ * @property {string} type
+ *   'loaded'
+ * @exportDoc
+ */
+
+
+/**
  * @event shaka.Player.UnloadingEvent
  * @description Fired when the player unloads or fails to load.
  *   Used by the Cast receiver to determine idle state.
@@ -1039,7 +1048,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           shaka.util.Error.Category.PLAYER,
           shaka.util.Error.Code.NO_VIDEO_ELEMENT));
 
-      events.onEnd = () => resolve();
+      events.onEnd = () => {
+        resolve();
+        // We dispatch the loaded event when the load promise is resolved
+        this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Loaded));
+      };
       events.onCancel = () => reject(this.createAbortLoadError_());
       events.onError = (e) => reject(e);
     });
@@ -5481,6 +5494,7 @@ shaka.Player.EventName = {
   Error: 'error',
   ExpirationUpdated: 'expirationupdated',
   LargeGap: 'largegap',
+  Loaded: 'loaded',
   Loading: 'loading',
   ManifestParsed: 'manifestparsed',
   OnStateChange: 'onstatechange',


### PR DESCRIPTION
Add a new event in the player that indicate that the load is complete.

This is necessary for SS ADS because it does the `player.load` process.