### PR TITLE
fix: build on python3

### DIFF
--- a/build/shakaBuildHelpers.py
+++ b/build/shakaBuildHelpers.py
@@ -296,7 +296,7 @@ def get_node_binary(module_name, bin_name=None):
     package_data = json.load(open_file(json_path, 'r'))
     bin_data = package_data['bin']
 
-    if type(bin_data) is str or type(bin_data) is unicode:
+    if type(bin_data) is str or type(bin_data) is str:
       # There's only one binary here.
       bin_rel_path = bin_data
     else:


### PR DESCRIPTION
I saw https://github.com/google/shaka-player/commit/56bb045ff68325d6b9de7cb3d56265ce3162f164, try it again on master it said:

```
...
[INFO] Generating Closure dependencies...
[INFO] Linting JavaScript...
Traceback (most recent call last):
  File "/tmp/shaka-player/build/all.py", line 150, in <module>
    shakaBuildHelpers.run_main(main)
  File "/tmp/shaka-player/build/shakaBuildHelpers.py", line 369, in run_main
    sys.exit(main(sys.argv[1:]))
  File "/tmp/shaka-player/build/all.py", line 103, in main
    if check.main(check_args) != 0:
  File "/tmp/shaka-player/build/check.py", line 348, in main
    if not step(parsed_args):
  File "/tmp/shaka-player/build/check.py", line 88, in check_js_lint
    return linter.lint(fix=args.fix, force=args.force)
  File "/tmp/shaka-player/build/compiler.py", line 325, in lint
    eslint = shakaBuildHelpers.get_node_binary('eslint')
  File "/tmp/shaka-player/build/shakaBuildHelpers.py", line 299, in get_node_binary
    if type(bin_data) is str or type(bin_data) is unicode:
NameError: name 'unicode' is not defined
```

change `unicode` to `str`

suggested by https://stackoverflow.com/questions/19877306/nameerror-global-name-unicode-is-not-defined-in-python-3