### PR TITLE
build: add mkdir to make .py command self-contained

### DIFF
--- a/build/apps.py
+++ b/build/apps.py
@@ -161,6 +161,14 @@ def main(args):
       action='store_true')
 
   parsed_args = parser.parse_args(args)
+
+  # Make the dist/ folder, ignore errors.
+  base = shakaBuildHelpers.get_source_base()
+  try:
+    os.mkdir(os.path.join(base, 'dist'))
+  except OSError:
+    pass
+
   force = parsed_args.force
 
   # Update node modules if needed.

--- a/build/build.py
+++ b/build/build.py
@@ -350,6 +350,13 @@ def main(args):
 
   parsed_args, commands = parser.parse_known_args(args)
 
+  # Make the dist/ folder, ignore errors.
+  base = shakaBuildHelpers.get_source_base()
+  try:
+    os.mkdir(os.path.join(base, 'dist'))
+  except OSError:
+    pass
+
   # Update node modules if needed.
   if not shakaBuildHelpers.update_node_modules():
     return 1

--- a/build/check.py
+++ b/build/check.py
@@ -332,6 +332,13 @@ def main(args):
 
   parsed_args = parser.parse_args(args)
 
+  # Make the dist/ folder, ignore errors.
+  base = shakaBuildHelpers.get_source_base()
+  try:
+    os.mkdir(os.path.join(base, 'dist'))
+  except OSError:
+    pass
+
   # Update node modules if needed.
   if not shakaBuildHelpers.update_node_modules():
     return 1


### PR DESCRIPTION
fix #2973 

Only 3 py commands need `mkdir`, the rest are self-contained already