### PR TITLE
Fixed choice of codecs for 4K and higher

### DIFF
--- a/lib/util/multi_map.js
+++ b/lib/util/multi_map.js
@@ -89,4 +89,12 @@ shaka.util.MultiMap = class {
       callback(key, this.map_[key]);
     }
   }
+
+  /**
+   * Returns the number of elements in the multimap.
+   * @return {number}
+   */
+  size() {
+    return Object.keys(this.map_).length;
+  }
 };

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -43,7 +43,7 @@ shaka.util.StreamUtils = class {
     // Now organize variants into buckets by codecs.
     /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
     let variantsByCodecs = StreamUtils.getVariantsByCodecs_(variants);
-    variantsByCodecs = StreamUtils.filterVariantsByHeight_(variantsByCodecs);
+    variantsByCodecs = StreamUtils.filterVariantsBySize_(variantsByCodecs);
 
     const bestCodecs = StreamUtils.findBestCodecs_(variantsByCodecs);
 
@@ -78,39 +78,39 @@ shaka.util.StreamUtils = class {
   }
 
   /**
-  * Filters variants with missing heights by all codecs.
+  * Filters variants with missing sizes by all codecs.
   *
   * @param {!shaka.util.MultiMap.<shaka.extern.Variant>} variantsByCodecs
   * @return {!shaka.util.MultiMap.<shaka.extern.Variant>}
   * @private
   */
-  static filterVariantsByHeight_(variantsByCodecs) {
-    let maxHeight = 0;
-    const heightByCodecs = new Map();
+  static filterVariantsBySize_(variantsByCodecs) {
+    let maxSize = 0;
+    const sizeByCodecs = new Map();
     const countCodecs = variantsByCodecs.size();
     variantsByCodecs.forEach((codecs, variants) => {
       for (const variant of variants) {
         const video = variant.video;
-        if (!video || !video.height) {
+        if (!video || !video.width || !video.height) {
           continue;
         }
 
-        const height = video.height * 1000 + (video.frameRate || 0);
-        if (!heightByCodecs.has(height)) {
-          heightByCodecs.set(height, new shaka.util.MultiMap());
+        const size = video.width * video.height + (video.frameRate || 0);
+        if (!sizeByCodecs.has(size)) {
+          sizeByCodecs.set(size, new shaka.util.MultiMap());
         }
 
         /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
-        const item = heightByCodecs.get(height);
+        const item = sizeByCodecs.get(size);
         item.push(codecs, variant);
 
         if (item.size() === countCodecs) {
-          maxHeight = Math.max(maxHeight, height);
+          maxSize = Math.max(maxSize, size);
         }
       }
     });
 
-    return maxHeight ? heightByCodecs.get(maxHeight) : variantsByCodecs;
+    return maxSize ? sizeByCodecs.get(maxSize) : variantsByCodecs;
   }
 
   /**

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -30,48 +30,101 @@ shaka.util.StreamUtils = class {
    * @param {number} preferredAudioChannelCount
    */
   static chooseCodecsAndFilterManifest(manifest, preferredAudioChannelCount) {
-    const MimeUtils = shaka.util.MimeUtils;
+    const StreamUtils = shaka.util.StreamUtils;
 
     // To start, consider a subset of variants based on audio channel
     // preferences.
     // For some content (#1013), surround-sound variants will use a different
     // codec than stereo variants, so it is important to choose codecs **after**
     // considering the audio channel config.
-    const variants = shaka.util.StreamUtils.filterVariantsByAudioChannelCount(
+    const variants = StreamUtils.filterVariantsByAudioChannelCount(
         manifest.variants, preferredAudioChannelCount);
-
-    /**
-     * @param {!shaka.extern.Variant} variant
-     * @return {string}
-     */
-    function variantCodecs(variant) {
-      // Only consider the base of the codec string.  For example, these should
-      // both be considered the same codec: avc1.42c01e, avc1.4d401f
-      let baseVideoCodec = '';
-      if (variant.video) {
-        baseVideoCodec = MimeUtils.getCodecBase(variant.video.codecs);
-      }
-
-      let baseAudioCodec = '';
-      if (variant.audio) {
-        baseAudioCodec = MimeUtils.getCodecBase(variant.audio.codecs);
-      }
-
-      return baseVideoCodec + '-' + baseAudioCodec;
-    }
 
     // Now organize variants into buckets by codecs.
     /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
+    let variantsByCodecs = StreamUtils.getVariantsByCodecs_(variants);
+    variantsByCodecs = StreamUtils.filterVariantsByHeight_(variantsByCodecs);
+
+    const bestCodecs = StreamUtils.findBestCodecs_(variantsByCodecs);
+
+    // Filter out any variants that don't match, forcing AbrManager to choose
+    // from the most efficient variants possible.
+    manifest.variants = manifest.variants.filter((variant) => {
+      const codecs = StreamUtils.getGroupVariantCodecs_(variant);
+      if (codecs == bestCodecs) {
+        return true;
+      }
+
+      shaka.log.debug('Dropping Variant (better codec available)', variant);
+      return false;
+    });
+  }
+
+  /**
+  * Get variants by codecs.
+  *
+  * @param {!Array<shaka.extern.Variant>} variants
+  * @return {!shaka.util.MultiMap.<shaka.extern.Variant>}
+  * @private
+  */
+  static getVariantsByCodecs_(variants) {
     const variantsByCodecs = new shaka.util.MultiMap();
     for (const variant of variants) {
-      const group = variantCodecs(variant);
+      const group = shaka.util.StreamUtils.getGroupVariantCodecs_(variant);
       variantsByCodecs.push(group, variant);
     }
 
-    // Compute the average bandwidth for each group of variants.
-    // Choose the lowest-bandwidth codecs.
-    let bestCodecs = null;
+    return variantsByCodecs;
+  }
+
+  /**
+  * Filters variants with missing heights by all codecs.
+  *
+  * @param {!shaka.util.MultiMap.<shaka.extern.Variant>} variantsByCodecs
+  * @return {!shaka.util.MultiMap.<shaka.extern.Variant>}
+  * @private
+  */
+  static filterVariantsByHeight_(variantsByCodecs) {
+    let maxHeight = 0;
+    const heightByCodecs = new Map();
+    const countCodecs = variantsByCodecs.size();
+    variantsByCodecs.forEach((codecs, variants) => {
+      for (const variant of variants) {
+        const video = variant.video;
+        if (!video || !video.height) {
+          continue;
+        }
+
+        const height = video.height * 1000 + (video.frameRate || 0);
+        if (!heightByCodecs.has(height)) {
+          heightByCodecs.set(height, new shaka.util.MultiMap());
+        }
+
+        /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
+        const item = heightByCodecs.get(height);
+        item.push(codecs, variant);
+
+        if (item.size() === countCodecs) {
+          maxHeight = Math.max(maxHeight, height);
+        }
+      }
+    });
+
+    return maxHeight ? heightByCodecs.get(maxHeight) : variantsByCodecs;
+  }
+
+  /**
+   * Find the lowest-bandwidth (best) codecs.
+   * Compute the average bandwidth for each group of variants.
+   *
+   * @param {!shaka.util.MultiMap.<shaka.extern.Variant>} variantsByCodecs
+   * @return {string}
+   * @private
+   */
+  static findBestCodecs_(variantsByCodecs) {
+    let bestCodecs = '';
     let lowestAverageBandwidth = Infinity;
+
     variantsByCodecs.forEach((codecs, variants) => {
       let sum = 0;
       let num = 0;
@@ -79,6 +132,7 @@ shaka.util.StreamUtils = class {
         sum += variant.bandwidth || 0;
         ++num;
       }
+
       const averageBandwidth = sum / num;
       shaka.log.debug('codecs', codecs, 'avg bandwidth', averageBandwidth);
 
@@ -87,21 +141,35 @@ shaka.util.StreamUtils = class {
         lowestAverageBandwidth = averageBandwidth;
       }
     });
-    goog.asserts.assert(bestCodecs != null, 'Should have chosen codecs!');
+
+    goog.asserts.assert(bestCodecs !== '', 'Should have chosen codecs!');
     goog.asserts.assert(!isNaN(lowestAverageBandwidth),
         'Bandwidth should be a number!');
 
-    // Filter out any variants that don't match, forcing AbrManager to choose
-    // from the most efficient variants possible.
-    manifest.variants = manifest.variants.filter((variant) => {
-      const codecs = variantCodecs(variant);
-      if (codecs == bestCodecs) {
-        return true;
-      }
+    return bestCodecs;
+  }
 
-      shaka.log.debug('Dropping Variant (better codec available)', variant);
-      return false;
-    });
+  /**
+   * Get a string representing all codecs used in a variant.
+   *
+   * @param {!shaka.extern.Variant} variant
+   * @return {string}
+   * @private
+   */
+  static getGroupVariantCodecs_(variant) {
+    // Only consider the base of the codec string.  For example, these should
+    // both be considered the same codec: avc1.42c01e, avc1.4d401f
+    let baseVideoCodec = '';
+    if (variant.video) {
+      baseVideoCodec = shaka.util.MimeUtils.getCodecBase(variant.video.codecs);
+    }
+
+    let baseAudioCodec = '';
+    if (variant.audio) {
+      baseAudioCodec = shaka.util.MimeUtils.getCodecBase(variant.audio.codecs);
+    }
+
+    return baseVideoCodec + '-' + baseAudioCodec;
   }
 
   /**

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -86,8 +86,9 @@ shaka.util.StreamUtils = class {
   */
   static filterVariantsBySize_(variantsByCodecs) {
     let maxSize = 0;
-    const sizeByCodecs = new Map();
+    const sizes = new Map();
     const countCodecs = variantsByCodecs.size();
+
     variantsByCodecs.forEach((codecs, variants) => {
       for (const variant of variants) {
         const video = variant.video;
@@ -96,12 +97,12 @@ shaka.util.StreamUtils = class {
         }
 
         const size = video.width * video.height + (video.frameRate || 0);
-        if (!sizeByCodecs.has(size)) {
-          sizeByCodecs.set(size, new shaka.util.MultiMap());
+        if (!sizes.has(size)) {
+          sizes.set(size, new shaka.util.MultiMap());
         }
 
         /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
-        const item = sizeByCodecs.get(size);
+        const item = sizes.get(size);
         item.push(codecs, variant);
 
         if (item.size() === countCodecs) {
@@ -110,7 +111,7 @@ shaka.util.StreamUtils = class {
       }
     });
 
-    return maxSize ? sizeByCodecs.get(maxSize) : variantsByCodecs;
+    return maxSize ? sizes.get(maxSize) : variantsByCodecs;
   }
 
   /**

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -43,7 +43,7 @@ shaka.util.StreamUtils = class {
     // Now organize variants into buckets by codecs.
     /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
     let variantsByCodecs = StreamUtils.getVariantsByCodecs_(variants);
-    variantsByCodecs = StreamUtils.filterVariantsBySize_(variantsByCodecs);
+    variantsByCodecs = StreamUtils.filterVariantsByDensity_(variantsByCodecs);
 
     const bestCodecs = StreamUtils.findBestCodecs_(variantsByCodecs);
 
@@ -78,15 +78,15 @@ shaka.util.StreamUtils = class {
   }
 
   /**
-  * Filters variants with missing sizes by all codecs.
+  * Filters variants by density.
   *
   * @param {!shaka.util.MultiMap.<shaka.extern.Variant>} variantsByCodecs
   * @return {!shaka.util.MultiMap.<shaka.extern.Variant>}
   * @private
   */
-  static filterVariantsBySize_(variantsByCodecs) {
-    let maxSize = 0;
-    const sizes = new Map();
+  static filterVariantsByDensity_(variantsByCodecs) {
+    let maxDensity = 0;
+    const codecGroupsByDensity = new Map();
     const countCodecs = variantsByCodecs.size();
 
     variantsByCodecs.forEach((codecs, variants) => {
@@ -96,22 +96,27 @@ shaka.util.StreamUtils = class {
           continue;
         }
 
-        const size = video.width * video.height + (video.frameRate || 0);
-        if (!sizes.has(size)) {
-          sizes.set(size, new shaka.util.MultiMap());
+        const density = video.width * video.height * (video.frameRate || 1);
+        if (!codecGroupsByDensity.has(density)) {
+          codecGroupsByDensity.set(density, new shaka.util.MultiMap());
         }
 
         /** @type {!shaka.util.MultiMap.<shaka.extern.Variant>} */
-        const item = sizes.get(size);
-        item.push(codecs, variant);
+        const group = codecGroupsByDensity.get(density);
+        group.push(codecs, variant);
 
-        if (item.size() === countCodecs) {
-          maxSize = Math.max(maxSize, size);
+        // We want to look at the groups in which all codecs are present.
+        // Take the max density from those groups where all codecs are present.
+        // Later, we will compare bandwidth numbers only within this group.
+        // Effectively, only the bandwidth differences in the highest-res and
+        // highest-framerate content will matter in choosing a codec.
+        if (group.size() === countCodecs) {
+          maxDensity = Math.max(maxDensity, density);
         }
       }
     });
 
-    return maxSize ? sizes.get(maxSize) : variantsByCodecs;
+    return maxDensity ? codecGroupsByDensity.get(maxDensity) : variantsByCodecs;
   }
 
   /**

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -553,7 +553,7 @@ describe('StreamUtils', () => {
         addVariant2160Vp9(manifest);
       });
 
-      shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest);
+      shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest, 2);
 
       expect(manifest.variants.length).toBe(2);
       expect(manifest.variants[0].video.codecs).toBe(vp09Codecs);
@@ -566,7 +566,7 @@ describe('StreamUtils', () => {
         addVariant1080Vp9(manifest);
       });
 
-      shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest);
+      shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest, 2);
 
       expect(manifest.variants.length).toBe(1);
       expect(manifest.variants[0].video.codecs).toBe(vp09Codecs);

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -500,7 +500,7 @@ describe('StreamUtils', () => {
     });
   });
 
-  describe('filterVariantsByHeight_', () => {
+  describe('filterVariantsBySize_', () => {
     const avc1Variant1080 = /** @type {shaka.extern.Variant} */(
       /** @type {?} */({
         bandwidth: 5058558,
@@ -549,14 +549,14 @@ describe('StreamUtils', () => {
       })
     );
 
-    it('filters variants by height', () => {
+    it('filters variants by size', () => {
       const variantsByCodecs = StreamUtils.getVariantsByCodecs_([
         avc1Variant1080,
         vp9Variant1080,
         vp9Variant2160,
       ]);
 
-      const actual = StreamUtils.filterVariantsByHeight_(
+      const actual = StreamUtils.filterVariantsBySize_(
           variantsByCodecs
       ).getAll();
 
@@ -576,7 +576,7 @@ describe('StreamUtils', () => {
           vp9Variant2160,
         ]);
 
-        const filteredVariantsByCodecs = StreamUtils.filterVariantsByHeight_(
+        const filteredVariantsByCodecs = StreamUtils.filterVariantsBySize_(
             variantsByCodecs
         );
 
@@ -593,7 +593,7 @@ describe('StreamUtils', () => {
           vp9Variant2160,
         ]);
 
-        const filteredVariantsByCodecs = StreamUtils.filterVariantsByHeight_(
+        const filteredVariantsByCodecs = StreamUtils.filterVariantsBySize_(
             variantsByCodecs
         );
 

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -501,6 +501,9 @@ describe('StreamUtils', () => {
   });
 
   describe('chooseCodecsAndFilterManifest', () => {
+    const avc1Codecs = 'avc1.640028';
+    const vp09Codecs = 'vp09.00.40.08.00.02.02.02.00';
+
     const addVariant1080Avc1 = (manifest) => {
       manifest.addVariant(0, (variant) => {
         variant.bandwidth = 5058558;
@@ -509,7 +512,7 @@ describe('StreamUtils', () => {
         });
         variant.addVideo(2, (stream) => {
           stream.bandwidth = 4928560;
-          stream.codecs = 'avc1.640028';
+          stream.codecs = avc1Codecs;
           stream.size(1920, 1080);
         });
       });
@@ -523,7 +526,7 @@ describe('StreamUtils', () => {
         });
         variant.addVideo(5, (stream) => {
           stream.bandwidth = 4781002;
-          stream.codecs = 'vp09.00.40.08.00.02.02.02.00';
+          stream.codecs = vp09Codecs;
           stream.size(1920, 1080);
         });
       });
@@ -537,13 +540,13 @@ describe('StreamUtils', () => {
         });
         variant.addVideo(8, (stream) => {
           stream.bandwidth = 10784324;
-          stream.codecs = 'vp09.00.40.08.00.02.02.02.00';
+          stream.codecs = vp09Codecs;
           stream.size(3840, 2160);
         });
       });
     };
 
-    it('chooses variants with different sizes by codecs', () => {
+    it('chooses variants with different sizes (density) by codecs', () => {
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {
         addVariant1080Avc1(manifest);
         addVariant1080Vp9(manifest);
@@ -553,10 +556,11 @@ describe('StreamUtils', () => {
       shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest);
 
       expect(manifest.variants.length).toBe(2);
-      expect(manifest.variants[0].id).toBe(3);
+      expect(manifest.variants[0].video.codecs).toBe(vp09Codecs);
+      expect(manifest.variants[1].video.codecs).toBe(vp09Codecs);
     });
 
-    it('chooses variants with same sizes by codecs', () => {
+    it('chooses variants with same sizes (density) by codecs', () => {
       manifest = shaka.test.ManifestGenerator.generate((manifest) => {
         addVariant1080Avc1(manifest);
         addVariant1080Vp9(manifest);
@@ -565,7 +569,7 @@ describe('StreamUtils', () => {
       shaka.util.StreamUtils.chooseCodecsAndFilterManifest(manifest);
 
       expect(manifest.variants.length).toBe(1);
-      expect(manifest.variants[0].id).toBe(3);
+      expect(manifest.variants[0].video.codecs).toBe(vp09Codecs);
     });
   });
 });


### PR DESCRIPTION
avc1: 240, 360, 480, 720, 1080
vp9: 240, 360, 480, 720, 1080, 1440, 2160 (average bandwidth is higher, more variants)

Before:
Best codecs: avc1 (incorrect)

After:
Best codecs: vp9 (correct)

Details: #3056

Remove variants where the height is not found in all codec groups.
