### PR TITLE
fix(ads): Use the correct AdsLoader AD_ERROR event

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -50,6 +50,7 @@ Jacob Trimble <modmaker@google.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Jesse Gunsch <gunsch@google.com>
+Jimmy Ly <jimmyly@google.com>
 Joey Parrish <joeyparrish@google.com>
 Johan Sundström <oyasumi@gmail.com>
 John Bowers <john.bowers@verizondigitalmedia.com>

--- a/lib/ads/client_side_ad_manager.js
+++ b/lib/ads/client_side_ad_manager.js
@@ -70,7 +70,7 @@ shaka.ads.ClientSideAdManager = class {
         });
 
     this.eventManager_.listen(this.adsLoader_,
-        google.ima.AdEvent.Type.AD_ERROR, (e) => {
+        google.ima.AdErrorEvent.Type.AD_ERROR, (e) => {
           this.onAdError_( /** @type {!google.ima.AdErrorEvent} */ (e));
         });
 


### PR DESCRIPTION
Listen to the `google.ima.AdErrorEvent.Type.AD_ERROR` event from the
IMA SDK AdsLoader instead of the `google.ima.AdEvent.Type.AD_ERROR` in
order to properly catch some ad errors that are currently being missed.

Resolves #3095 