### PR TITLE
Fix compiler chunk size issue in StringUtils for Xbox One

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,6 +55,7 @@ Tomohiro Matsuzawa <thmatuza75@hotmail.com>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
 uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
+Vimeo Inc. <*@vimeo.com>
 Vincent Valot <valot.vince@gmail.com>
 
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -23,6 +23,7 @@
 # Please keep the list sorted.
 
 Aaron Vaage <vaage@google.com>
+Adrián Gómez Llorente <adgllorente@gmail.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
@@ -85,8 +86,8 @@ Tomas Tichy <mr.tichyt@gmail.com>
 Tomohiro Matsuzawa <thmatuza75@hotmail.com>
 Torbjörn Einarsson <torbjorn.einarsson@edgeware.tv>
 Toshihiro Suzuki <t.suzuki326@gmail.com>
+Tyler Machen <tyler.machen@vimeo.com>
 Vasanth Polipelli <vasanthap@google.com>
 Vignesh Venkatasubramanian <vigneshv@google.com>
 Vincent Valot <valot.vince@gmail.com>
 Yohann Connell <robinconnell@google.com>
-Adrián Gómez Llorente <adgllorente@gmail.com>

--- a/lib/util/string_utils.js
+++ b/lib/util/string_utils.js
@@ -208,18 +208,16 @@ shaka.util.StringUtils = class {
 shaka.util.StringUtils.fromCharCodeImpl_ = new shaka.util.Lazy(() => {
   /** @param {number} size @return {boolean} */
   const supportsChunkSize = (size) => {
+    let charCodeResult = null;
+
     try {
+      const buffer = new Uint8Array(size);
       // The compiler will complain about suspicious value if this isn't
       // stored in a variable and used.
-      const buffer = new Uint8Array(size);
+      charCodeResult = String.fromCharCode(...buffer);
 
-      // This can't use the spread operator, or it blows up on Xbox One.
-      // So we use apply() instead, which is normally not allowed.
-      // See issue #2186 for more details.
-      // eslint-disable-next-line no-restricted-syntax
-      const foo = String.fromCharCode.apply(null, buffer);
-      goog.asserts.assert(foo, 'Should get value');
-      return true;
+      goog.asserts.assert(charCodeResult, 'Should get value');
+      return charCodeResult !== null;
     } catch (error) {
       return false;
     }
@@ -235,12 +233,7 @@ shaka.util.StringUtils.fromCharCodeImpl_ = new shaka.util.Lazy(() => {
         let ret = '';
         for (let i = 0; i < buffer.length; i += size) {
           const subArray = buffer.subarray(i, i + size);
-
-          // This can't use the spread operator, or it blows up on Xbox One.
-          // So we use apply() instead, which is normally not allowed.
-          // See issue #2186 for more details.
-          // eslint-disable-next-line no-restricted-syntax
-          ret += String.fromCharCode.apply(null, subArray);  // Issue #2186
+          ret += String.fromCharCode(...subArray);
         }
         return ret;
       };


### PR DESCRIPTION
Discovered issue with Closure Compiler that results in the removal of necessary code validation of the buffer. This change ensures that the necessary code is not removed by the compiler.

- Added Vimeo Inc. as a contributor
- Changed StringUtils to have previous solution which also ensures that code will not be truncated by Closure Compiler 

Closes #2433