### PR TITLE
fix: user can pick variant track/texttrack from streaming event

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1868,8 +1868,22 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Pick the initial streams to play.
     const initialVariant = this.chooseVariant_();
     goog.asserts.assert(initialVariant, 'Must choose an initial variant!');
-    this.switchVariant_(initialVariant, /* fromAdaptation= */ true,
-        /* clearBuffer= */ false, /* safeMargin= */ 0);
+
+    // However, we would skip switch to initial variant
+    // if user already pick variant track (via selectVariantTrack api)
+    let activeVariantTrack = null;
+
+    for (const variantTrack of this.getVariantTracks()) {
+      if (variantTrack.active) {
+        activeVariantTrack = variantTrack;
+        break;
+      }
+    }
+
+    if (! activeVariantTrack) {
+      this.switchVariant_(initialVariant, /* fromAdaptation= */ true,
+          /* clearBuffer= */ false, /* safeMargin= */ 0);
+    }
 
     // Decide if text should be shown automatically.
     const initialTextStream = this.chooseTextStream_();

--- a/lib/player.js
+++ b/lib/player.js
@@ -1880,7 +1880,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // Decide if text should be shown automatically.
     const initialTextStream = this.chooseTextStream_();
-    if (initialTextStream) {
+
+    // Similar to video/audio track, we would skip switch initial text track
+    // if user already pick text track (via selectTextTrack api)
+    const activeTextTrack = this.getTextTracks().find((t) => t.active);
+
+    if (!activeTextTrack && initialTextStream) {
       this.addTextStreamToSwitchHistory_(
           initialTextStream, /* fromAdaptation= */ true);
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1871,16 +1871,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     // However, we would skip switch to initial variant
     // if user already pick variant track (via selectVariantTrack api)
-    let activeVariantTrack = null;
+    const activeVariantTrack = this.getVariantTracks().find((t) => t.active);
 
-    for (const variantTrack of this.getVariantTracks()) {
-      if (variantTrack.active) {
-        activeVariantTrack = variantTrack;
-        break;
-      }
-    }
-
-    if (! activeVariantTrack) {
+    if (!activeVariantTrack) {
       this.switchVariant_(initialVariant, /* fromAdaptation= */ true,
           /* clearBuffer= */ false, /* safeMargin= */ 0);
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -1866,45 +1866,55 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.dispatchEvent(this.makeEvent_(shaka.Player.EventName.Streaming));
 
     // Pick the initial streams to play.
-    const initialVariant = this.chooseVariant_();
-    goog.asserts.assert(initialVariant, 'Must choose an initial variant!');
-
-    // However, we would skip switch to initial variant
+    // however, we would skip switch to initial variant
     // if user already pick variant track (via selectVariantTrack api)
+    let initialVariant = null;
     const activeVariantTrack = this.getVariantTracks().find((t) => t.active);
 
     if (!activeVariantTrack) {
+      initialVariant = this.chooseVariant_();
+      goog.asserts.assert(initialVariant, 'Must choose an initial variant!');
       this.switchVariant_(initialVariant, /* fromAdaptation= */ true,
           /* clearBuffer= */ false, /* safeMargin= */ 0);
+
+      // Now that we have initial streams, we may adjust the start time to align
+      // to a segment boundary.
+      if (this.config_.streaming.startAtSegmentBoundary) {
+        const startTime = this.playhead_.getTime();
+        const adjustedTime =
+            await this.adjustStartTime_(initialVariant, startTime);
+
+        this.playhead_.setStartTime(adjustedTime);
+      }
+
+      // Since the first streams just became active, send an adaptation event.
+      this.onAdaptation_(null,
+          shaka.util.StreamUtils.variantToTrack(initialVariant));
     }
 
     // Decide if text should be shown automatically.
-    const initialTextStream = this.chooseTextStream_();
-
-    // Similar to video/audio track, we would skip switch initial text track
+    // similar to video/audio track, we would skip switch initial text track
     // if user already pick text track (via selectTextTrack api)
     const activeTextTrack = this.getTextTracks().find((t) => t.active);
 
-    if (!activeTextTrack && initialTextStream) {
-      this.addTextStreamToSwitchHistory_(
-          initialTextStream, /* fromAdaptation= */ true);
+    if (!activeTextTrack) {
+      const initialTextStream = this.chooseTextStream_();
+
+      if (initialTextStream) {
+        this.addTextStreamToSwitchHistory_(
+            initialTextStream, /* fromAdaptation= */ true);
+      }
+
+      if (initialVariant) {
+        this.setInitialTextState_(initialVariant, initialTextStream);
+      }
+
+      // Don't initialize with a text stream unless we should be streaming text.
+      if (initialTextStream && this.shouldStreamText_()) {
+        this.streamingEngine_.switchTextStream(initialTextStream);
+      }
     }
 
-    this.setInitialTextState_(initialVariant, initialTextStream);
-    // Don't initialize with a text stream unless we should be streaming text.
-    if (initialTextStream && this.shouldStreamText_()) {
-      this.streamingEngine_.switchTextStream(initialTextStream);
-    }
-
-    // Now that we have initial streams, we may adjust the start time to align
-    // to a segment boundary.
-    if (this.config_.streaming.startAtSegmentBoundary) {
-      const startTime = this.playhead_.getTime();
-      const adjustedTime =
-          await this.adjustStartTime_(initialVariant, startTime);
-
-      this.playhead_.setStartTime(adjustedTime);
-    }
 
     // Start streaming content. This will start the flow of content down to
     // media source.
@@ -1919,10 +1929,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     this.filterManifestByCurrentVariant_();
     // Dispatch a 'trackschanged' event now that all initial filtering is done.
     this.onTracksChanged_();
-
-    // Since the first streams just became active, send an adaptation event.
-    this.onAdaptation_(null,
-        shaka.util.StreamUtils.variantToTrack(initialVariant));
 
     // Now that we've filtered out variants that aren't compatible with the
     // active one, update abr manager with filtered variants.


### PR DESCRIPTION
## Description
fix https://github.com/google/shaka-player/issues/3448

in 2.5.1, we can pick variant track from manifest alone.

this functionality is broken from v3.

this patch allowed user to pick variant track from streaming event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
