### PR TITLE
Allow test Edge Chromium with Karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For details on what's coming next, see our [development roadmap](roadmap.md).
 |Chrome¹    |**Y**     |**Y**    |**Y**    |**Y**    |**Native**|**Y**   | -   |
 |Firefox¹   |**Y**     |**Y**    |**Y**    |untested⁵|**Native**| -      | -   |
 |Edge¹      |**Y**     | -       | -       | -       | -        | -      | -   |
-|Edge Chromium|**Y**     |**Y**    | -       |untested⁵|**Native**| -      | -   |
+|Edge Chromium|**Y**     |**Y**    |**Y**     |untested⁵|**Native**| -      | -   |
 |IE ≤ 10    | N        | -       | -       | -       | -        | -      | -   |
 |IE 11      |**Y** ⁴   | -       | -       | -       | -        | -      | -   |
 |Safari¹    | -        |**Y**    | -       | -       |**iPadOS 13<br>Native**| - | - |

--- a/build/test.py
+++ b/build/test.py
@@ -74,13 +74,13 @@ def _GetDefaultBrowsers():
     # For MP4 support on Linux Firefox, install gstreamer1.0-libav.
     # Opera on Linux only supports MP4 for Ubuntu 15.04+, so it is not in the
     # default list of browsers for Linux at this time.
-    return ['Chrome','Firefox']
+    return ['Chrome','Edge','Firefox']
 
   if shakaBuildHelpers.is_darwin():
-    return ['Chrome','Firefox','Safari']
+    return ['Chrome','Edge','Firefox','Safari']
 
   if shakaBuildHelpers.is_windows() or shakaBuildHelpers.is_cygwin():
-    return ['Chrome','Firefox','IE']
+    return ['Chrome','Edge','Firefox','IE']
 
   raise Error('Unrecognized system: %s' % platform.uname()[0])
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,6 +70,7 @@ module.exports = (config) => {
 
     plugins: [
       'karma-*',  // default plugins
+      '@*/karma-*', // default scoped plugins
 
       // An inline plugin which supplies the webdriver-screenshot middleware.
       {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     }
   ],
   "devDependencies": {
+    "@chiragrupani/karma-chromium-edge-launcher": "^2.1.0",
     "@teppeis/clutz": "^1.0.29-4c95e12.v20190929",
     "awesomplete": "^1.1.4",
     "babel-core": "^6.26.3",
@@ -33,7 +34,7 @@
     "jasmine-ajax": "^4.0.0",
     "jimp": "^0.11.0",
     "jsdoc": "github:joeyparrish/jsdoc#45c271fa",
-    "karma": "^6.1.1",
+    "karma": "^6.2.0",
     "karma-babel-preprocessor": "^7.0.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",


### PR DESCRIPTION
With this change it is possible to run the tests in Edge Chromium by default.

Karma needs to be updated to allow wildcard scoped packages to be used by default, see: https://github.com/karma-runner/karma/pull/3659

Test results on macOS:
```
./build/test.py
[WARNING] Using default browsers: ['Chrome', 'Edge', 'Firefox', 'Safari']
[INFO] Generating Closure dependencies...
[INFO] Compiling the library (ui, release)...
[INFO] Running test (1 / 1, 0 failed so far)...
Chrome 89.0.4389.90 (Mac OS 10.15.7): Executed 2058 of 2096 (skipped 38) SUCCESS (7 mins 14.056 secs / 7 mins 4.732 secs)
Edge 89.0.774.54 (Mac OS 10.15.7): Executed 2011 of 2096 (skipped 85) SUCCESS (7 mins 12.33 secs / 7 mins 4.255 secs)
Firefox 86.0 (Mac OS 10.15): Executed 2011 of 2096 (skipped 85) SUCCESS (7 mins 18.377 secs / 7 mins 9.345 secs)
Safari 14.0.3 (Mac OS 10.15.7): Executed 2011 of 2096 (skipped 85) SUCCESS (7 mins 17.412 secs / 7 mins 6.846 secs)
TOTAL: 8091 SUCCESS
[INFO] Run complete
[INFO] Result (exit code): 0
```