### PR TITLE
feat(ads): Add setVpaidMode to the ima externs

### DIFF
--- a/externs/ima.js
+++ b/externs/ima.js
@@ -16,11 +16,8 @@ var google = {};
 /** @const */
 google.ima = {};
 
-/** @const */
-google.ima.settings = {};
-
-/** @param {string} locale */
-google.ima.settings.setLocale = function(locale) {};
+/** @type {!google.ima.ImaSdkSettings} */
+google.ima.settings;
 
 
 /**
@@ -191,6 +188,20 @@ google.ima.ImaSdkSettings = class {
    * @param {string} version
    */
   setPlayerVersion(version) {}
+
+  /**
+   * @param {google.ima.ImaSdkSettings.VpaidMode} vpaidMode
+   */
+  setVpaidMode(vpaidMode) {}
+};
+
+/**
+ * @enum {number}
+ */
+google.ima.ImaSdkSettings.VpaidMode = {
+  DISABLED: 0,
+  ENABLED: 1,
+  INSECURE: 2,
 };
 
 


### PR DESCRIPTION
Sets the type of the google.ima.settings object extern to
`google.ima.ImaSdkSettings` to avoid duplicating the defined methods.
Also adds the setVpaidMode method and VpaidMode enum to the
google.ima.ImaSdkSettings class extern.

Resolves #3134 