### PR TITLE
docs: add link to complete list of categories

### DIFF
--- a/docs/tutorials/plugins.md
+++ b/docs/tutorials/plugins.md
@@ -108,6 +108,7 @@ python build/build.py +@complete -@polyfill
 python build/build.py +@complete -@polyfill -@text
 ```
 
+To see the complete list of categories, its in [`build/types/`](https://github.com/google/shaka-player/tree/master/build/types)
 
 #### Build Configs
 


### PR DESCRIPTION
When user read about these anotation `+@complete -@polyfill`, they wonder where it came from.

It is not immediately obvious where to see it without reading the next section.

I know this because I've dig into `build.py` file to realize this line: `Build files are the files found in build/types...`

And when I comeback to read - it is in the next section, it is worth to duplicating in this case I think.