### PR TITLE
ban new Date.getTime()

### DIFF
--- a/build/conformance.textproto
+++ b/build/conformance.textproto
@@ -133,6 +133,12 @@ requirement: {
   whitelist_regexp: 'lib/util/buffer_utils.js'
 }
 
+requirement: {
+  type: BANNED_CODE_PATTERN
+  value: 'function template () { new Date().getTime() }'
+  error_message: 'Use Date.now() instead.'
+}
+
 # Disallow console logging.
 requirement: {
   type: BANNED_PROPERTY_CALL

--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -345,7 +345,7 @@ shaka.media.MediaSourcePlayhead = class {
       // You can only seek like this every so often. This is to prevent an
       // infinite loop on systems where changing currentTime takes a significant
       // amount of time (e.g. Chromecast).
-      const time = new Date().getTime() / 1000;
+      const time = Date.now() / 1000;
       if (!this.lastCorrectiveSeek_ || this.lastCorrectiveSeek_ < time - 1) {
         this.lastCorrectiveSeek_ = time;
         this.videoWrapper_.setTime(targetTime);


### PR DESCRIPTION
Hi!

This request forces shaka-player to use `Date.now()` for time calculations.

First point here is that this is faster than `new Date().getTime()`.

Second point is that it allows monkey-patching `Date.now()` in runtime.

We are having issues with using `Date.now()` for time calculations (`Date.now` is not monotonic because it's affected by system time changes).
We are are going to monkey-patch `Date.now()` by using offset returned by `performance.now()` so it becomes monotonic and this patch makes this change consistent in our code and shaka-player.