### PR TITLE
Bitmap Subtitle is displaying middle of the screen

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Aaron Vaage <vaage@google.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Andy Hochhaus <ahochhaus@samegoal.com>
+Ashutosh Kumar Mukhiya <ashukm4@gmail.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Boris Cupac <borisrt2309@gmail.com>
 Bryan Huh <bhh1988@gmail.com>

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -1061,7 +1061,7 @@ shaka.text.TtmlTextParser.RateInfo_ = class {
  * @example 50.17% 10%
  */
 shaka.text.TtmlTextParser.percentValues_ =
-    /^(\d{1,2}(?:\.\d+)?|100)% (\d{1,2}(?:\.\d+)?|100)%$/;
+    /^(\d{1,2}(?:\.\d+)?|100(?:.0+)?)% (\d{1,2}(?:\.\d+)?|100(?:.0+)?)%$/;
 
 /**
  * @const

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -1061,7 +1061,7 @@ shaka.text.TtmlTextParser.RateInfo_ = class {
  * @example 50.17% 10%
  */
 shaka.text.TtmlTextParser.percentValues_ =
-    /^(\d{1,2}(?:\.\d+)?|100(?:.0+)?)% (\d{1,2}(?:\.\d+)?|100(?:.0+)?)%$/;
+    /^(\d{1,2}(?:\.\d+)?|100(?:\.0+)?)% (\d{1,2}(?:\.\d+)?|100(?:\.0+)?)%$/;
 
 /**
  * @const


### PR DESCRIPTION
This is regarding the issue  #2477 

percentValues_ regex works fine for "100%", but not for "100.00%"
I have modified the regex to support 100.00%.

I have sent mpd URL to shaka-player-issues@google.com to validate the issue.