### PR TITLE
fix(ttml): Wrong calc of viewport anchors for cue region

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -387,13 +387,13 @@ shaka.text.TtmlTextParser = class {
       percentage = TtmlTextParser.percentValues_.exec(origin);
       results = percentage || TtmlTextParser.pixelValues_.exec(origin);
       if (results != null) {
-        if (globalHeight != null) {
-          region.viewportAnchorX = Number(results[1]) * 100 / globalHeight;
+        if (globalWidth != null) {
+          region.viewportAnchorX = Number(results[1]) * 100 / globalWidth;
         } else {
           region.viewportAnchorX = Number(results[1]);
         }
-        if (globalWidth != null) {
-          region.viewportAnchorY = Number(results[2]) * 100 / globalWidth;
+        if (globalHeight != null) {
+          region.viewportAnchorY = Number(results[2]) * 100 / globalHeight;
         } else {
           region.viewportAnchorY = Number(results[2]);
         }


### PR DESCRIPTION
Width should be used for calculation x, and height for calculation y.