### PR TITLE
onPollWindow_: use startTime when currentTime is not ready yet (fixes #2848)

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -313,7 +313,7 @@ shaka.media.MediaSourcePlayhead = class {
       return;
     }
 
-    const currentTime = this.mediaElement_.currentTime;
+    const currentTime = this.videoWrapper_.getTime();
     let seekStart = this.timeline_.getSeekRangeStart();
     const seekEnd = this.timeline_.getSeekRangeEnd();
 


### PR DESCRIPTION
There is a race condition: it could happen that `onPollWindow_` checks falling outside the availability window before `videoElement` returns the `currentTime` correctly (it returns 0 instead) so the following calculation leads to incorrect jump forward. Now it will use `this.videoWrapper_.getTime()` which returns `startTime` in that case instead.