### PR TITLE
Support for DASHEventMessageBox Version 1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -64,5 +64,6 @@ Toshihiro Suzuki <t.suzuki326@gmail.com>
 uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
 Vincent Valot <valot.vince@gmail.com>
+Prakash <duggaraju@gmail.com>
 
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -100,3 +100,4 @@ Vignesh Venkatasubramanian <vigneshv@google.com>
 Vincent Valot <valot.vince@gmail.com>
 Yohann Connell <robinconnell@google.com>
 Adrián Gómez Llorente <adgllorente@gmail.com>
+Prakash Duggaraju <duggaraju@gmail.com>

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1567,19 +1567,56 @@ shaka.media.StreamingEngine = class {
    *     scheme_id_uri for which emsg boxes should be parsed.
    * @param {!shaka.extern.ParsedBox} box
    * @private
+   * https://dashif-documents.azurewebsites.net/Events/master/event.html#emsg-format
+   * aligned(8) class DASHEventMessageBox
+   *    extends FullBox(‘emsg’, version, flags = 0){
+   * if (version==0) {
+   *   string scheme_id_uri;
+   *   string value;
+   *   unsigned int(32) timescale;
+   *   unsigned int(32) presentation_time_delta;
+   *   unsigned int(32) event_duration;
+   *   unsigned int(32) id;
+   * } else if (version==1) {
+   *   unsigned int(32) timescale;
+   *   unsigned int(64) presentation_time;
+   *   unsigned int(32) event_duration;
+   *   unsigned int(32) id;
+   *   string scheme_id_uri;
+   *   string value;
+   * }
+   * unsigned int(8) message_data[];
    */
   parseEMSG_(reference, emsgSchemeIdUris, box) {
-    const schemeId = box.reader.readTerminatedString();
-    // Read the rest of the data.
-    const value = box.reader.readTerminatedString();
-    const timescale = box.reader.readUint32();
-    const presentationTimeDelta = box.reader.readUint32();
-    const eventDuration = box.reader.readUint32();
-    const id = box.reader.readUint32();
+    let timescale;
+    let id;
+    let eventDuration;
+    let schemeId;
+    let startTime;
+    let presentationTimeDelta;
+    let value;
+
+    if (box.version === 0) {
+      schemeId = box.reader.readTerminatedString();
+      value = box.reader.readTerminatedString();
+      timescale = box.reader.readUint32();
+      presentationTimeDelta = box.reader.readUint32();
+      eventDuration = box.reader.readUint32();
+      id = box.reader.readUint32();
+      startTime = reference.startTime + (presentationTimeDelta / timescale);
+    } else {
+      timescale = box.reader.readUint32();
+      const pts = box.reader.readUint64();
+      startTime = pts / timescale;
+      presentationTimeDelta = startTime - reference.startTime;
+      eventDuration = box.reader.readUint32();
+      id = box.reader.readUint32();
+      schemeId = box.reader.readTerminatedString();
+      value = box.reader.readTerminatedString();
+    }
     const messageData = box.reader.readBytes(
         box.reader.getLength() - box.reader.getPosition());
 
-    const startTime = reference.startTime + (presentationTimeDelta / timescale);
 
     // See DASH sec. 5.10.3.3.1
     // If a DASH client detects an event message box with a scheme that is not

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -2586,6 +2586,27 @@ describe('StreamingEngine', () => {
       expect(event.detail).toEqual(emsgObj);
     });
 
+    it('raises an event for registered embedded v1 emsg boxes ', async () => {
+      // same event but verison 1.
+      const v1EmsgSegment = Uint8ArrayUtils.fromHex(
+          '0000003f656d7367010000000000000100000000000000080000ffff00000001' +
+          '666f6f3a6261723a637573746f6d64617461736368656d6500310074657374');
+      segmentData[ContentType.VIDEO].segments[0] = v1EmsgSegment;
+      videoStream.emsgSchemeIdUris = [emsgObj.schemeIdUri];
+
+      // Here we go!
+      streamingEngine.switchVariant(variant);
+      streamingEngine.switchTextStream(textStream);
+      await streamingEngine.start();
+      playing = true;
+      await runTest();
+
+      expect(onEvent).toHaveBeenCalledTimes(1);
+
+      const event = onEvent.calls.argsFor(0)[0];
+      expect(event.detail).toEqual(emsgObj);
+    });
+
     it('raises multiple events', async () => {
       const dummyBox =
           shaka.util.Uint8ArrayUtils.fromHex('0000000c6672656501020304');


### PR DESCRIPTION
Adds support to parse version 1 of 'emsg' boxes.
The structure of 'emsg' box is described in the DASH-IF spec at
https://dashif-documents.azurewebsites.net/Events/master/event.html#emsg-format
Added unit test to ensure the box is correctly parsed.