### PR TITLE
seeking while video paused no longer continue playing

### DIFF
--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -73,6 +73,14 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       this.markAdBreaks_();
     });
 
+    /**
+     * When user is scrubbing the seek bar - we should pause the video - see https://git.io/JUhHG
+     * but will conditionally pause or play the video after scrubbing
+     * depending on its previous state
+     *
+     * @private {boolean}
+     */
+    this.wasPlaying_ = false;
 
     /** @private {!Array.<!shaka.ads.CuePoint>} */
     this.adCuePoints_ = [];
@@ -134,6 +142,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
    * @override
    */
   onChangeStart() {
+    this.wasPlaying_ = !this.video.paused;
     this.controls.setSeeking(true);
     this.video.pause();
   }
@@ -176,7 +185,10 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
     // call the event so that we can respond immediately.
     this.seekTimer_.tickNow();
     this.controls.setSeeking(false);
-    this.video.play();
+
+    if (this.wasPlaying_) {
+      this.video.play();
+    }
   }
 
   /** @return {boolean} */


### PR DESCRIPTION
Previously, when seeking we do a **pause** then **continue play** after seeking. That will lead to a subtle bug.

For example: user pause a video, then seeking.

The end result user want: video is seeked but continued to be pause, that is not the current behavior (video will play when done seeking).

Is there any benefit of our current approach ?