### PR TITLE
Keep segmentIterator history on streaming_engine

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -123,6 +123,7 @@ shaka.media.StreamingEngine = class {
     for (const state of this.mediaStates_.values()) {
       this.cancelUpdate_(state);
       aborts.push(this.abortOperations_(state));
+      state.segmentIteratorMap.clear();
     }
 
     await Promise.all(aborts);
@@ -425,7 +426,6 @@ shaka.media.StreamingEngine = class {
     }
 
     mediaState.stream = stream;
-    mediaState.segmentIterator = null;
 
     const streamTag = shaka.media.StreamingEngine.logPrefix_(mediaState);
     shaka.log.debug('switch: switching to Stream ' + streamTag);
@@ -504,17 +504,26 @@ shaka.media.StreamingEngine = class {
 
     goog.asserts.assert(mediaState.stream.segmentIndex,
         'Segment index should exist by now!');
-
-    // This is set to null in switchInternal_, and only created here after we
-    // know the async process to create segmentIndex is complete.
-    goog.asserts.assert(!mediaState.segmentIterator,
-        'Segment iterator should have been reset by now!');
-    mediaState.segmentIterator =
-        mediaState.stream.segmentIndex[Symbol.iterator]();
+    this.initSegmentIterator_(mediaState);
 
     if (this.shouldAbortCurrentRequest_(mediaState)) {
       shaka.log.info('Aborting current segment request.');
       mediaState.operation.abort();
+    }
+  }
+
+
+  /**
+   * If there isn't one create a segmentIterator for the current
+   * mediaState's stream.
+   *
+   * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
+   * @private
+   */
+  initSegmentIterator_(mediaState) {
+    if (!mediaState.segmentIteratorMap.has(mediaState.stream)) {
+      mediaState.segmentIteratorMap.set(mediaState.stream,
+          mediaState.stream.segmentIndex[Symbol.iterator]());
     }
   }
 
@@ -771,13 +780,15 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   createMediaState_(stream) {
-    const segmentIterator = stream.segmentIndex ?
-        stream.segmentIndex[Symbol.iterator]() : null;
+    const segmentIteratorMap = new Map();
+    if (stream.segmentIndex) {
+      segmentIteratorMap.set(stream, stream.segmentIndex[Symbol.iterator]());
+    }
     return /** @type {shaka.media.StreamingEngine.MediaState_} */ ({
       stream,
       type: stream.type,
       lastStream: null,
-      segmentIterator,
+      segmentIteratorMap,
       lastSegmentReference: null,
       lastInitSegmentReference: null,
       lastTimestampOffset: null,
@@ -873,10 +884,7 @@ shaka.media.StreamingEngine = class {
 
     goog.asserts.assert(mediaState.stream.segmentIndex,
         'Segment index should exist by now!');
-    if (!mediaState.segmentIterator) {
-      mediaState.segmentIterator =
-          mediaState.stream.segmentIndex[Symbol.iterator]();
-    }
+    this.initSegmentIterator_(mediaState);
 
     // Update the MediaState.
     try {
@@ -1083,14 +1091,16 @@ shaka.media.StreamingEngine = class {
    */
   getSegmentReferenceNeeded_(mediaState, presentationTime, bufferEnd) {
     const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+    const segmentIterator = mediaState.segmentIteratorMap
+        .get(mediaState.stream);
     goog.asserts.assert(
-        mediaState.segmentIterator, 'Segment iterator should exist!');
+        segmentIterator, 'Segment iterator should exist!');
 
     if (mediaState.stream == mediaState.lastStream) {
       // Something is buffered from the same Stream.  Use the current position
       // in the segment index.  This is updated via next() after each segment is
       // appended.
-      return mediaState.segmentIterator.current();
+      return segmentIterator.current();
     } else if (mediaState.lastSegmentReference) {
       // Something is buffered from another Stream.
       goog.asserts.assert(mediaState.lastStream,
@@ -1099,7 +1109,7 @@ shaka.media.StreamingEngine = class {
       shaka.log.v1(logPrefix, 'looking up segment from new stream',
           'endTime:', mediaState.lastSegmentReference.endTime);
 
-      const ref = mediaState.segmentIterator.seek(
+      const ref = segmentIterator.seek(
           mediaState.lastSegmentReference.endTime);
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment',
@@ -1113,7 +1123,7 @@ shaka.media.StreamingEngine = class {
       shaka.log.v1(logPrefix, 'looking up segment',
           'bufferEnd:', bufferEnd);
 
-      const ref = mediaState.segmentIterator.seek(bufferEnd);
+      const ref = segmentIterator.seek(bufferEnd);
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment',
             'bufferEnd:', bufferEnd);
@@ -1135,12 +1145,12 @@ shaka.media.StreamingEngine = class {
 
       let ref = null;
       if (inaccurateTolerance) {
-        ref = mediaState.segmentIterator.seek(lookupTime);
+        ref = segmentIterator.seek(lookupTime);
       }
       if (!ref) {
         // If we can't find a valid segment with the drifted time, look for a
         // segment with the presentation time.
-        ref = mediaState.segmentIterator.seek(presentationTime);
+        ref = segmentIterator.seek(presentationTime);
       }
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment',
@@ -1563,6 +1573,7 @@ shaka.media.StreamingEngine = class {
    */
   advanceToNextSegment_(mediaState, reference, stream) {
     const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+    const segmentIterator = mediaState.segmentIteratorMap.get(stream);
 
     // We must use |stream| instead of |mediaState.stream| because switch() may
     // have been called.
@@ -1570,7 +1581,7 @@ shaka.media.StreamingEngine = class {
     mediaState.lastSegmentReference = reference;
     // Only advance the segmentIterator if the stream hasn't changed.
     if (mediaState.stream == stream) {
-      const ref = mediaState.segmentIterator.next().value;
+      const ref = segmentIterator.next().value;
       shaka.log.v2(logPrefix, 'advancing to next segment', ref);
     }
   }
@@ -1909,7 +1920,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   type: shaka.util.ManifestParserUtils.ContentType,
  *   stream: shaka.extern.Stream,
  *   lastStream: ?shaka.extern.Stream,
- *   segmentIterator: shaka.media.SegmentIterator,
+ *   segmentIteratorMap: Map.<!shaka.extern.Stream,
+ *       !shaka.media.SegmentIterator>,
  *   lastSegmentReference: shaka.media.SegmentReference,
  *   lastInitSegmentReference: shaka.media.InitSegmentReference,
  *   lastTimestampOffset: ?number,
@@ -1939,7 +1951,8 @@ shaka.media.StreamingEngine.PlayerInterface;
  *   The current Stream.
  * @property {?shaka.extern.Stream} lastStream
  *   The Stream of the last segment that was appended.
- * @property {shaka.media.SegmentIndexIterator} segmentIterator
+ * @property {Map.<!shaka.extern.Stream,
+ *     !shaka.media.SegmentIterator>} segmentIteratorMap
  *   An iterator through the segments of |stream|.
  * @property {shaka.media.SegmentReference} lastSegmentReference
  *   The SegmentReference of the last segment that was appended.


### PR DESCRIPTION
Fixes https://github.com/google/shaka-player/issues/2956

The fix involves keeping a reference of each stream's segmentIterator on the streaming engine, instead of only keeping the current stream's iterator and reseting it on every switch.

The fix and the previous erroneous behaviour can be tested/reproduced running Shaka's demo app, e.g.:

* change to the repo's root
* run python -m SimpleHTTPServer 80
* browse to http://localhost/demo
* on the demo UI go to settings and set Adaptation->Switch Interval->0.2, and set the log level to Debug
* play the "Big Buck Bunny: the Dark Truths" asset, and at the start throttle to 500k/100k and then back to Online
* on the web inspector's console filter by switching to to observe the bitrate changes, and look for quick switches like video: 5 -> video: 6 -> video: 5 (which causes the issue without the fix).

Adding a bit more knowledge to help people review this...

Shaka's streaming engine is the unit which owns the logic to request media segments from the network and append them on the media source buffer, and so it keeps a state object, mediaState, for each media type it needs (typically one for video and another for audio), which then stores the current chosen stream and it's related segmentIterator (btw I wonder if the segmentIterator is not owned by the stream to allow for multiple concurrent downloads, like playing and downloading at the same time).

The problem resides in the fact that the segmentIterator is not kept on the stream object itself, but instead on the mediaState owned by the streaming engine which only keeps the segmentIterator for the current stream. Probably because of this design decision, the streaming_engine needed to set the segmentIterator to null on the start of the switch call, and then asynchronously request a new segmentIterator object (which will always start at position zero).

The major design issue here was, that it didn't foresee the possibility that with a low enough switchInterval the stream kept on the mediaState can eventually switch multiple times during an in-progress media update (e.g. fetchAndAppend) and actually return to the current stream before the append_ method ends, which was causing the uncaught error because although the stream on the mediaState is the same as the one stored on the fetchAndAppend closure, the segmentIterator can be still null falling inside a non expected failure.

Additionally, even if the segmentIterator on that same scenario, is reset before the call to `segmentIterator.next()`  is made, the streaming engine will be in a state where it will start downloading segments from the start of the stream, because although the stream is same, the segmentIterator is new (and holds zero as the currentPosition), making the logic on getSegmentReferenceNeeded work in an incorrect way.

Another option I thought at the time, was for instead of keeping the segmentIterators instances just for this edgy scenario, to change getSegmentReferenceNeeded so that it always do the segmentIterator.seek logic with the position from the lastSegmentReference, the bufferEnd or the current playhead position, but that would always require computing the segment reference from the time, instead of just asking the next segment from the index, when downloading from the same stream, which wouldn't be optimal I think.