### PR TITLE
Improve preferredVideoCodecs & preferredAudioCodecs

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -147,7 +147,7 @@ shaka.util.StreamUtils = class {
     let subset = variants;
     for (const videoCodec of preferredVideoCodecs) {
       const filtered = subset.filter((variant) => {
-        return variant.video && variant.video.codecs == videoCodec;
+        return variant.video && variant.video.codecs.startsWith(videoCodec);
       });
       if (filtered.length) {
         subset = filtered;

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -157,7 +157,7 @@ shaka.util.StreamUtils = class {
 
     for (const audioCodec of preferredAudioCodecs) {
       const filtered = subset.filter((variant) => {
-        return variant.audio && variant.audio.codecs == audioCodec;
+        return variant.audio && variant.audio.codecs.startsWith(audioCodec);
       });
       if (filtered.length) {
         subset = filtered;

--- a/test/util/stream_utils_unit.js
+++ b/test/util/stream_utils_unit.js
@@ -708,7 +708,7 @@ describe('StreamUtils', () => {
       });
       const variants =
           shaka.util.StreamUtils.choosePreferredCodecs(manifest.variants,
-              /* preferredVideoCodecs= */[vp09Codecs],
+              /* preferredVideoCodecs= */['vp09'],
               /* preferredAudioCodecs= */['opus']);
 
       expect(variants.length).toBe(1);
@@ -726,7 +726,7 @@ describe('StreamUtils', () => {
       });
       const variants =
           shaka.util.StreamUtils.choosePreferredCodecs(manifest.variants,
-              /* preferredVideoCodecs= */[vp09Codecs],
+              /* preferredVideoCodecs= */['vp09'],
               /* preferredAudioCodecs= */[]);
 
       expect(variants.length).toBe(2);


### PR DESCRIPTION
Currently a full chain comparison is done, but in video codecs, you may want H.265/VP9 with no profile preference, with this change it is possible to do this.
Examples:
'hvc1' instead of 'hvc1.1.2.L123.80' and 'hvc1.1.2.L153.80'
'vp09' instead of 'vp09.00.40.08.00.02.02.02.00'

Issue: #2179