### PR TITLE
Update offline tutorial to use a player config for offline storage

### DIFF
--- a/docs/tutorials/offline.md
+++ b/docs/tutorials/offline.md
@@ -293,8 +293,10 @@ following code:
   // download progress and override the track selection callback.
   window.storage = new shaka.offline.Storage(player);
   window.storage.configure({
-    progressCallback: setDownloadProgress,
-    trackSelectionCallback: selectTracks
+    offline: {
+      progressCallback: setDownloadProgress,
+      trackSelectionCallback: selectTracks
+    }
   });
 ```
 
@@ -507,8 +509,10 @@ function initStorage(player) {
   // download progress and override the track selection callback.
   window.storage = new shaka.offline.Storage(player);
   window.storage.configure({
-    progressCallback: setDownloadProgress,
-    trackSelectionCallback: selectTracks
+    offline: {
+      progressCallback: setDownloadProgress,
+      trackSelectionCallback: selectTracks
+    }
   });
 }
 


### PR DESCRIPTION
When configuring offline storage in initStorage in initialising storage, an OfflineConfig was used instead of a player config, which worked in v2.5 but not in ~v3.5~ v3.0. Because of this when the final code was run the progress bar wouldn't work properly as progressCallback was not set.

## Description

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [ ] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
