### PR TITLE
Allow TS in Safari 14 or above when there is no mux.js

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -36,10 +36,12 @@ shaka.polyfill.MediaSource = class {
       // Chromecast cannot make accurate determinations via isTypeSupported.
       shaka.polyfill.MediaSource.patchCastIsTypeSupported_();
     } else if (safariVersion) {
-      // TS content is broken on Safari in general.
-      // See https://github.com/google/shaka-player/issues/743
-      // and https://bugs.webkit.org/show_bug.cgi?id=165342
-      shaka.polyfill.MediaSource.rejectTsContent_();
+      // TS content is broken on Safari in 13 or less.
+      if (safariVersion <= 13) {
+        // See https://github.com/google/shaka-player/issues/743
+        // and https://bugs.webkit.org/show_bug.cgi?id=165342
+        shaka.polyfill.MediaSource.rejectTsContent_();
+      }
 
       // NOTE:  shaka.Player.isBrowserSupported() has its own restrictions on
       // Safari version.


### PR DESCRIPTION
Closes: https://github.com/google/shaka-player/issues/2695

Support is restricted to Safari 14 or higher due to previous versions having problems and it is not usable.