### PR TITLE
Guard for Comcast and endianness flip

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1486,6 +1486,7 @@ shaka.media.DrmEngine.prototype.onKeyStatusesChange_ = function(event) {
         keyId.byteLength == 16 &&
         !shaka.util.Platform.isTizen() &&
         !shaka.util.Platform.isVideoFutur() &&
+        !shaka.util.Platform.isWPE() &&
         !shaka.util.Platform.isWebOS() &&
         !shaka.util.Platform.isTiVo()) {
       // Read out some fields in little-endian:

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -79,6 +79,15 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is Comcast X1.
+   *
+   * @return {boolean}
+   */
+  static isWPE() {
+    return shaka.util.Platform.userAgentContains_('WPE');
+  }
+
+  /**
    * Check if the current platform is a Tizen TV.
    *
    * @return {boolean}


### PR DESCRIPTION
I wanted to push this up for review.  Have not signed CLA yet and need legal to review etc.  So maybe we can just push this patch into 3.0.3 on Shaka side.  

It allows us to guard against the endianness flip on some device platforms.  This is for WPE, user agent for Comcast X1 devices and mimics what we do for Tizen and Webos.   