### PR TITLE
fix: correctly detect Edge Chromium as Edge

### DIFF
--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -55,7 +55,11 @@ shaka.util.Platform = class {
    * @return {boolean}
    */
   static isEdge() {
-    return shaka.util.Platform.userAgentContains_('Edge/');
+    if (navigator.userAgent.match(/Edge?\//)) {
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
Edge Chromium UA example: `User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43`

Since https://github.com/google/shaka-player/pull/2801, trying to play PlayReady content with Shaka on Edge Chromium would result in a MANIFEST_RESTRICTIONS_CANNOT_BE_MET error since it wasn't selected to do the endianness black magic.

Edge Chromium should be detected as Edge to correctly correct the key endianness.

This affects the `v3.0.4` and `v2.5.16` releases.