### PR TITLE
Update closing parens wrapped in parentheses

### DIFF
--- a/build/wrapper.template.js
+++ b/build/wrapper.template.js
@@ -38,4 +38,4 @@
     // Export directly to the global scope.
     innerGlobal.shaka = exportTo.shaka;
   }
-})();
+}());


### PR DESCRIPTION
```javascript
(function(){
  ...
})();
```
That function is now an expression position and now we can immediately invoke it. But then you've got the extra invoking parents hanging off on the end. So we can do better for the reader by wrapping the entire invocation expression in parens. 

```javascript
(function (){
  ...
}());
```
So now the goal is not to just get it passed to the compiler, but to give a little bit more information to the reader, so that when the reader sees a function and the closing parens wrapped in parentheses, that means something.

important here is not the function, it's the result of the function. And just by moving the pair in one space over, we give a little bit more information to the reader and that can be helpful. 