### PR TITLE
periods(fix) jsdoc comment in function

### DIFF
--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -1359,7 +1359,7 @@ shaka.util.PeriodCombiner = class {
     return EQUAL;
   }
 
-  /*
+  /**
    * @param {number} outputValue
    * @param {number} bestValue
    * @param {number} candidateValue


### PR DESCRIPTION
The compareClosestPreferMinimalAbsDiff_ was missing a * in the
jsdoc comment; closure compiler was complaining with

    > WARNING - Parse error. Non-JSDoc comment has annotations.
    > Did you mean to start it with '/**'?