### PR TITLE
Fix metadata tracks for SS

### DIFF
--- a/externs/shaka/ads.js
+++ b/externs/shaka/ads.js
@@ -81,6 +81,11 @@ shaka.extern.IAdManager = class extends EventTarget {
    * @param {shaka.extern.TimelineRegionInfo} region
    */
   onTimedMetadata(region) {}
+
+  /**
+   * @param {Object} value
+   */
+  onCueMetadataChange(value) {}
 };
 
 

--- a/externs/shaka/ads.js
+++ b/externs/shaka/ads.js
@@ -83,7 +83,8 @@ shaka.extern.IAdManager = class extends EventTarget {
   onTimedMetadata(region) {}
 
   /**
-   * @param {Object} value
+   * @param {Object} value ID3 metadata, it's essentially a Map of <Any, Any>
+   * https://id3.org/id3v2.3.0#Declared_ID3v2_frames
    */
   onCueMetadataChange(value) {}
 };

--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -11,6 +11,7 @@ goog.require('shaka.Player');
 goog.require('shaka.ads.AdsStats');
 goog.require('shaka.ads.ClientSideAdManager');
 goog.require('shaka.ads.ServerSideAdManager');
+goog.require('shaka.log');
 goog.require('shaka.util.FakeEventTarget');
 
 
@@ -363,6 +364,9 @@ shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
   onCueMetadataChange(value) {
     if (this.ssAdManager_) {
       this.ssAdManager_.onCueMetadataChange(value);
+    } else {
+      shaka.log.warning('The method was called without initializing server ' +
+        'side logic and will not take effect');
     }
   }
 };

--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -347,6 +347,16 @@ shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
       this.ssAdManager_.onTimedMetadata(region);
     }
   }
+
+  /**
+   * @override
+   * @export
+   */
+  onCueMetadataChange(value) {
+    if (this.ssAdManager_) {
+      this.ssAdManager_.onCueMetadataChange(value);
+    }
+  }
 };
 
 

