### PR TITLE
Add support of fontSize in percentages and cell resolution unit for TTML captions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -50,6 +50,7 @@ SameGoal Inc. <*@samegoal.com>
 Sanborn Hilland <sanbornh@rogers.com>
 Sander Saares <sander@saares.eu>
 TalkTalk Plc <*@talktalkplc.com>
+Tatsiana Gelahova <tatsiana.gelahova@gmail.com>
 Tomas Tichy <mr.tichyt@gmail.com>
 Tomohiro Matsuzawa <thmatuza75@hotmail.com>
 Toshihiro Suzuki <t.suzuki326@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -76,6 +76,7 @@ Sandra Lokshina <ismena@google.com>
 Satheesh Velmurugan <satheesh@philo.com>
 Semih Gokceoglu <semih.gkcoglu@gmail.com>
 Seth Madison <seth@philo.com>
+Tatsiana Gelahova <tatsiana.gelahova@gmail.com>
 Theodore Abshire <theodab@google.com>
 Thomas Stephens <thomas@ustudio.com>
 Tim Plummer <objelisks@google.com>

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -250,13 +250,7 @@ shaka.extern.Cue = class {
      * The number of horizontal and vertical cells into which
      * the Root Container Region area is divided
      *
-     * @typedef {{ columns: number, rows: number }}
-     *
-     * @property {number} columns
-     *     The number of vertical cells
-     * @property {number} rows
-     *     The number of horizontal cells
-     *
+     * @type {{ columns: number, rows: number }}
      * @exportDoc
      */
     this.cellResolution;

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -249,9 +249,14 @@ shaka.extern.Cue = class {
     /**
      * The number of horizontal and vertical cells into which
      * the Root Container Region area is divided
-     * cellResolution[0] - columns
-     * cellResolution[1] - rows
-     * @type {!Array.<number>}
+     *
+     * @typedef {{ columns: number, rows: number }}
+     *
+     * @property {number} columns
+     *     The number of vertical cells
+     * @property {number} rows
+     *     The number of horizontal cells
+     *
      * @exportDoc
      */
     this.cellResolution;

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -247,6 +247,22 @@ shaka.extern.Cue = class {
     this.backgroundColor;
 
     /**
+     * The number of horizontal cells into which the Root Container
+     * Region area is divided
+     * @type {!number}
+     * @exportDoc
+     */
+    this.cellResolutionRows;
+
+    /**
+     * The number of vertical cells into which the Root Container
+     * Region area is divided
+     * @type {!number}
+     * @exportDoc
+     */
+    this.cellResolutionColumns;
+
+    /**
      * Image background represented by any string that would be
      * accepted in image HTML element.
      * E. g. 'data:[mime type];base64,[data]'.

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -247,20 +247,14 @@ shaka.extern.Cue = class {
     this.backgroundColor;
 
     /**
-     * The number of horizontal cells into which the Root Container
-     * Region area is divided
-     * @type {!number}
+     * The number of horizontal and vertical cells into which
+     * the Root Container Region area is divided
+     * cellResolution[0] - columns
+     * cellResolution[1] - rows
+     * @type {!Array.<number>}
      * @exportDoc
      */
-    this.cellResolutionRows;
-
-    /**
-     * The number of vertical cells into which the Root Container
-     * Region area is divided
-     * @type {!number}
-     * @exportDoc
-     */
-    this.cellResolutionColumns;
+    this.cellResolution;
 
     /**
      * Image background represented by any string that would be

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -205,13 +205,7 @@ shaka.text.Cue = class {
      * @override
      * @exportInterface
      */
-    this.cellResolutionRows = Cue.cellResolution.ROWS;
-
-    /**
-     * @override
-     * @exportInterface
-     */
-    this.cellResolutionColumns = Cue.cellResolution.COLUMNS;
+    this.cellResolution = [Cue.cellResolution.COLUMNS, Cue.cellResolution.ROWS];
   }
 };
 
@@ -311,7 +305,7 @@ shaka.text.Cue.fontWeight = {
 /**
  * Default values for cue cellResolution
  *
- * @enum {number}
+ * @const
  * @export
  */
 shaka.text.Cue.cellResolution = {

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -302,6 +302,7 @@ shaka.text.Cue.fontWeight = {
   'BOLD': 700,
 };
 
+
 /**
  * @enum {string}
  * @export

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -200,6 +200,18 @@ shaka.text.Cue = class {
      * @exportInterface
      */
     this.spacer = false;
+
+    /**
+     * @override
+     * @exportInterface
+     */
+    this.cellResolutionRows = Cue.cellResolution.ROWS;
+
+    /**
+     * @override
+     * @exportInterface
+     */
+    this.cellResolutionColumns = Cue.cellResolution.COLUMNS;
   }
 };
 
@@ -296,6 +308,16 @@ shaka.text.Cue.fontWeight = {
   'BOLD': 700,
 };
 
+/**
+ * Default values for cue cellResolution
+ *
+ * @enum {number}
+ * @export
+ */
+shaka.text.Cue.cellResolution = {
+  'COLUMNS': 32,
+  'ROWS': 15,
+};
 
 /**
  * @enum {string}

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -205,7 +205,10 @@ shaka.text.Cue = class {
      * @override
      * @exportInterface
      */
-    this.cellResolution = [32, 15]; // columns, rows
+    this.cellResolution = {
+      columns: 32,
+      rows: 15,
+    };
   }
 };
 

--- a/lib/text/cue.js
+++ b/lib/text/cue.js
@@ -205,7 +205,7 @@ shaka.text.Cue = class {
      * @override
      * @exportInterface
      */
-    this.cellResolution = [Cue.cellResolution.COLUMNS, Cue.cellResolution.ROWS];
+    this.cellResolution = [32, 15]; // columns, rows
   }
 };
 
