### PR TITLE
Change default timeout network requests

### DIFF
--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -33,6 +33,7 @@
  *   For example, 0.5 means "between 50% below and 50% above the retry delay."
  * @property {number} timeout
  *   The request timeout, in milliseconds.  Zero means "unlimited".
+ *   <i>Defaults to 30000 milliseconds.</i>
  *
  * @tutorial network-and-buffering-config
  *

--- a/lib/net/backoff.js
+++ b/lib/net/backoff.js
@@ -139,7 +139,7 @@ shaka.net.Backoff = class {
       baseDelay: 1000,
       backoffFactor: 2,
       fuzzFactor: 0.5,
-      timeout: 0,
+      timeout: 30000,
     };
   }
 


### PR DESCRIPTION
Closes: https://github.com/google/shaka-player/issues/1578

We are having problems with Chromecast-CAF and since it uses ShakaPlayer it is necessary to change this here by default.