### PR TITLE
Fix: player.getThumbnails incorrectly calculates the Y position

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3422,8 +3422,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const segmentTime = reference.endTime - reference.startTime;
         const thumbnailPosition =
             Math.floor(thumbnailTime * totalImages / segmentTime);
-        positionX = (thumbnailPosition % columns) / columns * fullImageWidth;
-        positionY = (thumbnailPosition % rows) / rows * fullImageHeight;
+        positionX = (thumbnailPosition % columns) * width;
+        positionY = Math.floor(thumbnailPosition / rows) * height;
       }
       return {
         height: height,


### PR DESCRIPTION
Close: https://github.com/google/shaka-player/issues/3511