### PR TITLE
Fix missing error STORAGE_LIMIT_REACHED when the downloadSizeCallback is false

### DIFF
--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -539,6 +539,9 @@ shaka.offline.Storage = class {
             shaka.util.Error.Code.STORAGE_LIMIT_REACHED);
       }
     } catch (e) {
+      if (e instanceof shaka.util.Error) {
+        throw e;
+      }
       shaka.log.warning(
           'downloadSizeCallback has produced an unexpected error', e);
       throw new shaka.util.Error(

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -539,6 +539,7 @@ shaka.offline.Storage = class {
             shaka.util.Error.Code.STORAGE_LIMIT_REACHED);
       }
     } catch (e) {
+      // It is necessary to be able to catch the STORAGE_LIMIT_REACHED error
       if (e instanceof shaka.util.Error) {
         throw e;
       }


### PR DESCRIPTION
There are currently two errors: STORAGE_LIMIT_REACHED and DOWNLOAD_SIZE_CALLBACK_ERROR.

The first error was never thrown because the catch threw the second error. This PR fixes that error.