### PR TITLE
Set a fixed length of demo assets titles

### DIFF
--- a/demo/demo.less
+++ b/demo/demo.less
@@ -316,13 +316,34 @@ html, body {
 .asset-card .mdl-card__title {
   /* The maximum width of the title should be narrower than the width of the
    * card itself, so that the title doesn't overlap with the store button. */
-  max-width: 260px;
+  max-width: 300px;
+  height: 130px;
   margin: auto;
+}
+
+.mdl-card-wide {
+  /* assignes particular dimensions for the card so
+  that all the card have same alignment. */
+  height: 420px;
+  width: 350px;
+}
+
+.mdl-card__supporting-text {
+  /* hides description of card from home page
+  as i think we should create an icon for that. */
+  display: none;
 }
 
 .asset-card div {
   /* Override the default value of "stretch" for mdl cards. */
   justify-content: center;
+}
+
+.mdl-card-wide picture + div {
+  /* does not matter whether card(.mdl-card-wide).
+  have icons or not it provides place for that. */
+  width: 350px;
+  height: 25px;
 }
 
 .asset-card img {


### PR DESCRIPTION
## Description

<!--
  All the changes done fixes the issue of not similar cards in the UI. A little of less solves it.

initially `mdl-card-wide` has no defined height and width which leads to non similar  cards.
I removed description from the home page in card because it makes a difference in home page and all content page. I think we can create an icon for that.

-->


## Screenshots (optional)
![oooooo](https://user-images.githubusercontent.com/58463645/116308688-72b82a00-a7c5-11eb-8d19-66ff9ee57dce.PNG)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
![nnnnnn](https://user-images.githubusercontent.com/58463645/116308752-81064600-a7c5-11eb-8138-662088007d8e.PNG)

-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
