### PR TITLE
fix toggling subtitles in compiled mode, isTextVisible_ is not set

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3195,11 +3195,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Convert to boolean in case apps pass 0/1 instead false/true.
     const newVisibility = !!isVisible;
 
+    this.isTextVisible_ = newVisibility;
+    
     if (oldVisibilty == newVisibility) {
       return;
     }
-
-    this.isTextVisible_ = newVisibility;
 
     // Hold of on setting the text visibility until we have all the components
     // we need. This ensures that they stay in-sync.


### PR DESCRIPTION
This fixes toggling subtitles in compiled mode. Logic did not work because state was set after return.