### PR TITLE
Fix audio language switching while using AirPlay

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,7 @@ Rostislav Hejduk <Ross-cz@users.noreply.github.com>
 SameGoal Inc. <*@samegoal.com>
 Sanborn Hilland <sanbornh@rogers.com>
 Sander Saares <sander@saares.eu>
+Swank Motion Pictures Inc. <*@swankmp.com>
 TalkTalk Plc <*@talktalkplc.com>
 Tatsiana Gelahova <tatsiana.gelahova@gmail.com>
 Tomas Tichy <mr.tichyt@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -32,6 +32,7 @@ Ashutosh Kumar Mukhiya <ashukm4@gmail.com>
 Benjamin Wallberg <me@bwallberg.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
 Boris Cupac <borisrt2309@gmail.com>
+Brad Nadler <bnadler@swankmp.com>
 Bryan Huh <bhh1988@gmail.com>
 Chad Assareh <assareh@google.com>
 Chris Fillmore <fillmore.chris@gmail.com>

--- a/lib/player.js
+++ b/lib/player.js
@@ -5002,6 +5002,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // This will reset the "enabled" of other tracks to false.
     track.enabled = true;
 
+    // AirPlay does not reset the "enabled" of other tracks to false, so
+    // it must be changed by hand.
+    if (track.id !== currentTrack.id) {
+      currentTrack.enabled = false;
+    }
+
     const oldTrack =
       shaka.util.StreamUtils.html5AudioTrackToTrack(currentTrack);
     const newTrack =


### PR DESCRIPTION
When sending a video to an AirPlay target, such as an Apple TV or a TV
with AirPlay built in, it can become impossible to change from one
audio language, to a second audio language, then return to the first
audio language.

When enabling a new audio track, it is assumed that
all other tracks will be disabled. However, while sending media to the
AirPlay target, no tracks are automatically disabled. As a result, it
would become impossible to reselect certain audio tracks as the player
would keep playing an enabled track, even if it isn't the most recently
enabled track.

Issue #3125

## Description

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [X] I have run `./build/test.py` and all tests pass
