### PR TITLE
hover effect on setting icon and some padding

### DIFF
--- a/demo/demo.less
+++ b/demo/demo.less
@@ -33,14 +33,6 @@
   line-height: 36px;
 }
 
-.mdl-button--icon {
-  /* By default, MDL icon buttons may end up vertically off-center.  This aligns
-   * them to the center both vertically and horizontally. */
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 /* This is a less mixin only, rather than a CSS class. MDL has an equivalent
  * class with the same name, which can be used in the application directly. */
 .hidden() {

--- a/demo/demo.less
+++ b/demo/demo.less
@@ -32,6 +32,10 @@
 .mdl-button .material-icons {
   line-height: 36px;
 }
+//icon is not at the center. this fixes it.
+.mdl-button .material-icons-round {
+  padding-top: 3px;
+}
 
 /* This is a less mixin only, rather than a CSS class. MDL has an equivalent
  * class with the same name, which can be used in the application directly. */
@@ -381,6 +385,10 @@ html, body {
 
   /* Match the padding of the buttons next to the logo. */
   padding: 0 16px;
+}
+
+.app-header .mdl-layout__drawer-button .material-icons:hover {
+  transform: rotate(20deg);
 }
 
 footer li {

--- a/demo/demo.less
+++ b/demo/demo.less
@@ -32,9 +32,13 @@
 .mdl-button .material-icons {
   line-height: 36px;
 }
-//icon is not at the center. this fixes it.
-.mdl-button .material-icons-round {
-  padding-top: 3px;
+
+.mdl-button--icon {
+  /* By default, MDL icon buttons may end up vertically off-center.  This aligns
+   * them to the center both vertically and horizontally. */
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* This is a less mixin only, rather than a CSS class. MDL has an equivalent
@@ -95,6 +99,15 @@ html, body {
 .mdl-button--fab {
   filter: drop-shadow(0 2px 5px #333);
   transition: 0.2s ease-in-out;
+}
+
+.mdl-button--fab,
+.mdl-button--icon {
+  /* By default, MDL icon buttons may end up vertically off-center.  This aligns
+   * them to the center both vertically and horizontally. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .mdl-button--fab:hover {
@@ -387,8 +400,14 @@ html, body {
   padding: 0 16px;
 }
 
-.app-header .mdl-layout__drawer-button .material-icons:hover {
-  transform: rotate(20deg);
+.app-header .mdl-layout__drawer-button .material-icons {
+  &:hover {
+    /* Spin the gear icon in the settings menu when hovered. */
+    transform: rotate(90deg);
+  }
+
+  /* Animate the spin. */
+  transition: transform 0.3s ease-in-out;
 }
 
 footer li {


### PR DESCRIPTION
## Description

<!--
  initially X button(drawer-close-button) in the shaka player demo config is not at the center 
and no hover effect on settings icon these changes bring drawer-close button to the center
and gives a simplistic hover effect to setting icon

  If this fixes any issues, include lines like this:
  Fixes #3319
-->


## Screenshots (optional)
![o](https://user-images.githubusercontent.com/58463645/115313294-a0332100-a190-11eb-971b-97cbead6c2d1.PNG)


<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
![n](https://user-images.githubusercontent.com/58463645/115313402-d40e4680-a190-11eb-883f-418c6deaeb93.PNG)

-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue             
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
