### PR TITLE
Fix memory leak when creating segment references from a timeline

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
 Code It <*@code-it.fr>
 Damien Deis <developer.deis@gmail.com>
+Dany L'Hébreux <danylhebreux@gmail.com>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 Google Inc. <*@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -35,6 +35,7 @@ Chad Assareh <assareh@google.com>
 Chris Fillmore <fillmore.chris@gmail.com>
 Costel Madalin Grecu <madalin.grecu@adswizz.com>
 Damien Deis <developer.deis@gmail.com>
+Dany L'Hébreux <danylhebreux@gmail.com>
 Donato Borrello <donato@jwplayer.com>
 Duc Pham <duc.pham@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -465,16 +465,18 @@ shaka.dash.SegmentTemplate = class {
           info.unscaledPresentationTimeOffset;
       const repId = context.representation.id;
       const bandwidth = context.bandwidth || null;
+      const mediaTemplate = info.mediaTemplate;
+      const baseUris = context.representation.baseUris;
       const createUris =
           () => {
             goog.asserts.assert(
-                info.mediaTemplate,
+                mediaTemplate,
                 'There should be a media template with a timeline');
             const mediaUri = MpdUtils.fillUriTemplate(
-                info.mediaTemplate, repId,
+                mediaTemplate, repId,
                 segmentReplacement, bandwidth || null, timeReplacement);
             return ManifestParserUtils
-                .resolveUris(context.representation.baseUris, [mediaUri])
+                .resolveUris(baseUris, [mediaUri])
                 .map((g) => {
                   return g.toString();
                 });

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -467,6 +467,12 @@ shaka.dash.SegmentTemplate = class {
       const bandwidth = context.bandwidth || null;
       const mediaTemplate = info.mediaTemplate;
       const baseUris = context.representation.baseUris;
+
+      // This callback must not capture any non-local
+      // variables, such as info, context, etc.  Make
+      // sure any values you reference here have
+      // been assigned to local variables within the
+      // loop, or else we will end up with a leak.
       const createUris =
           () => {
             goog.asserts.assert(


### PR DESCRIPTION
Issue : https://github.com/google/shaka-player/issues/3038

We found the issue within our app with the latest Chromecast CAF receiver update (November 22, 2020) that use Shaka 3.0.x. With our live stream containing 90 minutes of buffer, we notice high level of buffering issue with our customer.

### Here some results after around 1 hour of playback :

| Before | After |
| ------ | ----- |
| ![shaka-demo-app-leak-before](https://user-images.githubusercontent.com/475632/101791560-ac67ed00-3ad1-11eb-806b-017f22cf6a6c.png) | ❌  |
|  ![Screen Shot 2020-12-09 at 2 46 14 PM](https://user-images.githubusercontent.com/475632/101791653-c86b8e80-3ad1-11eb-8e8e-8dd4f848258b.png) | ![Screen Shot 2020-12-09 at 2 45 34 PM](https://user-images.githubusercontent.com/475632/101791683-d02b3300-3ad1-11eb-803d-de1053f46459.png) |


I builded a custom version of Shaka player into my Chromecast receiver app and here the usedJSHeapSize results.

#### Before
```Javascript
09:49:15.562 Shaka test /// usedJSHeapSize: 97.607819 MB  /// lower usedJSHeapSize: 27.552935 /// higher usedJSHeapSize: 98.064532
09:49:15.564 Shaka test /// usedJSHeapSize increased 70 MB in 344 seconds since beginning of live playback session
```


#### After
```Javascript
09:39:57.263 Shaka test /// usedJSHeapSize: 34.529496 MB  /// lower usedJSHeapSize: 27.120771 /// higher usedJSHeapSize: 40.800786
09:39:57.264 Shaka test /// usedJSHeapSize increased 7 MB in 508 seconds since beginning of live playback session
```




