### PR TITLE
Tizen2.4 bugfixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Nick Desaulniers <nick@mozilla.com>
 Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>
+Peter Nycander <peter.nycander@gmail.com>
 Philo Inc. <*@philo.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Roi Lipman <roilipman@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -64,6 +64,7 @@ Niklas Korz <nk@alugha.com>
 Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>
+Peter Nycander <peter.nycander@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -510,9 +510,14 @@ shaka.media.DrmEngine = class {
     // Suppress duplicate init data.
     // Note that some init data are extremely large and can't portably be used
     // as keys in a dictionary.
+
     const metadatas = this.activeSessions_.values();
     for (const metadata of metadatas) {
-      if (shaka.util.BufferUtils.equal(initData, metadata.initData)) {
+      // Tizen 2015 and 2016 models will send multiple webkitneedkey events
+      // with the same init data. If the duplicates are supressed, playback
+      // will stall without errors.
+      if (shaka.util.BufferUtils.equal(initData, metadata.initData)
+          && !shaka.util.Platform.isTizen2()) {
         shaka.log.debug('Ignoring duplicate init data.');
         return;
       }

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -144,7 +144,8 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isApple() {
-    return !!navigator.vendor && navigator.vendor.includes('Apple');
+    return !!navigator.vendor && navigator.vendor.includes('Apple')
+            && !shaka.util.Platform.isTizen();
   }
 
   /**

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -85,6 +85,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Tizen 2 TV.
+   *
+   * @return {boolean}
+   */
+  static isTizen2() {
+    return shaka.util.Platform.userAgentContains_('Tizen 2');
+  }
+
+  /**
    * Check if the current platform is a Video Futur.
    *
    * @return {boolean}


### PR DESCRIPTION
Solves #2448 and #2447

I've tested it manually on device and it works fine, not sure if this could cause any other issues though?

The check is for both Tizen 2.3 and 2.4, but I have not been able to connect a debugger to Tizen 2.3 yet. I suspect the issue is there aswell and I hope that this will fix it. As mentioned by @avelad in #2448 , this is probably the same as #813. 

`webkitneedkey` is fired with the same `event.initData` for the video and audio tracks, which is flagged by `newInitData` as a faulty state.

I am not sure how to write tests for this, I'd be happy to take any pointers..