### PR TITLE
feat: deduplicate text streams in period flattening

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -88,6 +88,7 @@ shaka.util.PeriodCombiner = class {
 
     shaka.util.PeriodCombiner.filterOutAudioStreamDuplicates_(periods);
     shaka.util.PeriodCombiner.filterOutVideoStreamDuplicates_(periods);
+    shaka.util.PeriodCombiner.filterOutTextStreamDuplicates_(periods);
 
     // Optimization: for single-period VOD, do nothing.  This makes sure
     // single-period DASH content will be 100% accurately represented in the
@@ -245,6 +246,35 @@ shaka.util.PeriodCombiner = class {
     }
   }
 
+  /**
+   * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods
+   * @private
+   */
+  static filterOutTextStreamDuplicates_(periods) {
+    const ArrayUtils = shaka.util.ArrayUtils;
+    // Two text streams are considered to be duplicates of
+    // one another if their ids are different, but all the other
+    // information is the same.
+    for (const period of periods) {
+      const filteredTexts = [];
+      for (const t1 of period.textStreams) {
+        let duplicate = false;
+        for (const t2 of filteredTexts) {
+          if (t1.id != t2.id &&
+            t1.language == t2.language &&
+            ArrayUtils.hasSameElements(t1.roles, t2.roles)) {
+            duplicate = true;
+          }
+        }
+
+        if (!duplicate) {
+          filteredTexts.push(t1);
+        }
+      }
+
+      period.textStreams = filteredTexts;
+    }
+  }
 
   /**
    * @param {!Array.<shaka.util.PeriodCombiner.Period>} periods

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -459,6 +459,20 @@ describe('PeriodCombiner', () => {
     a3.bandwidth = 97065;
     a2.roles = ['role1', 'role2'];
 
+    // t1 and t3 are duplicats
+    const t1 = makeTextStream('en');
+    t1.originalId = 't1';
+    t1.bandwidth = 65106;
+    t1.roles = ['role1'];
+
+    const t2 = makeAudioStream('en');
+    t2.originalId = 't2';
+    t2.roles = ['role1', 'role2'];
+
+    const t3 = makeAudioStream('en');
+    t3.originalId = 't3';
+    t3.roles = ['role1'];
+
     /** @type {!Array.<shaka.util.PeriodCombiner.Period>} */
     const periods = [
       {
@@ -473,7 +487,11 @@ describe('PeriodCombiner', () => {
           a2,
           a3,
         ],
-        textStreams: [],
+        textStreams: [
+          t1,
+          t2,
+          t3,
+        ],
       },
     ];
 

--- a/test/util/periods_unit.js
+++ b/test/util/periods_unit.js
@@ -462,14 +462,13 @@ describe('PeriodCombiner', () => {
     // t1 and t3 are duplicats
     const t1 = makeTextStream('en');
     t1.originalId = 't1';
-    t1.bandwidth = 65106;
     t1.roles = ['role1'];
 
-    const t2 = makeAudioStream('en');
+    const t2 = makeTextStream('en');
     t2.originalId = 't2';
     t2.roles = ['role1', 'role2'];
 
-    const t3 = makeAudioStream('en');
+    const t3 = makeTextStream('en');
     t3.originalId = 't3';
     t3.roles = ['role1'];
 


### PR DESCRIPTION
Title said it all :)

In a multi-period stream with the same text streams over periods, we would get back duplicates text tracks when calling `getTextTracks` player API.

That PR should fix that behaviour.