### PR TITLE
fixed error #3208 #3204

### DIFF
--- a/build/generateLocalizations.py
+++ b/build/generateLocalizations.py
@@ -32,7 +32,7 @@ import contextlib
 import json
 import os
 import sys
-
+import io
 import shakaBuildHelpers
 
 
@@ -248,7 +248,7 @@ def main(args):
   combined_localizations = {}
   for locale in args.locales:
     path = os.path.join(args.source, locale + '.json')
-    with open(path, 'r') as f:
+    with io.open(path, 'r' , encoding='utf8') as f:
       combined_localizations[locale] = json.load(f)
 
   doc = GenerateLocalizations(combined_localizations, args.class_name)


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Module named io is imported and io.open() is used instead of open() for fixing encoding error which occurs in python2 .
added encoding type as utf-8 in line 251 for fixing UnicodeDecodeError
Fixes # (issue)
#3208
#3204
## Screenshots (optional)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)


## Checklist:

<!--Please delete options that are not relevant.-->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code



- [ ] New and existing unit tests pass locally with my changes
