### PR TITLE
fix: not force update caption by default

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -175,7 +175,7 @@ shaka.text.UITextDisplayer = class {
    * @param {boolean=} forceUpdate
    * @private
    */
-  updateCaptions_(forceUpdate = true) {
+  updateCaptions_(forceUpdate = false) {
     const currentTime = this.video_.currentTime;
 
     // Return true if the cue should be displayed at the current time point.


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Notice when debug non relevent issue.

If we always force update captions, then the logic inside updateCaptions_ does not make sense (as we keep delete/insert cue at lightning speed with every tick update)