### PR TITLE
feat: add com.apple.fps.3_0 into the defaultKeySystems

### DIFF
--- a/lib/dash/content_protection.js
+++ b/lib/dash/content_protection.js
@@ -561,7 +561,10 @@ shaka.dash.ContentProtection.defaultKeySystems_ = new Map()
     .set('urn:uuid:79f0049a-4098-8642-ab92-e65be0885f95',
         'com.microsoft.playready')
     .set('urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb',
-        'com.adobe.primetime');
+        'com.adobe.primetime')
+    .set('urn:uuid:94ce86fb-07ff-4f43-adb8-93d2fa968ca2',
+        'com.apple.fps.3_0');
+
 
 /**
  * A map of key system name to license server url parser.

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -699,6 +699,7 @@ shaka.media.DrmEngine = class {
     for (const info of allDrmInfo) {
       const config = {
         // Ignore initDataTypes.
+        initDataTypes: ['cenc'],
         audioCapabilities: [],
         videoCapabilities: [],
         distinctiveIdentifier: 'optional',

--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -698,7 +698,6 @@ shaka.media.DrmEngine = class {
     // Create a config entry for each key system.
     for (const info of allDrmInfo) {
       const config = {
-        // Ignore initDataTypes.
         initDataTypes: ['cenc'],
         audioCapabilities: [],
         videoCapabilities: [],


### PR DESCRIPTION
This adds default support for the `com.apple.fps.3_0` keySystem, as long as this part of the dash manifest `ContentProtection`, and you give correct licenseURI / serverCertificate in the advancedConfig.

I still have issues with my DRM Provider, which doesn't seem to read the keyId well in the license request data.