### PR TITLE
Add support for efficient preprocessing of DASH manifests after parsing into an XMLDocument

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -634,7 +634,8 @@ shaka.extern.DrmConfiguration;
  *   ignoreSuggestedPresentationDelay: boolean,
  *   ignoreEmptyAdaptationSet: boolean,
  *   ignoreMaxSegmentDuration: boolean,
- *   keySystemsByURI: !Object.<string, string>
+ *   keySystemsByURI: !Object.<string, string>,
+ *   manifestPreprocessor: function(!Element)
  * }}
  *
  * @property {string} clockSyncUri
@@ -684,6 +685,10 @@ shaka.extern.DrmConfiguration;
  * @property {Object.<string, string>} keySystemsByURI
  *   A map of scheme URI to key system name. Defaults to default key systems
  *   mapping handled by Shaka.
+ * @property {function(!Element)} manifestPreprocessor
+ *   Called immediately after the DASH manifest has been parsed into an
+ *   XMLDocument. Provides a way for applications to perform efficient
+ *   preprocessing of the manifest.
  * @exportDoc
  */
 shaka.extern.DashManifestConfiguration;

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -289,6 +289,11 @@ shaka.dash.DashParser = class {
     const Functional = shaka.util.Functional;
     const XmlUtils = shaka.util.XmlUtils;
 
+    const manifestPreprocessor = this.config_.dash.manifestPreprocessor;
+    if (manifestPreprocessor) {
+      manifestPreprocessor(mpd);
+    }
+
     // Get any Location elements.  This will update the manifest location and
     // the base URI.
     /** @type {!Array.<string>} */

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -109,6 +109,12 @@ shaka.util.PlayerConfiguration = class {
           'urn:uuid:f239e769-efa3-4850-9c16-a903c6932efb':
             'com.adobe.primetime',
         },
+        // Need some operation in the callback or else closure may remove calls
+        // to the function as it would be a no-op.  The operation can't just be
+        // a log message, because those are stripped in the compiled build.
+        manifestPreprocessor: (element) => {
+          return element;
+        },
       },
       hls: {
         ignoreTextStreamFailures: false,

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -1790,6 +1790,48 @@ describe('DashParser Manifest', () => {
     expect(manifest.presentationTimeline).toBeTruthy();
   });
 
+  it('Invokes manifestPreprocessor in config', async () => {
+    const manifestText = [
+      '<MPD minBufferTime="PT75S">',
+      '  <Period id="1" duration="PT30S">',
+      '    <AdaptationSet id="2" mimeType="video/mp4">',
+      '      <Representation id="video-sd" width="640" height="480">',
+      '        <BaseURL>v-sd.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet id="3" mimeType="audio/mp4">',
+      '      <Representation id="audio-en">',
+      '        <BaseURL>a-en.mp4</BaseURL>',
+      '        <SegmentBase indexRange="100-200" />',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '    <AdaptationSet mimeType="text/vtt" lang="de">',
+      '      <Representation>',
+      '        <BaseURL>http://example.com/de.vtt</BaseURL>',
+      '      </Representation>',
+      '    </AdaptationSet>',
+      '  </Period>',
+      '</MPD>',
+    ].join('\n');
+
+    fakeNetEngine.setResponseText('dummy://foo', manifestText);
+    const config = shaka.util.PlayerConfiguration.createDefault().manifest;
+    config.dash.manifestPreprocessor = (mpd) => {
+      const selector = 'AdaptationSet[mimeType="text/vtt"';
+      const vttElements = mpd.querySelectorAll(selector);
+      for (const element of vttElements) {
+        element.parentNode.removeChild(element);
+      }
+    };
+    parser.configure(config);
+
+    /** @type {shaka.extern.Manifest} */
+    const manifest = await parser.start('dummy://foo', playerInterface);
+    const stream = manifest.textStreams[0];
+    expect(stream).toBeUndefined();
+  });
+
   it('converts Accessibility element to "kind"', async () => {
     const manifestText = [
       '<MPD minBufferTime="PT75S">',


### PR DESCRIPTION

## Description
Implements #3339

Added support for efficient preprocessing of DASH manifest after they have been parsed into an XMLDocument

This is configure with the new manifest.dash.manifestPreprocessor  setting.

This is need to efficiently repair manifests that are not compatible with Shaka player.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

Documentation for DashManifestConfiguration changes

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
