### PR TITLE
Stall detector cause DOM error on SmartTV(issue #2920)

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -504,9 +504,15 @@ shaka.media.MediaSourcePlayhead = class {
         shaka.log.debug(`Seeking forward ${skip} seconds to break stall.`);
         mediaElement.currentTime += skip;
       } else {
-        shaka.log.debug('Pausing and unpausing to break stall.');
-        mediaElement.pause();
-        mediaElement.play();
+        // avoid pause request when play() request still in process
+        const isPlaying = mediaElement.currentTime > 0 &&
+          !mediaElement.paused &&
+          mediaElement.readyState > HTMLMediaElement.HAVE_CURRENT_DATA;
+        if (isPlaying) {
+          shaka.log.debug('Pausing and unpausing to break stall.');
+          mediaElement.pause();
+          mediaElement.play();
+        }
       }
     });
 


### PR DESCRIPTION
Avoid pause request when play request still in process.