### PR TITLE
(fix) Subtitles are shown stacked

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -166,7 +166,7 @@ shaka.text.UITextDisplayer = class {
     // Return true if the cue should be displayed at the current time point.
     const shouldCueBeDisplayed = (cue) => {
       return this.cues_.includes(cue) && this.isTextVisible_ &&
-             cue.startTime <= currentTime && cue.endTime >= currentTime;
+             cue.startTime <= currentTime && cue.endTime > currentTime;
     };
 
     // For each cue in the current cues map, if the cue's end time has passed,


### PR DESCRIPTION
This PR solves issue #3151.

We've seen some SmartTVs show one subtitle without removing the previous one.

I think this is happening because two different subtitles may meet the condition of "greater or equal than" and "lower or equal than" at the same time. After changing the greater than or equal with a greater than subtitles were fixed.