### PR TITLE
fix(ads): height property was not taking effect on client side ads #3284

### DIFF
--- a/ui/less/ad_controls.less
+++ b/ui/less/ad_controls.less
@@ -30,7 +30,7 @@
   }
 }
 
-.shaka-client-side-ad-container {
+.shaka-client-side-ad-container, .shaka-server-side-ad-container {
   .absolute-position();
 
   /* IMA SDK adds their own ad UI into an iframe element.

--- a/ui/less/ad_controls.less
+++ b/ui/less/ad_controls.less
@@ -23,6 +23,7 @@
 
 .shaka-server-side-ad-container {
   .fill-container();
+  .shrinkable();
 
   &:not([ad-active="true"]) {
     pointer-events: none;
@@ -31,9 +32,7 @@
 
 .shaka-client-side-ad-container {
   .absolute-position();
-}
 
-.shaka-controls-container {
   /* IMA SDK adds their own ad UI into an iframe element.
    * Adjust its position to fit in with our UI, when
    * Shaka UI is enabled. */
@@ -41,8 +40,7 @@
     .shaka-video-container[shaka-controls="true"] & {
       /* This moves the iframe up a little bit, so it
        * doesn't operlap with our controls. */
-      height: 92%;
-      z-index: 1;
+      height: 90%;
     }
   }
 }

--- a/ui/less/ad_controls.less
+++ b/ui/less/ad_controls.less
@@ -21,15 +21,6 @@
   }
 }
 
-.shaka-server-side-ad-container {
-  .fill-container();
-  .shrinkable();
-
-  &:not([ad-active="true"]) {
-    pointer-events: none;
-  }
-}
-
 .shaka-client-side-ad-container, .shaka-server-side-ad-container {
   .absolute-position();
 
@@ -42,6 +33,15 @@
        * doesn't operlap with our controls. */
       height: 90%;
     }
+  }
+}
+
+.shaka-server-side-ad-container {
+  .fill-container();
+  .shrinkable();
+
+  &:not([ad-active="true"]) {
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
## Description

controls were covering the SkipAd button.
this commit lifts up the shaka-client-side-ad-container.
also the shaka-server-side-ad-container was overflowing outside shaka-controls-container, now its shrinkable.
<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->

refer to #3284 
<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
