### PR TITLE
Fix error `4012 RESTRICTIONS_CANNOT_BE_MET` for webOS TV platform

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1326,7 +1326,8 @@ shaka.media.DrmEngine = class {
       if (this.currentDrmInfo_.keySystem == 'com.microsoft.playready' &&
           keyId.byteLength == 16 &&
           !shaka.util.Platform.isTizen() &&
-          !shaka.util.Platform.isVideoFutur()) {
+          !shaka.util.Platform.isVideoFutur() &&
+          !shaka.util.Platform.isWebOS()) {
         // Read out some fields in little-endian:
         const dataView = shaka.util.BufferUtils.toDataView(keyId);
         const part0 = dataView.getUint32(0, /* LE= */ true);


### PR DESCRIPTION
For webOS TV 2020 platform, like for Tizen, key IDs should not be
transformed to big-endian UUIDs, it causes `4012
RESTRICTIONS_CANNOT_BE_MET` error.

Issue #2512