### PR TITLE
Fix management of dash segment template index references for multiperiod live DASH streams

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -65,6 +65,12 @@ shaka.dash.DashParser = class {
      */
     this.segmentIndexMap_ = {};
 
+    /**
+     * A map of period ids to their durations
+     * @private {!Object.<string, number>}
+     */
+    this.periodDurations_ = {};
+
     /** @private {shaka.util.PeriodCombiner} */
     this.periodCombiner_ = new shaka.util.PeriodCombiner();
 
@@ -570,6 +576,10 @@ shaka.dash.DashParser = class {
       const period = this.parsePeriod_(context, baseUris, info);
       periods.push(period);
 
+      if (context.period.id && periodDuration) {
+        this.periodDurations_[context.period.id] = periodDuration;
+      }
+
       if (periodDuration == null) {
         if (next) {
           // If the duration is still null and we aren't at the end, then we
@@ -1060,7 +1070,7 @@ shaka.dash.DashParser = class {
         const hasManifest = !!this.manifest_;
         streamInfo = shaka.dash.SegmentTemplate.createStreamInfo(
             context, requestInitSegment, this.segmentIndexMap_, hasManifest,
-            this.config_.dash.initialSegmentLimit);
+            this.config_.dash.initialSegmentLimit, this.periodDurations_);
       } else {
         goog.asserts.assert(isText,
             'Must have Segment* with non-text streams.');

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -35,11 +35,12 @@ shaka.dash.SegmentTemplate = class {
    * @param {boolean} isUpdate True if the manifest is being updated.
    * @param {number} segmentLimit The maximum number of segments to generate for
    *   a SegmentTemplate with fixed duration.
+   * @param {!Object.<string, number>} periodDurationMap
    * @return {shaka.dash.DashParser.StreamInfo}
    */
   static createStreamInfo(
       context, requestInitSegment, segmentIndexMap, isUpdate,
-      segmentLimit) {
+      segmentLimit, periodDurationMap) {
     goog.asserts.assert(context.representation.segmentTemplate,
         'Should only be called with SegmentTemplate');
     const SegmentTemplate = shaka.dash.SegmentTemplate;
@@ -77,7 +78,8 @@ shaka.dash.SegmentTemplate = class {
       return {
         generateSegmentIndex: () => {
           return SegmentTemplate.generateSegmentIndexFromDuration_(
-              shallowCopyOfContext, info, segmentLimit, initSegmentReference);
+              shallowCopyOfContext, info, segmentLimit, initSegmentReference,
+              periodDurationMap);
         },
       };
     } else {
@@ -259,11 +261,12 @@ shaka.dash.SegmentTemplate = class {
    * @param {shaka.dash.SegmentTemplate.SegmentTemplateInfo} info
    * @param {number} segmentLimit The maximum number of segments to generate.
    * @param {shaka.media.InitSegmentReference} initSegmentReference
+   * @param {!Object.<string, number>} periodDurationMap
    * @return {!Promise.<shaka.media.SegmentIndex>}
    * @private
    */
   static generateSegmentIndexFromDuration_(
-      context, info, segmentLimit, initSegmentReference) {
+      context, info, segmentLimit, initSegmentReference, periodDurationMap) {
     goog.asserts.assert(info.mediaTemplate,
         'There should be a media template with duration');
 
@@ -275,9 +278,20 @@ shaka.dash.SegmentTemplate = class {
     // Capture values that could change as the parsing context moves on to
     // other parts of the manifest.
     const periodStart = context.periodInfo.start;
-    const periodDuration = context.periodInfo.duration;
-    const periodEnd = periodDuration ?
-        periodStart + periodDuration : Infinity;
+    const periodId = context.period.id;
+    const initialPeriodDuration = context.periodInfo.duration;
+
+    // For multi-period live streams the period duration may not be known until
+    // the following period appears in an updated manifest. periodDurationMap
+    // provides the updated period duration.
+    const getPeriodEnd = () => {
+      const periodDuration =
+        (periodDurationMap && periodId && periodDurationMap[periodId]) ||
+        initialPeriodDuration;
+      const periodEnd = periodDuration ?
+        (periodStart + periodDuration) : Infinity;
+      return periodEnd;
+    };
 
     const segmentDuration = info.segmentDuration;
     goog.asserts.assert(
@@ -304,7 +318,7 @@ shaka.dash.SegmentTemplate = class {
 
         Math.min(
             presentationTimeline.getSegmentAvailabilityEnd(),
-            periodEnd),
+            getPeriodEnd()),
       ];
     };
 
@@ -378,7 +392,8 @@ shaka.dash.SegmentTemplate = class {
       const segmentStart = segmentPeriodTime + periodStart;
       // Cap the segment end at the period end so that references from the
       // next period will fit neatly after it.
-      const segmentEnd = Math.min(segmentStart + segmentDuration, periodEnd);
+      const segmentEnd = Math.min(segmentStart + segmentDuration,
+          getPeriodEnd());
 
       // This condition will be true unless the segmentStart was >= periodEnd.
       // If we've done the position calculations correctly, this won't happen.
@@ -394,7 +409,7 @@ shaka.dash.SegmentTemplate = class {
           initSegmentReference,
           timestampOffset,
           /* appendWindowStart= */ periodStart,
-          /* appendWindowEnd= */ periodEnd);
+          /* appendWindowEnd= */ getPeriodEnd());
     };
 
     for (let position = minPosition; position <= maxPosition; ++position) {
@@ -407,7 +422,17 @@ shaka.dash.SegmentTemplate = class {
 
     // If the availability timeline currently ends before the period, we will
     // need to add references over time.
-    if (presentationTimeline.getSegmentAvailabilityEnd() < periodEnd) {
+    const willNeedToAddReferences =
+        presentationTimeline.getSegmentAvailabilityEnd() < getPeriodEnd();
+
+    // When we start a live stream with a period that ends within the
+    // availability window we will not need to add more references, but we will
+    // need to evict old references.
+    const willNeedToEvictReferences = getPeriodEnd() != Infinity &&
+        (presentationTimeline.getSegmentAvailabilityStart() > periodStart) &&
+        (presentationTimeline.getSegmentAvailabilityEnd() > getPeriodEnd());
+
+    if (willNeedToAddReferences || willNeedToEvictReferences) {
       // The period continues to get longer over time, so check for new
       // references once every |segmentDuration| seconds.
       // We clamp to |minPosition| in case the initial range was reversed and no
@@ -416,7 +441,9 @@ shaka.dash.SegmentTemplate = class {
       let nextPosition = Math.max(minPosition, maxPosition + 1);
       segmentIndex.updateEvery(segmentDuration, () => {
         // Evict any references outside the window.
-        segmentIndex.evict(presentationTimeline.getSegmentAvailabilityStart());
+        const availabilityStartTime =
+          presentationTimeline.getSegmentAvailabilityStart();
+        segmentIndex.evict(availabilityStartTime);
 
         // Compute any new references that need to be added.
         const [_, maxPosition] = computeAvailablePositionRange();
@@ -426,7 +453,7 @@ shaka.dash.SegmentTemplate = class {
           references.push(reference);
           nextPosition++;
         }
-        if (presentationTimeline.getSegmentAvailabilityEnd() >= periodEnd &&
+        if (availabilityStartTime > getPeriodEnd() &&
             !references.length) {
           // Signal stop.
           return null;

--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -286,7 +286,7 @@ shaka.dash.SegmentTemplate = class {
     // provides the updated period duration.
     const getPeriodEnd = () => {
       const periodDuration =
-        (periodDurationMap && periodId && periodDurationMap[periodId]) ||
+        (periodId != null && periodDurationMap[periodId]) ||
         initialPeriodDuration;
       const periodEnd = periodDuration ?
         (periodStart + periodDuration) : Infinity;
@@ -428,9 +428,7 @@ shaka.dash.SegmentTemplate = class {
     // When we start a live stream with a period that ends within the
     // availability window we will not need to add more references, but we will
     // need to evict old references.
-    const willNeedToEvictReferences = getPeriodEnd() != Infinity &&
-        (presentationTimeline.getSegmentAvailabilityStart() > periodStart) &&
-        (presentationTimeline.getSegmentAvailabilityEnd() > getPeriodEnd());
+    const willNeedToEvictReferences = presentationTimeline.isLive();
 
     if (willNeedToAddReferences || willNeedToEvictReferences) {
       // The period continues to get longer over time, so check for new
@@ -453,8 +451,10 @@ shaka.dash.SegmentTemplate = class {
           references.push(reference);
           nextPosition++;
         }
-        if (availabilityStartTime > getPeriodEnd() &&
-            !references.length) {
+
+        // The timer must continue firing until the entire period is
+        // unavailable, so that all references will be evicted.
+        if (availabilityStartTime > getPeriodEnd() && !references.length) {
           // Signal stop.
           return null;
         }

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -369,7 +369,8 @@ shaka.media.SegmentIndex = class {
   /**
    * Returns a new iterator that initially points to the segment that contains
    * the given time.  Like the normal iterator, next() must be called first to
-   * get to the first element.
+   * get to the first element. Returns null if we do not find a segment at the
+   * requested time.
    *
    * @param {number} time
    * @return {?shaka.media.SegmentIterator}

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -361,7 +361,7 @@ shaka.media.SegmentIndex = class {
   }
 
 
-  /** @return {!shaka.media.SegmentIterator} */
+  /** @return {?shaka.media.SegmentIterator} */
   [Symbol.iterator]() {
     return this.getIteratorForTime(0);
   }
@@ -372,13 +372,13 @@ shaka.media.SegmentIndex = class {
    * get to the first element.
    *
    * @param {number} time
-   * @return {!shaka.media.SegmentIterator}
+   * @return {?shaka.media.SegmentIterator}
    * @export
    */
   getIteratorForTime(time) {
     let index = this.find(time);
     if (index == null) {
-      index = -1;
+      return null;
     } else {
       index--;
     }
@@ -497,8 +497,10 @@ shaka.media.SegmentIterator = class {
         'Please use SegmentIndex.getIteratorForTime instead of seek().');
 
     const iter = this.segmentIndex_.getIteratorForTime(time);
-    this.currentPosition_ = iter.currentPosition_;
-    this.currentPartialPosition_ = iter.currentPartialPosition_;
+    if (iter) {
+      this.currentPosition_ = iter.currentPosition_;
+      this.currentPartialPosition_ = iter.currentPartialPosition_;
+    }
     return this.next().value;
   }
 

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -503,6 +503,9 @@ shaka.media.SegmentIterator = class {
     if (iter) {
       this.currentPosition_ = iter.currentPosition_;
       this.currentPartialPosition_ = iter.currentPartialPosition_;
+    } else {
+      this.currentPosition_ = Number.MAX_VALUE;
+      this.currentPartialPosition_ = 0;
     }
     return this.next().value;
   }

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -361,9 +361,11 @@ shaka.media.SegmentIndex = class {
   }
 
 
-  /** @return {?shaka.media.SegmentIterator} */
+  /** @return {!shaka.media.SegmentIterator} */
   [Symbol.iterator]() {
-    return this.getIteratorForTime(0);
+    const iter = this.getIteratorForTime(0);
+    goog.asserts.assert(iter != null, 'Iterator for 0 should never be null!');
+    return iter;
   }
 
   /**

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1113,11 +1113,8 @@ shaka.media.StreamingEngine = class {
 
       mediaState.segmentIterator =
           mediaState.stream.segmentIndex.getIteratorForTime(time);
-      const ref = mediaState.segmentIterator.next().value;
-      if (ref == null) {
-        shaka.log.warning(logPrefix, 'cannot find segment', 'endTime:', time);
-        mediaState.segmentIterator = null;
-      }
+      const ref = mediaState.segmentIterator &&
+          mediaState.segmentIterator.next().value;
       return ref;
     } else {
       // Nothing is buffered.  Start at the playhead time.
@@ -1136,14 +1133,16 @@ shaka.media.StreamingEngine = class {
       if (inaccurateTolerance) {
         mediaState.segmentIterator =
             mediaState.stream.segmentIndex.getIteratorForTime(lookupTime);
-        ref = mediaState.segmentIterator.next().value;
+        ref = mediaState.segmentIterator &&
+            mediaState.segmentIterator.next().value;
       }
-      if (!ref) {
+      if (! ref) {
         // If we can't find a valid segment with the drifted time, look for a
         // segment with the presentation time.
         mediaState.segmentIterator =
             mediaState.stream.segmentIndex.getIteratorForTime(presentationTime);
-        ref = mediaState.segmentIterator.next().value;
+        ref = mediaState.segmentIterator &&
+            mediaState.segmentIterator.next().value;
       }
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment',

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1115,6 +1115,9 @@ shaka.media.StreamingEngine = class {
           mediaState.stream.segmentIndex.getIteratorForTime(time);
       const ref = mediaState.segmentIterator &&
           mediaState.segmentIterator.next().value;
+      if (ref == null) {
+        shaka.log.warning(logPrefix, 'cannot find segment', 'endTime:', time);
+      }
       return ref;
     } else {
       // Nothing is buffered.  Start at the playhead time.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1136,7 +1136,7 @@ shaka.media.StreamingEngine = class {
         ref = mediaState.segmentIterator &&
             mediaState.segmentIterator.next().value;
       }
-      if (! ref) {
+      if (!ref) {
         // If we can't find a valid segment with the drifted time, look for a
         // segment with the presentation time.
         mediaState.segmentIterator =

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1116,6 +1116,7 @@ shaka.media.StreamingEngine = class {
       const ref = mediaState.segmentIterator.next().value;
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment', 'endTime:', time);
+        mediaState.segmentIterator = null;
       }
       return ref;
     } else {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -12,6 +12,7 @@ goog.require('shaka.Deprecate');
 goog.require('shaka.text.Cue');
 goog.require('shaka.text.CueRegion');
 goog.require('shaka.util.Dom');
+goog.require('shaka.util.EventManager');
 goog.require('shaka.util.Timer');
 
 
@@ -74,6 +75,13 @@ shaka.text.UITextDisplayer = class {
 
     /** private {Map.<!shaka.extern.Cue, !HTMLElement>} */
     this.currentCuesMap_ = new Map();
+
+    /** @private {shaka.util.EventManager} */
+    this.eventManager_ = new shaka.util.EventManager();
+
+    this.eventManager_.listen(document, 'fullscreenchange', () => {
+      this.updateCaptions_(/* forceUpdate= */ true);
+    });
   }
 
 
@@ -118,6 +126,12 @@ shaka.text.UITextDisplayer = class {
     }
 
     this.currentCuesMap_.clear();
+
+    // Tear-down the event manager to ensure messages stop moving around.
+    if (this.eventManager_) {
+      this.eventManager_.release();
+      this.eventManager_ = null;
+    }
   }
 
 
@@ -158,9 +172,10 @@ shaka.text.UITextDisplayer = class {
 
   /**
    * Display the current captions.
+   * @param {boolean=} forceUpdate
    * @private
    */
-  updateCaptions_() {
+  updateCaptions_(forceUpdate = true) {
     const currentTime = this.video_.currentTime;
 
     // Return true if the cue should be displayed at the current time point.
@@ -172,7 +187,7 @@ shaka.text.UITextDisplayer = class {
     // For each cue in the current cues map, if the cue's end time has passed,
     // remove the entry from the map, and remove the captions from the page.
     for (const cue of this.currentCuesMap_.keys()) {
-      if (!shouldCueBeDisplayed(cue)) {
+      if (!shouldCueBeDisplayed(cue) || forceUpdate) {
         const captions = this.currentCuesMap_.get(cue);
         this.textContainer_.removeChild(captions);
         this.currentCuesMap_.delete(cue);


### PR DESCRIPTION
## Description

Fixes #3354

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass

Testing on other platforms is in still in progress, but I would like to get some early feedback on the proposed changes.

Could use some guidance on building unit tests for this. I don't currently see any tests the timer based extension and evictions of references for live segment template indexes. 

Note one automated test is failing on Safari, but I don't think it has anything to do with my changes
Safari 14.1 (Mac OS 10.15.7) CastUtils serialize/deserialize TimeRanges deserialize into equivalent objects FAILED
	Error: Timeout - Async function did not complete within 120000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL) in node_modules/jasmine-core/lib/jasmine-core/jasmine.js (line 7525)
	<Jasmine>
	Expected 0 to be greater than 0.
	<Jasmine>
	test/cast/cast_utils_unit.js:257:9 <- test/cast/cast_utils_unit.js:367:48
	<Jasmine>

