### PR TITLE
Update redirect detection in dash parser

### DIFF
--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -89,6 +89,7 @@ shaka.extern.Request;
 /**
  * @typedef {{
  *   uri: string,
+ *   originalUri: string,
  *   data: BufferSource,
  *   headers: !Object.<string, string>,
  *   timeMs: (number|undefined),

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -206,10 +206,15 @@ shaka.dash.DashParser = class {
       return 0;
     }
 
-    // For redirections add the response uri to the first entry in the
-    // Manifest Uris array.
-    if (response.uri && !this.manifestUris_.includes(response.uri)) {
-      this.manifestUris_.unshift(response.uri);
+    // If the HTTP request results in an HTTP redirect,
+    // the redirected URL replaces the original manifest URL
+    if (response.uri && response.uri != response.originalUri) {
+      const redirectedUriIndex =
+        this.manifestUris_.indexOf(response.originalUri);
+
+      if (redirectedUriIndex != -1) {
+        this.manifestUris_[redirectedUriIndex] = response.uri;
+      }
     }
 
     // This may throw, but it will result in a failed promise.

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -241,14 +241,13 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     // undefined.  To make it easier for application developers, we will fill
     // them in with defaults if necessary.
     //
-    // We clone retryParameters and uris so that if a filter modifies the
+    // We clone retryParameters so that if a filter modifies the
     // request, it doesn't contaminate future requests.
     request.method = request.method || 'GET';
     request.headers = request.headers || {};
     request.retryParameters = request.retryParameters ?
         ObjectUtils.cloneObject(request.retryParameters) :
         shaka.net.NetworkingEngine.defaultRetryParameters();
-    request.uris = ObjectUtils.cloneObject(request.uris);
 
     // Apply the registered filters to the request.
     const requestFilterOperation = this.filterRequest_(type, request);

--- a/test/dash/dash_parser_live_unit.js
+++ b/test/dash/dash_parser_live_unit.js
@@ -453,6 +453,7 @@ describe('DashParser Live', () => {
         shaka.util.AbortableOperation.completed({
           uri: redirectedUri,
           data: manifestData,
+          originalUri,
         }));
 
     const manifest = await parser.start(originalUri, playerInterface);
@@ -461,7 +462,7 @@ describe('DashParser Live', () => {
     // But includes a redirect
     expect(fakeNetEngine.request).toHaveBeenCalledTimes(1);
     const netRequest = fakeNetEngine.request.calls.argsFor(0)[1];
-    expect(netRequest.uris).toEqual([redirectedUri, originalUri]);
+    expect(netRequest.uris).toEqual([redirectedUri]);
 
     // Since the manifest request was redirected, the segment refers to
     // the redirected base.

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -831,8 +831,9 @@ describe('StreamingEngine', () => {
       // Just return any old ArrayBuffer for any requested segment.
       netEngine.request.and.callFake((requestType, request) => {
         const buffer = new ArrayBuffer(0);
+        const uri = request.uris[0];
         /** @type {shaka.extern.Response} */
-        const response = {uri: request.uris[0], data: buffer, headers: {}};
+        const response = {uri, originalUri: uri, data: buffer, headers: {}};
         return shaka.util.AbortableOperation.completed(response);
       });
 
@@ -2819,8 +2820,9 @@ describe('StreamingEngine', () => {
       // Just return any old ArrayBuffer for any requested segment.
       netEngine.request.and.callFake((requestType, request) => {
         const buffer = new ArrayBuffer(0);
+        const uri = request.uris[0];
         /** @type {shaka.extern.Response} */
-        const response = {uri: request.uris[0], data: buffer, headers: {}};
+        const response = {uri, originalUri: uri, data: buffer, headers: {}};
         return shaka.util.AbortableOperation.completed(response);
       });
 

--- a/test/net/networking_engine_unit.js
+++ b/test/net/networking_engine_unit.js
@@ -1200,6 +1200,6 @@ describe('NetworkingEngine', /** @suppress {accessControls} */ () => {
 
   /** @return {shaka.extern.Response} */
   function createResponse() {
-    return {uri: '', data: new ArrayBuffer(5), headers: {}};
+    return {uri: '', originalUri: '', data: new ArrayBuffer(5), headers: {}};
   }
 });  // describe('NetworkingEngine')


### PR DESCRIPTION
Fixes false redirect detection in Dash parser.

Problem: with the current approach each time the manifest URL has changed it will be added to the list of manifestUris_.  In the scenarios when the application changes the manifest URL in request filters manifestUris_ will contain all the previous URL too. 
This behavior may not affect the playback, but the retry mechanism will be not working correctly. When the request for the manifest will be failed, the manifest with the previous URL will be requested during the retry flow. 

According to the DASH IF IOP 4.3 chapter 3.2.15.3. Client Requirements and Recommendations:

> If the HTTP request results in an HTTP redirect using a 3xx response code, the redirected URL replaces the original manifest URL

https://dashif.org/docs/DASH-IF-IOP-v4.3.pdf

So new manifest should not be 'added' to the list of manifestUris_, but replace the redirected URL.

This will also fix the behavior when manifest with the original URI will be requested in the retry flow, when the manifest request would be failed. The problem is described in https://github.com/google/shaka-player/issues/2216.


**Note: Application that uses custom HTTP plugin should return expected response - <shaka.extern.Response>**
https://shaka-player-demo.appspot.com/docs/api/shaka.extern.html#.Response
**And return originalUri in order to have a sticky redirect.**.
These changes are needed in order to have correct detection for the redirect.

Closes https://github.com/google/shaka-player/issues/2216

Thanks.