### PR TITLE
fixes encoding error

### DIFF
--- a/build/generateLocalizations.py
+++ b/build/generateLocalizations.py
@@ -248,7 +248,7 @@ def main(args):
   combined_localizations = {}
   for locale in args.locales:
     path = os.path.join(args.source, locale + '.json')
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf8') as f:
       combined_localizations[locale] = json.load(f)
 
   doc = GenerateLocalizations(combined_localizations, args.class_name)


### PR DESCRIPTION
fixes #3204 

Added `encoding='utf8' to the arguments of open() which no longer shows an error and works fine`