--- a/lib/ads/server_side_ad_manager.js
+++ b/lib/ads/server_side_ad_manager.js
@@ -269,7 +269,6 @@ shaka.ads.ServerSideAdManager = class {
     this.onEvent_(new shaka.util.FakeEvent(shaka.ads.AdManager.AD_STARTED,
         {'ad': this.ad_}));
     this.adContainer_.setAttribute('ad-active', 'true');
-    this.video_.pause();
   }
 
   /**

--- a/lib/ads/server_side_ad_manager.js
+++ b/lib/ads/server_side_ad_manager.js
@@ -63,24 +63,6 @@ shaka.ads.ServerSideAdManager = class {
 
     this.streamManager_.setClickElement(this.adContainer_);
 
-    // Native HLS over Safari/iOS/iPadOS
-    // This is a real EventTarget, but the compiler doesn't know that.
-    // TODO: File a bug or send a PR to the compiler externs to fix this.
-    const textTracks = /** @type {EventTarget} */(this.video_.textTracks);
-    this.eventManager_.listen(textTracks, 'addtrack', (event) => {
-      const track = event.track;
-      if (track.kind == 'metadata') {
-        track.mode = 'hidden';
-        track.addEventListener('cuechange', () => {
-          for (const cue of track.activeCues) {
-            const metadata = {};
-            metadata[cue.value.key] = cue.value.data;
-            this.streamManager_.onTimedMetadata(metadata);
-          }
-        });
-      }
-    });
-
     // Events
     this.eventManager_.listen(this.streamManager_,
         google.ima.dai.api.StreamEvent.Type.LOADED, (e) => {
@@ -217,6 +199,18 @@ shaka.ads.ServerSideAdManager = class {
           region.eventElement.getAttribute('messageData') : null;
       const timestamp = region.startTime;
       this.streamManager_.processMetadata(type, data, timestamp);
+    }
+  }
+
+  /**
+   * @param {Object} value
+   */
+  onCueMetadataChange(value) {
+    // Native HLS over Safari/iOS/iPadOS
+    if (value.key && value.data) {
+      const metadata = {};
+      metadata[value.key] = value.data;
+      this.streamManager_.onTimedMetadata(metadata);
     }
   }
 

--- a/lib/ads/server_side_ad_manager.js
+++ b/lib/ads/server_side_ad_manager.js
@@ -207,6 +207,11 @@ shaka.ads.ServerSideAdManager = class {
    */
   onCueMetadataChange(value) {
     // Native HLS over Safari/iOS/iPadOS
+    // For live event streams, the stream needs some way of informing the SDK
+    // that an ad break is coming up or ending. In the IMA DAI SDK, this is
+    // done through timed metadata. Timed metadata is carried as part of the
+    // DAI stream content and carries ad break timing information used by the
+    // SDK to track ad breaks.
     if (value.key && value.data) {
       const metadata = {};
       metadata[value.key] = value.data;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2002,28 +2002,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // TODO: File a bug or send a PR to the compiler externs to fix this.
       const textTracks = /** @type {EventTarget} */(this.video_.textTracks);
       this.eventManager_.listen(
-          textTracks, 'addtrack', (e) => {
-            this.onTracksChanged_();
-            const track = e.track;
-            if (track.kind != 'metadata') {
-              return;
-            }
-            track.mode = 'hidden';
-            this.eventManager_.listen(track, 'cuechange', () => {
-              for (const cue of track.activeCues) {
-                if (this.adManager_) {
-                  this.adManager_.onCueMetadataChange(cue.value);
-                }
-              }
-            });
-            new shaka.util.Timer(() => {
-              const textTracks = Array.from(this.video_.textTracks)
-                  .filter((track) => { return track.kind == 'metadata'; });
-              for (const textTrack of textTracks) {
-                textTrack.mode = 'hidden';
-              }
-            }).tickNow().tickAfter(/* seconds= */ 0.5);
-          });
+          textTracks, 'addtrack', (e) => this.onAddTextTrack_(e));
       this.eventManager_.listen(
           textTracks, 'removetrack', () => this.onTracksChanged_());
       this.eventManager_.listen(
@@ -2072,6 +2051,37 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       fullyLoaded.reject(abortedError);
       return Promise.resolve();  // Abort complete.
     });
+  }
+
+  /**
+   * @param {!Event} event
+   * @private
+   */
+  onAddTextTrack_(event) {
+    this.onTracksChanged_();
+    const track = event.track;
+    if (track.kind != 'metadata') {
+      return;
+    }
+    // Hidden mode is required for the cuechange event to launch correctly
+    track.mode = 'hidden';
+    this.eventManager_.listen(track, 'cuechange', () => {
+      for (const cue of track.activeCues) {
+        if (this.adManager_) {
+          this.adManager_.onCueMetadataChange(cue.value);
+        }
+      }
+    });
+    // In Safari the initial assignment does not always work, so we schedule
+    // this process to be repeated several times to ensure that it has been put
+    // in the correct mode.
+    new shaka.util.Timer(() => {
+      const textTracks = Array.from(this.video_.textTracks)
+          .filter((track) => { return track.kind == 'metadata'; });
+      for (const textTrack of textTracks) {
+        textTrack.mode = 'hidden';
+      }
+    }).tickNow().tickAfter(/* seconds= */ 0.5);
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -2871,8 +2871,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       return tracks;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks)
-          .filter((track) => { return track.kind != 'metadata'; });
+      const textTracks = Array.from(this.video_.textTracks);
       const StreamUtils = shaka.util.StreamUtils;
       return textTracks.map((text) => StreamUtils.html5TextTrackToTrack(text));
     } else {
@@ -2917,8 +2916,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // currentTextLanguage_.
       this.currentTextLanguage_ = stream.language;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks)
-          .filter((track) => { return track.kind != 'metadata'; });
+      const textTracks = Array.from(this.video_.textTracks);
       for (const textTrack of textTracks) {
         if (shaka.util.StreamUtils.html5TrackId(textTrack) == track.id) {
           // Leave the track in 'hidden' if it's selected but not showing.
@@ -3193,8 +3191,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // information (in the case that the values come out of sync in prod).
       return actual;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks)
-          .filter((track) => { return track.kind != 'metadata'; });
+      const textTracks = Array.from(this.video_.textTracks);
       return textTracks.some((t) => t.mode == 'showing');
     }
 
@@ -3247,8 +3244,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }
       }
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks)
-          .filter((track) => { return track.kind != 'metadata'; });
+      const textTracks = Array.from(this.video_.textTracks);
 
       // Find the active track by looking for one which is not disabled.  This
       // is the only way to identify the track which is currently displayed.

--- a/lib/player.js
+++ b/lib/player.js
@@ -2001,8 +2001,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // This is a real EventTarget, but the compiler doesn't know that.
       // TODO: File a bug or send a PR to the compiler externs to fix this.
       const textTracks = /** @type {EventTarget} */(this.video_.textTracks);
