### PR TITLE
docs: how to disable Range header requests at start of HLS playback

### DIFF
--- a/docs/tutorials/faq.md
+++ b/docs/tutorials/faq.md
@@ -43,6 +43,17 @@ headers in the response.  Additionally, with some manifests, we will send a
 This can also happen with mixed-content restrictions.  If the site is using
 `https:`, then your manifest and segments must also.
 
+*Sending `Range` header at the start of HLS playback can be disabled using this config:*
+```
+player.configure({
+    manifest: {
+        hls: {
+            useFullSegmentsForStartTime: true,
+        },
+    },
+})
+```
+
 <hr>
 
 **Q:** I am getting `REQUESTED_KEY_SYSTEM_CONFIG_UNAVAILABLE` or error code


### PR DESCRIPTION
## Description
FAQ docs on how to disable Range header requests at start of HLS playback. Which speeds up start of playback when your server has problems with Range header requests

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [ ] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
