### PR TITLE
Allow OPUS on Tizen 5 or higher.

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -63,7 +63,9 @@ shaka.polyfill.MediaSource = class {
         // Bug filed: https://bugs.webkit.org/show_bug.cgi?id=165342
         shaka.polyfill.MediaSource.stubAbort_();
       }
-    } else if (shaka.util.Platform.isTizen()) {
+    } else if (shaka.util.Platform.isTizen2() ||
+        shaka.util.Platform.isTizen3() ||
+        shaka.util.Platform.isTizen4()) {
       // Tizen's implementation of MSE does not work well with opus. To prevent
       // the player from trying to play opus on Tizen, we will override media
       // source to always reject opus content.

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -76,6 +76,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a Tizen 4 TV.
+   *
+   * @return {boolean}
+   */
+  static isTizen4() {
+    return shaka.util.Platform.userAgentContains_('Tizen 4');
+  }
+
+  /**
    * Check if the current platform is a Tizen 3 TV.
    *
    * @return {boolean}


### PR DESCRIPTION
OPUS was disabled in Tizen at https://github.com/google/shaka-player/issues/1751 but, in new versions of Tizen, OPUS is working