### PR TITLE
Force update captions with resizes

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -82,6 +82,15 @@ shaka.text.UITextDisplayer = class {
     this.eventManager_.listen(document, 'fullscreenchange', () => {
       this.updateCaptions_(/* forceUpdate= */ true);
     });
+
+    /** @private {ResizeObserver} */
+    this.resizeObserver_ = null;
+    if ('ResizeObserver' in window) {
+      this.resizeObserver_ = new ResizeObserver(() => {
+        this.updateCaptions_(/* forceUpdate= */ true);
+      });
+      this.resizeObserver_.observe(this.textContainer_);
+    }
   }
 
 
@@ -131,6 +140,11 @@ shaka.text.UITextDisplayer = class {
     if (this.eventManager_) {
       this.eventManager_.release();
       this.eventManager_ = null;
+    }
+
+    if (this.resizeObserver_) {
+      this.resizeObserver_.disconnect();
+      this.resizeObserver_ = null;
     }
   }
 


### PR DESCRIPTION
There are measurements that use absolute values in pixels after a conversion. By making this change we force to update the subtitles that are being shown to have the correct dimensions.

Related to: https://github.com/google/shaka-player/pull/3414