### PR TITLE
Support parallel prefetch of mpeg-dash segments

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -721,7 +721,8 @@ shaka.extern.ManifestConfiguration;
  *   stallThreshold: number,
  *   stallSkip: number,
  *   useNativeHlsOnSafari: boolean,
- *   inaccurateManifestTolerance: number
+ *   inaccurateManifestTolerance: number,
+ *   prefetchLimit: number
  * }}
  *
  * @description

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -106,6 +106,14 @@ shaka.media.StreamingEngine = class {
 
     /** @private {!shaka.util.Destroyer} */
     this.destroyer_ = new shaka.util.Destroyer(() => this.doDestroy_());
+
+    /**
+     * Maps a reference to op
+     *
+     * @private {!Map.<shaka.media.AnySegmentReference,
+                         !shaka.net.NetworkingEngine.PendingRequest>}
+     */
+    this.prefetchMap_ = new Map();
   }
 
   /** @override */
@@ -764,6 +772,7 @@ shaka.media.StreamingEngine = class {
       type: stream.type,
       lastStream: null,
       segmentIterator,
+      prefetchPosTime: 0,
       lastSegmentReference: null,
       lastInitSegmentReference: null,
       lastTimestampOffset: null,
@@ -1025,6 +1034,8 @@ shaka.media.StreamingEngine = class {
       // fetching another audio segment.
       return 1;
     }
+
+    this.prefetch_(mediaState, reference);
 
     const p = this.fetchAndAppend_(mediaState, presentationTime, reference);
     p.catch(() => {});  // TODO(#1993): Handle asynchronous errors.
@@ -1626,7 +1637,6 @@ shaka.media.StreamingEngine = class {
         mediaState.stream.mimeType == MimeUtils.CLOSED_CAPTION_MIMETYPE;
   }
 
-
   /**
    * Fetches the given segment.
    *
@@ -1638,6 +1648,32 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async fetch_(mediaState, reference) {
+    shaka.log.v2('fetching: reference=', reference);
+
+    let op = null;
+    if (this.prefetchMap_.has(reference)) {
+      op = this.prefetchMap_.get(reference);
+      this.prefetchMap_.delete(reference);
+    } else {
+      op = this.fireRequest_(reference);
+    }
+
+    mediaState.operation = op;
+    const response = await op.promise;
+    mediaState.operation = null;
+    return response.data;
+  }
+
+  /**
+   * Fire the request.
+   *
+   * @param
+   *  {(null|!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
+   *   reference
+   *
+   * @private
+   */
+  fireRequest_(reference) {
     const requestType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
 
     const request = shaka.util.Networking.createSegmentRequest(
@@ -1646,15 +1682,36 @@ shaka.media.StreamingEngine = class {
         reference.endByte,
         this.config_.retryParameters);
 
-    shaka.log.v2('fetching: reference=', reference);
-
-    const op = this.playerInterface_.netEngine.request(requestType, request);
-    mediaState.operation = op;
-    const response = await op.promise;
-    mediaState.operation = null;
-    return response.data;
+    return this.playerInterface_.netEngine.request(requestType, request);
   }
 
+  /**
+   * Fetches the given segment.
+   *
+   * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
+   * @param
+   *  {(!shaka.media.InitSegmentReference|!shaka.media.SegmentReference)}
+   *   startReference
+   *
+   * @private
+   */
+  prefetch_(mediaState, startReference) {
+    const currTime = mediaState.segmentIterator.current().startTime;
+    mediaState.segmentIterator.seek(
+        Math.max(currTime, mediaState.prefetchPosTime));
+    let reference = startReference;
+    while (this.prefetchMap_.size < this.config_.prefetchLimit &&
+           reference != null) {
+      if (!this.prefetchMap_.has(reference)) {
+        const op = this.fireRequest_(reference);
+        this.prefetchMap_.set(reference, op);
+      }
+      mediaState.prefetchPosTime =
+          mediaState.segmentIterator.current().startTime;
+      reference = mediaState.segmentIterator.next().value;
+    }
+    mediaState.segmentIterator.seek(currTime);
+  }
 
   /**
    * Clears the buffer and schedules another update.
@@ -1836,6 +1893,7 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   stream: shaka.extern.Stream,
  *   lastStream: ?shaka.extern.Stream,
  *   segmentIterator: shaka.media.SegmentIterator,
+ *   prefetchPosTime: number,
  *   lastSegmentReference: shaka.media.SegmentReference,
  *   lastInitSegmentReference: shaka.media.InitSegmentReference,
  *   lastTimestampOffset: ?number,
@@ -1867,6 +1925,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   The Stream of the last segment that was appended.
  * @property {shaka.media.SegmentIndexIterator} segmentIterator
  *   An iterator through the segments of |stream|.
+ * @property {number} prefetchPosTime
+ *   Last prefetched time through the segments of |stream|.
  * @property {shaka.media.SegmentReference} lastSegmentReference
  *   The SegmentReference of the last segment that was appended.
  * @property {shaka.media.InitSegmentReference} lastInitSegmentReference

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -135,6 +135,7 @@ shaka.util.PlayerConfiguration = class {
       // To enable low latency streaming, inaccurateManifestTolerance should be
       // set to 0.
       inaccurateManifestTolerance: 2,
+      prefetchLimit: 10,
     };
 
     // WebOS, Tizen, and Chromecast have long hardware pipelines that respond

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "shaka-player",
-  "description": "DASH/EME video player library",
-  "version": "3.0.0",
-  "homepage": "https://github.com/google/shaka-player",
-  "author": "Google",
+  "name": "drishti-shaka",
+  "description": "DASH/EME video player library with networking speedup",
+  "version": "1.0.4",
+  "homepage": "https://github.com/sabyasachiroy/shaka-player",
+  "author": "Sabyasachi Roy",
   "maintainers": [
     {
-      "name": "Joey Parrish",
-      "email": "joeyparrish@google.com"
+      "name": "Sabyasachi Roy",
+      "email": "sabyasachiroy@gmail.com"
     }
   ],
   "devDependencies": {
@@ -60,14 +60,14 @@
   "main": "dist/shaka-player.compiled.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/google/shaka-player.git"
+    "url": "git+https://github.com/sabyasachiroy/shaka-player.git"
   },
   "bugs": {
-    "url": "https://github.com/google/shaka-player/issues"
+    "url": "https://github.com/sabyasachiroy/shaka-player/issues"
   },
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
+    "prepublishOnly": "python build/all.py --force"
   },
   "dependencies": {
     "eme-encryption-scheme-polyfill": "^2.0.1"


### PR DESCRIPTION
This diff adds the ability to prefetch and download segments listed in a
mpeg-dash manifest in parallel. Before this diff, the segments would be
downloaded serially.

The exact level of parallelism, or the exact number of segments to be
prefetched is controlled via a configuration "prefetchLimit". When set to
zero, it defaults back to older behaviour. When set to a positive number,
shaka-player would prefetch only that many segments in parallel and
then wait until some of the ongoing downloads finish before issuing more
prefetch requests.

There are some strange observations w.r.t. behaviour with range requests,
pre-flight OPTIONS request and chrome. In many cases every segment
request is preceded by a OPTIONS request. With browser's cache disabled this
often leads to multiple identical OPTIONS request. When cache is enabled,
that causes an undesirable behaviour with chrome. Chrome's cache has a
writer lock and it blocks any subsequent request that has the same URL
as the one being currently downloaded. This, for range requests, often
defeats the purpose of the diff as it leads to serialisation of all range
requests for the same segment (same URL). Thankfully, firefox does not see
this issue.

Tests:
o Ran this version of shaka-player on my local setup and saw
  segments getting prefetched in parallel.
o By changing the prefetchLimit, checked that the number of
  segments downloads being in flight mimicked the configuration.
o Tested the same on chrome as well as firefox.