### PR TITLE
export shaka.util.FairPlayUtils and shaka.util.BufferUtils

### DIFF
--- a/lib/util/buffer_utils.js
+++ b/lib/util/buffer_utils.js
@@ -10,7 +10,7 @@ goog.require('shaka.util.Iterables');
 
 /**
  * @summary A set of BufferSource utility functions.
- * @exportInterface
+ * @export
  */
 shaka.util.BufferUtils = class {
   /**

--- a/lib/util/fairplay_utils.js
+++ b/lib/util/fairplay_utils.js
@@ -12,7 +12,7 @@ goog.require('shaka.util.BufferUtils');
 
 /**
  * @summary A set of FairPlay utility functions.
- * @exportInterface
+ * @export
  */
 shaka.util.FairPlayUtils = class {
   /**


### PR DESCRIPTION
@exportInterface is used by the extern generator, but ignored by the
compiler. @export should be used for shaka.util.FairPlayUtils and
shaka.util.BufferUtils.

Closes #2626 and #2627