### PR TITLE
fix: Fix case sensitivity for drm content type

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,6 +18,7 @@ Adrián Gómez Llorente <adgllorente@gmail.com>
 Alex Jones <alexedwardjones@gmail.com>
 Alugha GmbH <*@alugha.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
+Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -26,6 +26,7 @@ Aaron Vaage <vaage@google.com>
 Alex Jones <alexedwardjones@gmail.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
 Andy Hochhaus <ahochhaus@samegoal.com>
+Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Ashutosh Kumar Mukhiya <ashukm4@gmail.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Boris Cupac <borisrt2309@gmail.com>

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -582,7 +582,7 @@ shaka.media.DrmEngine = class {
       return true;
     }
 
-    return this.supportedTypes_.has(contentType);
+    return this.supportedTypes_.has(contentType.toLowerCase());
   }
 
   /**
@@ -831,11 +831,11 @@ shaka.media.DrmEngine = class {
       const videoCaps = realConfig.videoCapabilities || [];
 
       for (const cap of audioCaps) {
-        this.supportedTypes_.add(cap.contentType);
+        this.supportedTypes_.add(cap.contentType.toLowerCase());
       }
 
       for (const cap of videoCaps) {
-        this.supportedTypes_.add(cap.contentType);
+        this.supportedTypes_.add(cap.contentType.toLowerCase());
       }
 
       goog.asserts.assert(this.supportedTypes_.size,

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -260,6 +260,7 @@ describe('DrmEngine', () => {
       expect(drmEngine.initialized()).toBe(true);
       expect(drmEngine.willSupport('audio/webm')).toBeTruthy();
       expect(drmEngine.willSupport('video/mp4; codecs="fake"')).toBeTruthy();
+      expect(drmEngine.willSupport('video/mp4; codecs="FAKE"')).toBeTruthy();
 
       // Because DrmEngine will err on being too accepting, make sure it will
       // reject something. However, we can only check that it is actually


### PR DESCRIPTION
This fixes the case sensitivity in the `DrmEngine` `willSupport` method. This comparison should be case insensitive, particularly for codec profiles described in hex which may be either lower or upper case. The change normalizes both the stored content types and the method arguments.

edit: Will likely target this for 2.5 as this release is the one directly affecting me. 

Closes #2799