-      this.eventManager_.listen(
-          textTracks, 'addtrack', (e) => this.onAddTextTrack_(e));
+      this.eventManager_.listen(textTracks, 'addtrack', (e) => {
+        this.onTracksChanged_();
+        this.processTimedMetadata_(e);
+      });
       this.eventManager_.listen(
           textTracks, 'removetrack', () => this.onTracksChanged_());
       this.eventManager_.listen(
@@ -2054,11 +2056,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
+   * We're looking for metadata tracks to process id3 tags for ad info on LIVE
+   * streams
+   *
    * @param {!Event} event
    * @private
    */
-  onAddTextTrack_(event) {
-    this.onTracksChanged_();
+  processTimedMetadata_(event) {
     const track = event.track;
     if (track.kind != 'metadata') {
       return;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2850,7 +2850,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
       return tracks;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks);
+      const textTracks = Array.from(this.video_.textTracks)
+          .filter((track) => { return track.kind != 'metadata'; });
       const StreamUtils = shaka.util.StreamUtils;
       return textTracks.map((text) => StreamUtils.html5TextTrackToTrack(text));
     } else {
@@ -2895,7 +2896,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // currentTextLanguage_.
       this.currentTextLanguage_ = stream.language;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks);
+      const textTracks = Array.from(this.video_.textTracks)
+          .filter((track) => { return track.kind != 'metadata'; });
       for (const textTrack of textTracks) {
         if (shaka.util.StreamUtils.html5TrackId(textTrack) == track.id) {
           // Leave the track in 'hidden' if it's selected but not showing.
@@ -3170,7 +3172,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // information (in the case that the values come out of sync in prod).
       return actual;
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks);
+      const textTracks = Array.from(this.video_.textTracks)
+          .filter((track) => { return track.kind != 'metadata'; });
       return textTracks.some((t) => t.mode == 'showing');
     }
 
@@ -3223,7 +3226,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }
       }
     } else if (this.video_ && this.video_.src && this.video_.textTracks) {
-      const textTracks = Array.from(this.video_.textTracks);
+      const textTracks = Array.from(this.video_.textTracks)
+          .filter((track) => { return track.kind != 'metadata'; });
 
       // Find the active track by looking for one which is not disabled.  This
       // is the only way to identify the track which is currently displayed.

--- a/lib/player.js
+++ b/lib/player.js
@@ -1997,7 +1997,28 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // TODO: File a bug or send a PR to the compiler externs to fix this.
       const textTracks = /** @type {EventTarget} */(this.video_.textTracks);
       this.eventManager_.listen(
-          textTracks, 'addtrack', () => this.onTracksChanged_());
+          textTracks, 'addtrack', (e) => {
+            this.onTracksChanged_();
+            const track = e.track;
+            if (track.kind != 'metadata') {
+              return;
+            }
+            track.mode = 'hidden';
+            this.eventManager_.listen(track, 'cuechange', () => {
+              for (const cue of track.activeCues) {
+                if (this.adManager_) {
+                  this.adManager_.onCueMetadataChange(cue.value);
+                }
+              }
+            });
+            new shaka.util.Timer(() => {
+              const textTracks = Array.from(this.video_.textTracks)
+                  .filter((track) => { return track.kind == 'metadata'; });
+              for (const textTrack of textTracks) {
+                textTrack.mode = 'hidden';
+              }
+            }).tickNow().tickAfter(/* seconds= */ 0.5);
+          });
       this.eventManager_.listen(
           textTracks, 'removetrack', () => this.onTracksChanged_());
       this.eventManager_.listen(

--- a/test/test/util/fake_ad_manager.js
+++ b/test/test/util/fake_ad_manager.js
@@ -51,6 +51,11 @@ shaka.test.FakeAdManager = class extends shaka.util.FakeEventTarget {
   onTimedMetadata(region) {}
 
   /**
+   * @override
+   */
+  onCueMetadataChange(data) {}
+
+  /**
    * @param {!shaka.test.FakeAd} ad
    */
   startAd(ad) {


### PR DESCRIPTION
This change include:
- Remove bad pause for SS ads
- Fix cuechange trigger event. Safari doesn't fire cuechange if the track mode is not hidden or showing. We force the change in several times to ensure that the change is done.

Note: This change include some changes of https://github.com/google/shaka-player/pull/2476 but this PR doesn't expose any new event. Also simplify the logic to introduce metadata events from mux.js in a future