### PR TITLE
Support Frequent Manifest Updates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -67,5 +67,4 @@ uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
 Vincent Valot <valot.vince@gmail.com>
 Prakash <duggaraju@gmail.com>
-
-
+Raymond Cheng <raycheng100@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -103,3 +103,4 @@ Vincent Valot <valot.vince@gmail.com>
 Yohann Connell <robinconnell@google.com>
 Adrián Gómez Llorente <adgllorente@gmail.com>
 Prakash Duggaraju <duggaraju@gmail.com>
+Raymond Cheng <raycheng100@gmail.com>

--- a/lib/media/presentation_timeline.js
+++ b/lib/media/presentation_timeline.js
@@ -23,12 +23,14 @@ shaka.media.PresentationTimeline = class {
    *   seconds.  Only required for live.
    * @param {boolean=} autoCorrectDrift Whether to account for drift when
    *   determining the availability window.
+   * @param {number=} updateIntervalSeconds The interval at which the
+   *   streaming engine should check for manifest updates, in seconds.
    *
    * @see {shaka.extern.Manifest}
    * @see {@tutorial architecture}
    */
   constructor(presentationStartTime, presentationDelay,
-      autoCorrectDrift = true) {
+      autoCorrectDrift = true, updateIntervalSeconds = 1) {
     /** @private {?number} */
     this.presentationStartTime_ = presentationStartTime;
 
@@ -93,6 +95,14 @@ shaka.media.PresentationTimeline = class {
      * @private {number}
      */
     this.availabilityTimeOffset_ = 0;
+
+    /**
+     * The interval at which the streaming engine should check for manifest
+     * updates, in seconds.
+     *
+     * @private {number}
+     */
+    this.updateIntervalSeconds_ = updateIntervalSeconds;
   }
 
 
@@ -105,6 +115,17 @@ shaka.media.PresentationTimeline = class {
     return this.duration_;
   }
 
+  /**
+   * Get the interval at which the streaming engine should check for manifest
+   * updates, in seconds.
+   *
+   * @return {number} The interval at which the streaming engine should check
+   *   for manifest updates, in seconds.
+   * @export
+   */
+  getUpdateIntervalSeconds() {
+    return this.updateIntervalSeconds_;
+  }
 
   /**
    * @return {number} The presentation's max segment duration in seconds.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -991,6 +991,16 @@ shaka.media.StreamingEngine = class {
     }
     mediaState.endOfStream = false;
 
+    const getUpdateIntervalSeconds = () => {
+      if (this.manifest_ &&
+          this.manifest_.presentationTimeline &&
+          this.manifest_.presentationTimeline.getUpdateIntervalSeconds) {
+        return this.manifest_.presentationTimeline.getUpdateIntervalSeconds();
+      } else {
+        return 1;
+      }
+    };
+
     // If we've buffered to the buffering goal then schedule an update.
     if (bufferedAhead >= scaledBufferingGoal) {
       shaka.log.v2(logPrefix, 'buffering goal met');
@@ -998,7 +1008,7 @@ shaka.media.StreamingEngine = class {
       // Do not try to predict the next update.  Just poll twice every second.
       // The playback rate can change at any time, so any prediction we make now
       // could be terribly invalid soon.
-      return 0.5;
+      return getUpdateIntervalSeconds() / 2;
     }
 
     const bufferEnd =
@@ -1010,7 +1020,7 @@ shaka.media.StreamingEngine = class {
       // In any case just try again... if the manifest is incomplete or is not
       // being updated then we'll idle forever; otherwise, we'll end up getting
       // a SegmentReference eventually.
-      return 1;
+      return getUpdateIntervalSeconds();
     }
 
     // Do not let any one stream get far ahead of any other.
@@ -1041,7 +1051,7 @@ shaka.media.StreamingEngine = class {
       // For example, let video buffering catch up to audio buffering before
       // fetching another audio segment.
       shaka.log.v2(logPrefix, 'waiting for other streams to buffer');
-      return 1;
+      return getUpdateIntervalSeconds();
     }
 
     const p = this.fetchAndAppend_(mediaState, presentationTime, reference);

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1762,6 +1762,9 @@ describe('DashParser Manifest', () => {
     const presentationTimeline = manifest.presentationTimeline;
     const presentationDelay = presentationTimeline.getDelay();
     expect(presentationDelay).toBe(1.5*manifest.minBufferTime);
+    const updateIntervalSeconds =
+        presentationTimeline.getUpdateIntervalSeconds();
+    expect(updateIntervalSeconds).toBe(1);
   });
 
   it('Honors the ignoreEmptyAdaptationSet config', async () => {

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -507,6 +507,8 @@ describe('HlsParser live', () => {
               .setResponseValue('test:/main.mp4', segmentData);
           const manifest = await parser.start('test:/master', playerInterface);
           expect(manifest.presentationTimeline.getDelay()).toBe(15);
+          expect(manifest.presentationTimeline.getUpdateIntervalSeconds())
+              .toBe(1);
         });
 
     it('sets presentation delay for low latency mode', async () => {

--- a/test/media/presentation_timeline_unit.js
+++ b/test/media/presentation_timeline_unit.js
@@ -52,9 +52,11 @@ describe('PresentationTimeline', () => {
       maxSegmentDuration,
       clockOffset,
       presentationDelay,
-      autoCorrectDrift = true) {
+      autoCorrectDrift = true,
+      updateIntervalSeconds = undefined) {
     const timeline = new shaka.media.PresentationTimeline(
-        presentationStartTime, presentationDelay, autoCorrectDrift);
+        presentationStartTime, presentationDelay, autoCorrectDrift,
+        updateIntervalSeconds);
     timeline.setStatic(isStatic);
     timeline.setDuration(duration || Infinity);
     timeline.setSegmentAvailabilityDuration(segmentAvailabilityDuration);
@@ -404,6 +406,26 @@ describe('PresentationTimeline', () => {
       setElapsed(37);
       expect(timeline1.getSeekRangeEnd()).toBe(20);
       expect(timeline2.getSeekRangeEnd()).toBe(20);
+    });
+  });
+
+  describe('updateIntervalSeconds', () => {
+    it('defaults to 1', () => {
+      const timeline = makePresentationTimeline(
+          /* static= */ true, /* duration= */ 60, /* start= */ null,
+          /* availability= */ Infinity, /* max= */ 10,
+          /* clock= */ 0, /* presentation= */ 0);
+      expect(timeline.getUpdateIntervalSeconds()).toBe(1);
+    });
+
+    it('can be set lower than 1', () => {
+      const timeline = makePresentationTimeline(
+          /* static= */ true, /* duration= */ 60, /* start= */ null,
+          /* availability= */ Infinity, /* max= */ 10,
+          /* clock= */ 0, /* presentation= */ 0,
+          /* autoCorrectDrift= */ undefined,
+          /* updateIntervalSeconds= */ 0.5);
+      expect(timeline.getUpdateIntervalSeconds()).toBe(0.5);
     });
   });
 });


### PR DESCRIPTION
## Description
Support Frequent Manifest Updates

I am writing a RTSP manifest plugin, where media samples are pushed to
the client. I found that there are hard-coded assumptions that manifests
should not be polled for changes more often than once a second. These
hard-coded assumptions prevent us from achieving the lowest end-to-end
latency when using partial segments.

Changes
1) Added a new parameter to the PresentationTimeline constructor,
updateIntervalSeconds, which is the interval at which the streaming
engine should check the manifest for updates, in seconds. The default
value is 1, which matches existing behavior. Added a function,
getUpdateIntervalSeconds() to retrieve this value. Added unit tests to
verify default value of 1 and the ability to set below 1, and to verify
that the value is 1 for HLS and Dash.
2) Replaced the hard-coded 1-second assumption in the streaming engine
with PresentationTimeline.getUpdateIntervalSeconds().

Testing Procedure
1) Verify that existing manifest plugins are unaffected by this change.

## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [X] I have run `./build/test.py` and all tests pass
