### PR TITLE
Remove hard-coded tts:extent namespace in TTML parser

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -38,6 +38,7 @@ shaka.text.TtmlTextParser = class {
     const TtmlTextParser = shaka.text.TtmlTextParser;
     const XmlUtils = shaka.util.XmlUtils;
     const ttpNs = TtmlTextParser.parameterNs_;
+    const ttsNs = TtmlTextParser.styleNs_;
     const str = shaka.util.StringUtils.fromUTF8(data);
     const ret = [];
     const parser = new DOMParser();
@@ -95,7 +96,7 @@ shaka.text.TtmlTextParser = class {
         tickRate = XmlUtils.getAttributeNS(tt, ttpNs, 'tickRate');
         cellResolution = XmlUtils.getAttributeNS(tt, ttpNs, 'cellResolution');
         spaceStyle = tt.getAttribute('xml:space') || 'default';
-        extent = tt.getAttribute('tts:extent');
+        extent = XmlUtils.getAttributeNS(tt, ttsNs, 'extent');
       }
 
       if (spaceStyle != 'default' && spaceStyle != 'preserve') {

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -396,7 +396,7 @@ shaka.text.TtmlTextParser = class {
    * @param {!Element} regionElement
    * @param {!Array.<!Element>} styles Defined in the top of tt  element and
    * used principally for images.
-   * @param {string} globalExtent
+   * @param {?string} globalExtent
    * @return {shaka.text.CueRegion}
    * @private
    */


### PR DESCRIPTION
Related to https://github.com/google/shaka-player/issues/2756