### PR TITLE
chore: Update mux.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ HLS features supported:
  - VOD, Live, and Event types
  - Encrypted content with PlayReady and Widevine
  - ISO-BMFF / MP4 / CMAF support
- - MPEG-2 TS support (transmuxing provided by [mux.js][] v5.6.3+, must be
+ - MPEG-2 TS support (transmuxing provided by [mux.js][] v5.7.0+, must be
    separately included)
  - WebVTT and TTML
  - CEA-608/708 captions
@@ -132,8 +132,6 @@ HLS features **not** supported:
  - I-frame-only playlists: https://github.com/google/shaka-player/issues/742
  - Raw AAC, MP3, etc (without an MP4 container):
    https://github.com/google/shaka-player/issues/2337
- - CEA-708 in TS container not supported in mux.js yet:
-   https://github.com/videojs/mux.js/pull/346
 
 [mux.js]: https://github.com/videojs/mux.js/releases
 
@@ -196,7 +194,7 @@ Shaka Player supports:
       SegmentTemplate@index
     - Not supported in HLS
   - MPEG-2 TS
-    - With help from [mux.js][] v5.6.3+, can be played on any browser which
+    - With help from [mux.js][] v5.7.0+, can be played on any browser which
       supports MP4
     - Can find and parse timestamps to find segment start time in HLS
   - WebVTT
@@ -205,9 +203,10 @@ Shaka Player supports:
     - Supported in both XML form and embedded in MP4
   - CEA-608
     - Supported embedded in MP4
-    - With help from [mux.js][] v5.6.3+, supported embedded in TS
+    - With help from [mux.js][] v5.7.0+, supported embedded in TS
   - CEA-708
     - Supported embedded in MP4
+    - With help from [mux.js][] v5.7.0+, supported embedded in TS
   - SubRip (SRT)
     - UTF-8 encoding only
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "less": "^3.9.0 <3.12.0",
     "less-plugin-clean-css": "^1.5.1",
     "material-design-lite": "^1.3.0",
-    "mux.js": "^5.6.4",
+    "mux.js": "^5.7.0",
     "pwacompat": "^2.0.10",
     "rimraf": "^2.6.3",
     "sprintf-js": "^1.1.2",


### PR DESCRIPTION
This new version supports CEA-708