@@ -300,17 +300,6 @@ shaka.text.Cue.lineAlign = {
 shaka.text.Cue.fontWeight = {
   'NORMAL': 400,
   'BOLD': 700,
-};
-
-/**
- * Default values for cue cellResolution
- *
- * @const
- * @export
- */
-shaka.text.Cue.cellResolution = {
-  'COLUMNS': 32,
-  'ROWS': 15,
 };
 
 /**

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -76,6 +76,7 @@ shaka.text.TtmlTextParser = class {
       let tickRate = null;
       let spaceStyle = null;
       let extent = null;
+      let cellResolution = null;
       const tts = xml.getElementsByTagName('tt');
       const tt = tts[0];
       // TTML should always have tt element.
@@ -91,6 +92,7 @@ shaka.text.TtmlTextParser = class {
         frameRateMultiplier =
             XmlUtils.getAttributeNS(tt, ttpNs, 'frameRateMultiplier');
         tickRate = XmlUtils.getAttributeNS(tt, ttpNs, 'tickRate');
+        cellResolution = XmlUtils.getAttributeNS(tt, ttpNs, 'cellResolution');
         spaceStyle = tt.getAttribute('xml:space') || 'default';
         extent = tt.getAttribute('tts:extent');
       }
@@ -106,6 +108,9 @@ shaka.text.TtmlTextParser = class {
 
       const rateInfo = new TtmlTextParser.RateInfo_(
           frameRate, subFrameRate, frameRateMultiplier, tickRate);
+
+      const cellResolutionInfo =
+        TtmlTextParser.getCellResolution_(cellResolution);
 
       const metadataElements = TtmlTextParser.getLeafNodes_(
           tt.getElementsByTagName('metadata')[0]);
@@ -127,7 +132,8 @@ shaka.text.TtmlTextParser = class {
       for (const node of textNodes) {
         const cue = TtmlTextParser.parseCue_(
             node, time.periodStart, rateInfo, metadataElements, styles,
-            regionElements, cueRegions, whitespaceTrim, false);
+            regionElements, cueRegions, whitespaceTrim, false,
+            cellResolutionInfo);
         if (cue) {
           ret.push(cue);
         }
@@ -239,12 +245,13 @@ shaka.text.TtmlTextParser = class {
    * @param {!Array.<!shaka.text.CueRegion>} cueRegions
    * @param {boolean} whitespaceTrim
    * @param {boolean} isNested
+   * @param {Object} cellResolutionInfo
    * @return {shaka.text.Cue}
    * @private
    */
   static parseCue_(
       cueElement, offset, rateInfo, metadataElements, styles, regionElements,
-      cueRegions, whitespaceTrim, isNested) {
+      cueRegions, whitespaceTrim, isNested, cellResolutionInfo) {
     if (isNested && cueElement.nodeName == 'br') {
       const cue = new shaka.text.Cue(0, 0, '');
       cue.spacer = true;
@@ -322,7 +329,8 @@ shaka.text.TtmlTextParser = class {
             regionElements,
             cueRegions,
             whitespaceTrim,
-            /* isNested= */ true
+            /* isNested= */ true,
+            cellResolutionInfo,
         );
 
         if (nestedCue) {
@@ -333,6 +341,9 @@ shaka.text.TtmlTextParser = class {
 
     const cue = new shaka.text.Cue(start, end, payload);
     cue.nestedCues = nestedCues;
+
+    cue.cellResolutionRows = cellResolutionInfo.rows;
+    cue.cellResolutionColumns = cellResolutionInfo.columns;
 
     // Get other properties if available.
     const regionElement = shaka.text.TtmlTextParser.getElementsFromCollection_(
@@ -543,7 +554,8 @@ shaka.text.TtmlTextParser = class {
 
     const fontSize = TtmlTextParser.getStyleAttribute_(
         cueElement, region, styles, 'fontSize');
-    if (fontSize && fontSize.match(TtmlTextParser.unitValues_)) {
+    // TODO: correct regular expression
+    if (fontSize) {
       cue.fontSize = fontSize;
     }
 
@@ -932,6 +944,31 @@ shaka.text.TtmlTextParser = class {
     const milliseconds = Number(results[4]) || 0;
 
     return (milliseconds / 1000) + seconds + (minutes * 60) + (hours * 3600);
+  }
+
+  /**
+   *
+   * @param {?string} cellResolution
+   * @return {Object}
+   * @private
+   */
+  static getCellResolution_(cellResolution) {
+    const {COLUMNS, ROWS} = shaka.text.Cue.cellResolution;
+
+    // If not specified, the number of columns and rows must be considered
+    // to be 32 and 15 respectively
+    let columns = COLUMNS;
+    let rows = ROWS;
+
+    if (cellResolution) {
+      const regExp = /^(\d+) (\d+)$/.exec(cellResolution);
+
+      if (regExp !== null) {
+        columns = parseInt(regExp[1], 10);
+        rows = parseInt(regExp[2], 10);
+      }
+    }
+    return {columns, rows};
   }
 };
 

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -245,7 +245,7 @@ shaka.text.TtmlTextParser = class {
    * @param {!Array.<!shaka.text.CueRegion>} cueRegions
    * @param {boolean} whitespaceTrim
    * @param {boolean} isNested
-   * @param {?Object} cellResolution
+   * @param {?{columns: number, rows: number}} cellResolution
    * @return {shaka.text.Cue}
    * @private
    */
@@ -343,7 +343,7 @@ shaka.text.TtmlTextParser = class {
     cue.nestedCues = nestedCues;
 
     if (cellResolution) {
-      cue.cellResolution = Object.assign({}, cellResolution);
+      cue.cellResolution = cellResolution;
     }
 
     // Get other properties if available.
@@ -957,10 +957,13 @@ shaka.text.TtmlTextParser = class {
    * Region area is divided
    *
    * @param {?string} cellResolution
-   * @return {?Object}
+   * @return {?{columns: number, rows: number}}
    * @private
    */
   static getCellResolution_(cellResolution) {
+    if (!cellResolution) {
+      return null;
+    }
     const matches = /^(\d+) (\d+)$/.exec(cellResolution);
 
     if (!matches) {

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -554,7 +554,12 @@ shaka.text.TtmlTextParser = class {
 
     const fontSize = TtmlTextParser.getStyleAttribute_(
         cueElement, region, styles, 'fontSize');
-    if (fontSize && fontSize.match(TtmlTextParser.unitValues_)) {
+
+    const isValidFontSizeUnit = fontSize
+      && (fontSize.match(TtmlTextParser.unitValues_)
+      || fontSize.match(TtmlTextParser.percentValue_));
+
+    if (isValidFontSizeUnit) {
       cue.fontSize = fontSize;
     }
 
@@ -1028,6 +1033,13 @@ shaka.text.TtmlTextParser.RateInfo_ = class {
  */
 shaka.text.TtmlTextParser.percentValues_ =
     /^(\d{1,2}(?:\.\d+)?|100)% (\d{1,2}(?:\.\d+)?|100)%$/;
+
+/**
+ * @const
+ * @private {!RegExp}
+ * @example 0.6% 90%
+ */
+shaka.text.TtmlTextParser.percentValue_ = /^(\d{1,2}(?:\.\d+)?|100)%$/;
 
 /**
  * @const

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -341,7 +341,7 @@ shaka.text.TtmlTextParser = class {
 
     const cue = new shaka.text.Cue(start, end, payload);
     cue.nestedCues = nestedCues;
-    cue.cellResolution= cellResolution;
+    cue.cellResolution = cellResolution;
 
     // Get other properties if available.
     const regionElement = shaka.text.TtmlTextParser.getElementsFromCollection_(
@@ -970,6 +970,7 @@ shaka.text.TtmlTextParser = class {
         rows = parseInt(regExp[2], 10);
       }
     }
+
     return [columns, rows];
   }
 };

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -245,7 +245,7 @@ shaka.text.TtmlTextParser = class {
    * @param {!Array.<!shaka.text.CueRegion>} cueRegions
    * @param {boolean} whitespaceTrim
    * @param {boolean} isNested
-   * @param {?Array.<number>} cellResolution
+   * @param {?Object} cellResolution
    * @return {shaka.text.Cue}
    * @private
    */
@@ -343,7 +343,7 @@ shaka.text.TtmlTextParser = class {
     cue.nestedCues = nestedCues;
 
     if (cellResolution) {
-      cue.cellResolution = cellResolution;
+      cue.cellResolution = Object.assign({}, cellResolution);
     }
 
     // Get other properties if available.
@@ -952,13 +952,12 @@ shaka.text.TtmlTextParser = class {
   }
 
   /**
-   * If ttp:cellResolution provided returns array
-   * with cellResolution info, where
-   * cellResolution[0] - columns
-   * cellResolution[1] - rows
+   * If ttp:cellResolution provided returns cell resolution info
+   * with number of columns and rows into which the Root Container
+   * Region area is divided
    *
    * @param {?string} cellResolution
-   * @return {?Array.<number>}
+   * @return {?Object}
    * @private
    */
   static getCellResolution_(cellResolution) {
@@ -971,7 +970,7 @@ shaka.text.TtmlTextParser = class {
     const columns = parseInt(matches[1], 10);
     const rows = parseInt(matches[2], 10);
 
-    return [columns, rows];
+    return {columns, rows};
   }
 };
 

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -245,13 +245,13 @@ shaka.text.TtmlTextParser = class {
    * @param {!Array.<!shaka.text.CueRegion>} cueRegions
    * @param {boolean} whitespaceTrim
    * @param {boolean} isNested
-   * @param {Object} cellResolutionInfo
+   * @param {!Array.<number>} cellResolution
    * @return {shaka.text.Cue}
    * @private
    */
   static parseCue_(
       cueElement, offset, rateInfo, metadataElements, styles, regionElements,
-      cueRegions, whitespaceTrim, isNested, cellResolutionInfo) {
+      cueRegions, whitespaceTrim, isNested, cellResolution) {
     if (isNested && cueElement.nodeName == 'br') {
       const cue = new shaka.text.Cue(0, 0, '');
       cue.spacer = true;
@@ -330,7 +330,7 @@ shaka.text.TtmlTextParser = class {
             cueRegions,
             whitespaceTrim,
             /* isNested= */ true,
-            cellResolutionInfo,
+            cellResolution,
         );
 
         if (nestedCue) {
@@ -341,9 +341,7 @@ shaka.text.TtmlTextParser = class {
 
     const cue = new shaka.text.Cue(start, end, payload);
     cue.nestedCues = nestedCues;
-
-    cue.cellResolutionRows = cellResolutionInfo.rows;
-    cue.cellResolutionColumns = cellResolutionInfo.columns;
+    cue.cellResolution= cellResolution;
 
     // Get other properties if available.
     const regionElement = shaka.text.TtmlTextParser.getElementsFromCollection_(
@@ -953,16 +951,16 @@ shaka.text.TtmlTextParser = class {
   /**
    *
    * @param {?string} cellResolution
-   * @return {Object}
+   * @return {!Array.<number>}
    * @private
    */
   static getCellResolution_(cellResolution) {
-    const {COLUMNS, ROWS} = shaka.text.Cue.cellResolution;
+    const {Cue} = shaka.text;
 
     // If not specified, the number of columns and rows must be considered
     // to be 32 and 15 respectively
-    let columns = COLUMNS;
-    let rows = ROWS;
+    let columns = Cue.cellResolution.COLUMNS;
+    let rows = Cue.cellResolution.ROWS;
 
     if (cellResolution) {
       const regExp = /^(\d+) (\d+)$/.exec(cellResolution);
@@ -972,7 +970,7 @@ shaka.text.TtmlTextParser = class {
         rows = parseInt(regExp[2], 10);
       }
     }
-    return {columns, rows};
+    return [columns, rows];
   }
 };
 

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -245,7 +245,7 @@ shaka.text.TtmlTextParser = class {
    * @param {!Array.<!shaka.text.CueRegion>} cueRegions
    * @param {boolean} whitespaceTrim
    * @param {boolean} isNested
-   * @param {!Array.<number>} cellResolution
+   * @param {?Array.<number>} cellResolution
    * @return {shaka.text.Cue}
    * @private
    */
@@ -341,7 +341,10 @@ shaka.text.TtmlTextParser = class {
 
     const cue = new shaka.text.Cue(start, end, payload);
     cue.nestedCues = nestedCues;
-    cue.cellResolution = cellResolution;
+
+    if (cellResolution) {
+      cue.cellResolution = cellResolution;
+    }
 
     // Get other properties if available.
     const regionElement = shaka.text.TtmlTextParser.getElementsFromCollection_(
@@ -949,27 +952,24 @@ shaka.text.TtmlTextParser = class {
   }
 
   /**
+   * If ttp:cellResolution provided returns array
+   * with cellResolution info, where
+   * cellResolution[0] - columns
+   * cellResolution[1] - rows
    *
    * @param {?string} cellResolution
-   * @return {!Array.<number>}
+   * @return {?Array.<number>}
    * @private
    */
   static getCellResolution_(cellResolution) {
-    const {Cue} = shaka.text;
+    const matches = /^(\d+) (\d+)$/.exec(cellResolution);
 
-    // If not specified, the number of columns and rows must be considered
-    // to be 32 and 15 respectively
-    let columns = Cue.cellResolution.COLUMNS;
-    let rows = Cue.cellResolution.ROWS;
-
-    if (cellResolution) {
-      const regExp = /^(\d+) (\d+)$/.exec(cellResolution);
-
-      if (regExp !== null) {
-        columns = parseInt(regExp[1], 10);
-        rows = parseInt(regExp[2], 10);
-      }
+    if (!matches) {
+      return null;
     }
+
+    const columns = parseInt(matches[1], 10);
+    const rows = parseInt(matches[2], 10);
 
     return [columns, rows];
   }

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -554,8 +554,7 @@ shaka.text.TtmlTextParser = class {
 
     const fontSize = TtmlTextParser.getStyleAttribute_(
         cueElement, region, styles, 'fontSize');
-    // TODO: correct regular expression
-    if (fontSize) {
+    if (fontSize && fontSize.match(TtmlTextParser.unitValues_)) {
       cue.fontSize = fontSize;
     }
 
@@ -1033,9 +1032,9 @@ shaka.text.TtmlTextParser.percentValues_ =
 /**
  * @const
  * @private {!RegExp}
- * @example 100px
+ * @example 100px, 8em, 0.80c
  */
-shaka.text.TtmlTextParser.unitValues_ = /^(\d+px|\d+em)$/;
+shaka.text.TtmlTextParser.unitValues_ = /^(\d+px|\d+em|\d*\.?\d+c)$/;
 
 /**
  * @const

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -883,25 +883,28 @@ describe('TtmlTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
 
-  it('parses cellResolution', () => {
+  it('cues should have default cellResolution', () => {
     verifyHelper(
         [
           {
             startTime: 1,
             endTime: 2,
-            cellResolution: [
-              Cue.cellResolution.COLUMNS,
-              Cue.cellResolution.ROWS,
-            ],
+            cellResolution: [32, 15],
+            fontSize: '0.45c',
           },
         ],
         '<tt xmlns:tts="http://www.w3.org/ns/ttml#styling">' +
+        '<styling>' +
+        '<style xml:id="s1" tts:fontSize="0.45c"/>' +
+        '</styling>' +
         '<body >' +
-        '<p begin="00:01.00" end="00:02.00">Test</p>' +
+        '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</body>' +
         '</tt>',
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+  });
 
+  it('parses cellResolution', () => {
     verifyHelper(
         [
           {
@@ -909,12 +912,18 @@ describe('TtmlTextParser', () => {
             endTime: 2,
             payload: 'Test',
             cellResolution: [60, 20],
+            fontSize: '67%',
           },
         ],
-        '<tt xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ' +
+        '<tt ' +
+        'xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ' +
+        'xmlns:tts="http://www.w3.org/ns/ttml#styling" ' +
         'ttp:cellResolution="60 20">' +
+        '<styling>' +
+        '<style xml:id="s1" tts:fontSize="67%"/>' +
+        '</styling>' +
         '<body >' +
-        '<p begin="00:01.00" end="00:02.00">Test</p>' +
+        '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</body>' +
         '</tt>',
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -889,7 +889,10 @@ describe('TtmlTextParser', () => {
           {
             startTime: 1,
             endTime: 2,
-            cellResolution: [32, 15],
+            cellResolution: {
+              columns: 32,
+              rows: 15,
+            },
             fontSize: '0.45c',
           },
         ],
@@ -911,7 +914,10 @@ describe('TtmlTextParser', () => {
             startTime: 1,
             endTime: 2,
             payload: 'Test',
-            cellResolution: [60, 20],
+            cellResolution: {
+              columns: 60,
+              rows: 20,
+            },
             fontSize: '67%',
           },
         ],

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -792,8 +792,8 @@ describe('TtmlTextParser', () => {
     verifyHelper(
         [
           {
-            startTime: 62.05,
-            endTime: 3723.2,
+            startTime: 1,
+            endTime: 2,
             payload: 'Test',
             color: 'red',
             backgroundColor: 'blue',
@@ -802,6 +802,12 @@ describe('TtmlTextParser', () => {
             fontStyle: Cue.fontStyle.ITALIC,
             lineHeight: '20px',
             fontSize: '10em',
+          },
+          {
+            startTime: 2,
+            endTime: 4,
+            payload: 'Test 2',
+            fontSize: '0.80c',
           },
         ],
         '<tt xmlns:tts="http://www.w3.org/ns/ttml#styling">' +
@@ -813,12 +819,14 @@ describe('TtmlTextParser', () => {
         'tts:fontStyle="italic" ' +
         'tts:lineHeight="20px" ' +
         'tts:fontSize="10em"/>' +
+        '<style xml:id="s2" tts:fontSize="0.80c" />' +
         '</styling>' +
         '<layout>' +
         '<region xml:id="subtitleArea" />' +
         '</layout>' +
         '<body region="subtitleArea">' +
-        '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
+        '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
+        '<p begin="00:02.00" end="00:04.00" style="s2">Test 2</p>' +
         '</body>' +
         '</tt>',
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
@@ -875,6 +883,42 @@ describe('TtmlTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
 
+  it('parses cellResolution', () => {
+    verifyHelper(
+        [
+          {
+            startTime: 1,
+            endTime: 2,
+            cellResolutionRows: Cue.cellResolution.ROWS,
+            cellResolutionColumns: Cue.cellResolution.COLUMNS,
+          },
+        ],
+        '<tt xmlns:tts="http://www.w3.org/ns/ttml#styling">' +
+        '<body >' +
+        '<p begin="00:01.00" end="00:02.00">Test</p>' +
+        '</body>' +
+        '</tt>',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+
+    verifyHelper(
+        [
+          {
+            startTime: 1,
+            endTime: 2,
+            payload: 'Test',
+            cellResolutionRows: 20,
+            cellResolutionColumns: 60,
+          },
+        ],
+        '<tt xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ' +
+        'ttp:cellResolution="60 20">' +
+        '<body >' +
+        '<p begin="00:01.00" end="00:02.00">Test</p>' +
+        '</body>' +
+        '</tt>',
+        {periodStart: 0, segmentStart: 0, segmentEnd: 0});
+  });
+
   it('chooses style on element over style on region', () => {
     verifyHelper(
         [
@@ -912,44 +956,6 @@ describe('TtmlTextParser', () => {
         '</body></tt>',
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
-
-  describe('getCellResolution_', () => {
-    const {cellResolution} = shaka.text.Cue;
-
-    const DEFAULT = {
-      columns: cellResolution.COLUMNS,
-      rows: cellResolution.ROWS,
-    };
-
-    const {getCellResolution_} = shaka.text.TtmlTextParser;
-
-    it('should return default values if cellResolution was not provided',
-        () => {
-          expect(getCellResolution_('')).toEqual(DEFAULT);
-          expect(getCellResolution_(null)).toEqual(DEFAULT);
-        });
-
-    it('should return default values if provided cellResolution is not valid',
-        () => {
-          expect(getCellResolution_('')).toEqual(DEFAULT);
-          expect(getCellResolution_('-50 14')).toEqual(DEFAULT);
-          expect(getCellResolution_('60 incorrect')).toEqual(DEFAULT);
-          expect(getCellResolution_('incorrect50 14')).toEqual(DEFAULT);
-          expect(getCellResolution_('50 14incorrect')).toEqual(DEFAULT);
-        });
-
-    it('should return columns and rows by provided cell resolution', () => {
-      expect(getCellResolution_('60 20')).toEqual({
-        columns: 60,
-        rows: 20,
-      });
-      expect(getCellResolution_('10 30')).toEqual({
-        columns: 10,
-        rows: 30,
-      });
-    });
-  });
-
 
   /**
    * @param {!Array} cues

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -913,6 +913,43 @@ describe('TtmlTextParser', () => {
         {periodStart: 0, segmentStart: 0, segmentEnd: 0});
   });
 
+  describe('getCellResolution_', () => {
+    const {cellResolution} = shaka.text.Cue;
+
+    const DEFAULT = {
+      columns: cellResolution.COLUMNS,
+      rows: cellResolution.ROWS,
+    };
+
+    const {getCellResolution_} = shaka.text.TtmlTextParser;
+
+    it('should return default values if cellResolution was not provided',
+        () => {
+          expect(getCellResolution_('')).toEqual(DEFAULT);
+          expect(getCellResolution_(null)).toEqual(DEFAULT);
+        });
+
+    it('should return default values if provided cellResolution is not valid',
+        () => {
+          expect(getCellResolution_('')).toEqual(DEFAULT);
+          expect(getCellResolution_('-50 14')).toEqual(DEFAULT);
+          expect(getCellResolution_('60 incorrect')).toEqual(DEFAULT);
+          expect(getCellResolution_('incorrect50 14')).toEqual(DEFAULT);
+          expect(getCellResolution_('50 14incorrect')).toEqual(DEFAULT);
+        });
+
+    it('should return columns and rows by provided cell resolution', () => {
+      expect(getCellResolution_('60 20')).toEqual({
+        columns: 60,
+        rows: 20,
+      });
+      expect(getCellResolution_('10 30')).toEqual({
+        columns: 10,
+        rows: 30,
+      });
+    });
+  });
+
 
   /**
    * @param {!Array} cues

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -889,8 +889,10 @@ describe('TtmlTextParser', () => {
           {
             startTime: 1,
             endTime: 2,
-            cellResolutionRows: Cue.cellResolution.ROWS,
-            cellResolutionColumns: Cue.cellResolution.COLUMNS,
+            cellResolution: [
+              Cue.cellResolution.COLUMNS,
+              Cue.cellResolution.ROWS,
+            ],
           },
         ],
         '<tt xmlns:tts="http://www.w3.org/ns/ttml#styling">' +
@@ -906,8 +908,7 @@ describe('TtmlTextParser', () => {
             startTime: 1,
             endTime: 2,
             payload: 'Test',
-            cellResolutionRows: 20,
-            cellResolutionColumns: 60,
+            cellResolution: [60, 20],
           },
         ],
         '<tt xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ' +

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -54,8 +54,8 @@ describe('UITextDisplayer', () => {
     textDisplayer = new shaka.ui.TextDisplayer(video, videoContainer);
   });
 
-  afterEach(() => {
-    textDisplayer.destroy();
+  afterEach(async () => {
+    await textDisplayer.destroy();
   });
 
   it('correctly displays styles for cues', async () => {

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -144,7 +144,10 @@ describe('UITextDisplayer', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '0.80c';
-    cue.cellResolution = [60, 20];
+    cue.cellResolution = {
+      columns: 60,
+      rows: 20,
+    };
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
@@ -167,7 +170,10 @@ describe('UITextDisplayer', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '0.90c';
-    cue.cellResolution = [32, 15];
+    cue.cellResolution = {
+      columns: 32,
+      rows: 15,
+    };
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -41,13 +41,16 @@ describe('UITextDisplayer', () => {
   }
 
 
-  beforeEach(() => {
+  beforeAll(() => {
     videoContainer =
       /** @type {!HTMLElement} */ (document.createElement('div'));
     videoContainer.style.height = `${videoContainerHeight}px`;
     document.body.appendChild(videoContainer);
     video = shaka.test.UiUtils.createVideoElement();
     videoContainer.appendChild(video);
+  });
+
+  beforeEach(() => {
     textDisplayer = new shaka.ui.TextDisplayer(video, videoContainer);
   });
 

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -160,4 +160,28 @@ describe('UITextDisplayer', () => {
     expect(cssObj).toEqual(
         jasmine.objectContaining({'font-size': expectedFontSize}));
   });
+
+  it('correctly displays styles for percentages units', async () => {
+    /** @type {!shaka.text.Cue} */
+    const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
+    cue.fontSize = '0.90c';
+    cue.cellResolutionRows = 15;
+    cue.cellResolutionColumns = 32;
+
+    textDisplayer.setTextVisibility(true);
+    textDisplayer.append([cue]);
+    // Wait until updateCaptions_() gets called.
+    await shaka.test.Util.delay(0.5);
+
+    // Expected value is calculated based on  ttp:cellResolution="32 15"
+    // videoContainerHeight=450px and tts:fontSize="90%" on the default style.
+    const expectedFontSize = '27px';
+
+    const textContainer =
+        videoContainer.querySelector('.shaka-text-container');
+    const captions = textContainer.querySelector('span');
+    const cssObj = parseCssText(captions.style.cssText);
+    expect(cssObj).toEqual(
+        jasmine.objectContaining({'font-size': expectedFontSize}));
+  });
 });

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -141,8 +141,7 @@ describe('UITextDisplayer', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '0.80c';
-    cue.cellResolutionRows = 20;
-    cue.cellResolutionColumns = 60;
+    cue.cellResolution = [60, 20];
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);
@@ -165,8 +164,7 @@ describe('UITextDisplayer', () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
     cue.fontSize = '0.90c';
-    cue.cellResolutionRows = 15;
-    cue.cellResolutionColumns = 32;
+    cue.cellResolution = [32, 15];
 
     textDisplayer.setTextVisibility(true);
     textDisplayer.append([cue]);

--- a/test/ui/text_displayer_unit.js
+++ b/test/ui/text_displayer_unit.js
@@ -169,7 +169,7 @@ describe('UITextDisplayer', () => {
   it('correctly displays styles for percentages units', async () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');
-    cue.fontSize = '0.90c';
+    cue.fontSize = '90%';
     cue.cellResolution = {
       columns: 32,
       rows: 15,

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -375,15 +375,15 @@ shaka.ui.TextDisplayer = class {
    * @private
    */
   static getLengthValueInfo_(lengthValue) {
-    const regexp = new RegExp(/(\d*\.?\d+)([a-z]+|%+)/).exec(lengthValue);
+    const matches = new RegExp(/(\d*\.?\d+)([a-z]+|%+)/).exec(lengthValue);
 
-    if (!regexp) {
+    if (!matches ) {
       return null;
     }
 
     return {
-      value: Number(regexp[1]),
-      unit: regexp[2],
+      value: Number(matches[1]),
+      unit: matches[2],
     };
   }
 

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -432,7 +432,8 @@ shaka.ui.TextDisplayer = class {
    * */
   static getComputedValue_(value, cue, videoContainer) {
     const containerHeight = videoContainer.clientHeight;
+    const cellResolutionRows = cue.cellResolution[1];
 
-    return (containerHeight * value / cue.cellResolutionRows) + 'px';
+    return (containerHeight * value / cellResolutionRows) + 'px';
   }
 };

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -268,13 +268,11 @@ shaka.ui.TextDisplayer = class {
       captionsStyle.margin = '0';
     }
 
-    const {convertLengthValue_} = shaka.ui.TextDisplayer;
-
     captionsStyle.fontFamily = cue.fontFamily;
     captionsStyle.fontWeight = cue.fontWeight.toString();
     captionsStyle.fontStyle = cue.fontStyle;
     captionsStyle.letterSpacing = cue.letterSpacing;
-    captionsStyle.fontSize = convertLengthValue_(
+    captionsStyle.fontSize = shaka.ui.TextDisplayer.convertLengthValue_(
         cue.fontSize, cue, this.videoContainer_
     );
 
@@ -377,7 +375,7 @@ shaka.ui.TextDisplayer = class {
   static getLengthValueInfo_(lengthValue) {
     const matches = new RegExp(/(\d*\.?\d+)([a-z]+|%+)/).exec(lengthValue);
 
-    if (!matches ) {
+    if (!matches) {
       return null;
     }
 
@@ -388,7 +386,10 @@ shaka.ui.TextDisplayer = class {
   }
 
   /**
-   * Converts length value
+   * Converts length value to an absolute value in pixels.
+   * If lengthValue is already an absolute value it will not
+   * be modified. Relative lengthValue will be converted to an
+   * absolute value in pixels based on Computed Cell Size
    *
    * @param {string} lengthValue
    * @param {!shaka.extern.Cue} cue
@@ -397,9 +398,12 @@ shaka.ui.TextDisplayer = class {
    * @private
   */
   static convertLengthValue_(lengthValue, cue, videoContainer) {
-    const {TextDisplayer} = shaka.ui;
+    const {
+      getLengthValueInfo_,
+      getAbsoluteLengthInPixels_,
+    } = shaka.ui.TextDisplayer;
 
-    const lengthValueInfo = TextDisplayer.getLengthValueInfo_(lengthValue);
+    const lengthValueInfo = getLengthValueInfo_(lengthValue);
 
     if (!lengthValueInfo) {
       return lengthValue;
@@ -409,20 +413,21 @@ shaka.ui.TextDisplayer = class {
 
     switch (unit) {
       case '%':
-        return TextDisplayer.getComputedValue_(
+        return getAbsoluteLengthInPixels_(
             value / 100,
             cue,
             videoContainer
         );
       case 'c':
-        return TextDisplayer.getComputedValue_(value, cue, videoContainer);
+        return getAbsoluteLengthInPixels_(value, cue, videoContainer);
       default:
         return lengthValue;
     }
   }
 
   /**
-   * Returns computed value
+   * Returns computed absolute length value in pixels based on cell
+   * and a video container size
    * @param {number} value
    * @param {!shaka.extern.Cue} cue
    * @param {HTMLElement} videoContainer
@@ -430,7 +435,7 @@ shaka.ui.TextDisplayer = class {
    *
    * @private
    * */
-  static getComputedValue_(value, cue, videoContainer) {
+  static getAbsoluteLengthInPixels_(value, cue, videoContainer) {
     const containerHeight = videoContainer.clientHeight;
     const cellResolutionRows = cue.cellResolution[1];
 

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -410,12 +410,10 @@ shaka.ui.TextDisplayer = class {
     switch (unit) {
       case '%':
         return shaka.ui.TextDisplayer.getAbsoluteLengthInPixels_(
-            value / 100, cue, videoContainer
-        );
+            value / 100, cue, videoContainer);
       case 'c':
         return shaka.ui.TextDisplayer.getAbsoluteLengthInPixels_(
-            value, cue, videoContainer
-        );
+            value, cue, videoContainer);
       default:
         return lengthValue;
     }

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -398,12 +398,8 @@ shaka.ui.TextDisplayer = class {
    * @private
   */
   static convertLengthValue_(lengthValue, cue, videoContainer) {
-    const {
-      getLengthValueInfo_,
-      getAbsoluteLengthInPixels_,
-    } = shaka.ui.TextDisplayer;
-
-    const lengthValueInfo = getLengthValueInfo_(lengthValue);
+    const lengthValueInfo =
+      shaka.ui.TextDisplayer.getLengthValueInfo_(lengthValue);
 
     if (!lengthValueInfo) {
       return lengthValue;
@@ -413,13 +409,13 @@ shaka.ui.TextDisplayer = class {
 
     switch (unit) {
       case '%':
-        return getAbsoluteLengthInPixels_(
-            value / 100,
-            cue,
-            videoContainer
+        return shaka.ui.TextDisplayer.getAbsoluteLengthInPixels_(
+            value / 100, cue, videoContainer
         );
       case 'c':
-        return getAbsoluteLengthInPixels_(value, cue, videoContainer);
+        return shaka.ui.TextDisplayer.getAbsoluteLengthInPixels_(
+            value, cue, videoContainer
+        );
       default:
         return lengthValue;
     }

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -397,9 +397,9 @@ shaka.ui.TextDisplayer = class {
    * @private
   */
   static convertLengthValue_(lengthValue, cue, videoContainer) {
-    const {getLengthValueInfo_} = shaka.ui.TextDisplayer;
+    const {TextDisplayer} = shaka.ui;
 
-    const lengthValueInfo = getLengthValueInfo_(lengthValue);
+    const lengthValueInfo = TextDisplayer.getLengthValueInfo_(lengthValue);
 
     if (!lengthValueInfo) {
       return lengthValue;
@@ -407,12 +407,32 @@ shaka.ui.TextDisplayer = class {
 
     const {unit, value} = lengthValueInfo;
 
-    if (unit === 'c') {
-      const containerHeight = videoContainer.clientHeight;
-
-      return (containerHeight * (1 /cue.cellResolutionRows) * value) + 'px';
+    switch (unit) {
+      case '%':
+        return TextDisplayer.getComputedValue_(
+            value / 100,
+            cue,
+            videoContainer
+        );
+      case 'c':
+        return TextDisplayer.getComputedValue_(value, cue, videoContainer);
+      default:
+        return lengthValue;
     }
+  }
 
-    return lengthValue;
+  /**
+   * Returns computed value
+   * @param {number} value
+   * @param {!shaka.extern.Cue} cue
+   * @param {HTMLElement} videoContainer
+   * @return {string}
+   *
+   * @private
+   * */
+  static getComputedValue_(value, cue, videoContainer) {
+    const containerHeight = videoContainer.clientHeight;
+
+    return (containerHeight * value / cue.cellResolutionRows) + 'px';
   }
 };

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -399,7 +399,7 @@ shaka.ui.TextDisplayer = class {
   */
   static convertLengthValue_(lengthValue, cue, videoContainer) {
     const lengthValueInfo =
-      shaka.ui.TextDisplayer.getLengthValueInfo_(lengthValue);
+        shaka.ui.TextDisplayer.getLengthValueInfo_(lengthValue);
 
     if (!lengthValueInfo) {
       return lengthValue;

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -437,8 +437,7 @@ shaka.ui.TextDisplayer = class {
    * */
   static getAbsoluteLengthInPixels_(value, cue, videoContainer) {
     const containerHeight = videoContainer.clientHeight;
-    const cellResolutionRows = cue.cellResolution[1];
 
-    return (containerHeight * value / cellResolutionRows) + 'px';
+    return (containerHeight * value / cue.cellResolution.rows) + 'px';
   }
 };

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -268,11 +268,15 @@ shaka.ui.TextDisplayer = class {
       captionsStyle.margin = '0';
     }
 
+    const {convertLengthValue_} = shaka.ui.TextDisplayer;
+
     captionsStyle.fontFamily = cue.fontFamily;
     captionsStyle.fontWeight = cue.fontWeight.toString();
-    captionsStyle.fontSize = cue.fontSize;
     captionsStyle.fontStyle = cue.fontStyle;
     captionsStyle.letterSpacing = cue.letterSpacing;
+    captionsStyle.fontSize = convertLengthValue_(
+        cue.fontSize, cue, this.videoContainer_
+    );
 
     // The line attribute defines the positioning of the text container inside
     // the video container.
@@ -360,5 +364,55 @@ shaka.ui.TextDisplayer = class {
     } else {
       panelStyle.height = cue.size + '%';
     }
+  }
+
+  /**
+   * Returns info about provided lengthValue
+   * @example 100px => { value: 100, unit: 'px' }
+   * @param {?string} lengthValue
+   *
+   * @return {?{ value: number, unit: string }}
+   * @private
+   */
+  static getLengthValueInfo_(lengthValue) {
+    const regexp = new RegExp(/(\d*\.?\d+)([a-z]+|%+)/).exec(lengthValue);
+
+    if (!regexp) {
+      return null;
+    }
+
+    return {
+      value: Number(regexp[1]),
+      unit: regexp[2],
+    };
+  }
+
+  /**
+   * Converts length value
+   *
+   * @param {string} lengthValue
+   * @param {!shaka.extern.Cue} cue
+   * @param {HTMLElement} videoContainer
+   * @return {string}
+   * @private
+  */
+  static convertLengthValue_(lengthValue, cue, videoContainer) {
+    const {getLengthValueInfo_} = shaka.ui.TextDisplayer;
+
+    const lengthValueInfo = getLengthValueInfo_(lengthValue);
+
+    if (!lengthValueInfo) {
+      return lengthValue;
+    }
+
+    const {unit, value} = getLengthValueInfo_(lengthValue);
+
+    if (unit === 'c') {
+      const containerHeight = videoContainer.clientHeight;
+
+      return (containerHeight * (1 /cue.cellResolutionRows) * value) + 'px';
+    }
+
+    return lengthValue;
   }
 };

--- a/ui/text_displayer.js
+++ b/ui/text_displayer.js
@@ -405,7 +405,7 @@ shaka.ui.TextDisplayer = class {
       return lengthValue;
     }
 
-    const {unit, value} = getLengthValueInfo_(lengthValue);
+    const {unit, value} = lengthValueInfo;
 
     if (unit === 'c') {
       const containerHeight = videoContainer.clientHeight;


### PR DESCRIPTION
Scope of PR:
- parse ttp:cellResolution and provide it to shaka.text.Cue, so text displayers can  use it in next calculations
- add support of fontSize in '%' and 'c' to ttml_text_parser
- add support of font size in cell resolution units to shaka.ui.TextDisplayer
- add unit tests

Note:
- add partial support of font size in percentages to shaka.ui.TextDisplayer

**From w3c spec:*
*Percentages:  if not region element, then relative to the parent element's computed font size; otherwise, relative to the Computed Cell Size.*
Currently will be calculated relative to the Computed Cell Size.

Spec:
tts:fontSize - https://www.w3.org/TR/ttml1/#style-attribute-fontSize
ttp:cellResolution - https://www.w3.org/TR/ttml1/#parameter-attribute-cellResolution
<length> - https://www.w3.org/TR/ttml1/#style-value-length

Useful links that helped during development and documentation investigation:
https://www.w3.org/TR/ttml1/
http://sandflow.com/imsc1_1/ - IMSC1 Renderer
https://trac.videolan.org/vlc/ticket/18347 

Sample TTML that can be used for testing:
[ttml-captions-test.zip](https://github.com/google/shaka-player/files/4289000/ttml-captions-test.zip)


Closes https://github.com/google/shaka-player/issues/2403