### PR TITLE
Fix #3524 nested cues timing with infinite range parent

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -111,7 +111,17 @@ shaka.text.UITextDisplayer = class {
       const containsCue = cuesList.some(
           (cueInList) => shaka.text.Cue.equal(cueInList, cue));
       if (!containsCue) {
-        this.cues_.push(cue);
+        // If cues nested inside one that has a infinite time range then
+        // ignore the outer one.
+        if (cue.nestedCues.length &&
+            cue.startTime == 0 &&
+            cue.endTime == Infinity) {
+          for (const nestedCue of cue.nestedCues) {
+            this.cues_.push(nestedCue);
+          }
+        } else {
+          this.cues_.push(cue);
+        }
       }
     }
 

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -169,6 +169,57 @@ describe('UITextDisplayer', () => {
     expect(cssObj).toEqual(jasmine.objectContaining(expectCssObj));
   });
 
+  it('honours nested timing where parent has infinite end', async () => {
+    /** @type {!shaka.text.Cue} */
+    const cue = new shaka.text.Cue(0, Infinity, '');
+    const nestedCue1 = new shaka.text.Cue(0, 100, 'Captain\'s log.');
+    const nestedCue2 = new shaka.text.Cue(3600, 3700, 'Captain\'s dog.');
+
+    nestedCue1.color = 'green';
+    nestedCue1.backgroundColor = 'black';
+    nestedCue1.direction = shaka.text.Cue.direction.HORIZONTAL_LEFT_TO_RIGHT;
+    nestedCue1.fontSize = '10px';
+    nestedCue1.fontWeight = shaka.text.Cue.fontWeight.NORMAL;
+    nestedCue1.fontStyle = 'normal';
+    nestedCue1.lineHeight = '2';
+    nestedCue1.textAlign = 'center';
+    nestedCue1.writingMode = shaka.text.Cue.writingMode.HORIZONTAL_TOP_TO_BOTTOM;
+
+    nestedCue2.color = 'black';
+    nestedCue2.backgroundColor = 'green';
+    nestedCue2.direction = shaka.text.Cue.direction.HORIZONTAL_RIGHT_TO_LEFT;
+    nestedCue2.fontSize = '20px';
+    nestedCue2.fontWeight = shaka.text.Cue.fontWeight.NORMAL;
+    nestedCue2.fontStyle = 'normal';
+    nestedCue2.lineHeight = '1.5';
+    nestedCue2.textAlign = 'right';
+    nestedCue2.writingMode = shaka.text.Cue.writingMode.HORIZONTAL_BOTTOM_TO_TOP;
+
+    cue.nestedCues = [nestedCue1, nestedCue2];
+
+    textDisplayer.setTextVisibility(true);
+    textDisplayer.append([cue]);
+    // Wait until updateCaptions_() gets called.
+    await shaka.test.Util.delay(0.5);
+
+    const textContainer =
+        videoContainer.querySelector('.shaka-text-container');
+    const captions =
+        textContainer.querySelector('span:not(.shaka-text-wrapper)');
+    const cssObj = parseCssText(captions.style.cssText);
+    expect(cssObj).toEqual(
+        jasmine.objectContaining({
+          'color': 'green',
+          'background-color': 'black',
+          'direction': 'ltr',
+          'font-size': '10px',
+          'font-style': 'normal',
+          'font-weight': 400,
+          'line-height': 2,
+          'text-align': 'center',
+        }));
+  });
+
   it('correctly displays styles for cellResolution units', async () => {
     /** @type {!shaka.text.Cue} */
     const cue = new shaka.text.Cue(0, 100, 'Captain\'s log.');

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -183,7 +183,8 @@ describe('UITextDisplayer', () => {
     nestedCue1.fontStyle = 'normal';
     nestedCue1.lineHeight = '2';
     nestedCue1.textAlign = 'center';
-    nestedCue1.writingMode = shaka.text.Cue.writingMode.HORIZONTAL_TOP_TO_BOTTOM;
+    nestedCue1.writingMode =
+      shaka.text.Cue.writingMode.HORIZONTAL_TOP_TO_BOTTOM;
 
     nestedCue2.color = 'black';
     nestedCue2.backgroundColor = 'green';
@@ -193,7 +194,8 @@ describe('UITextDisplayer', () => {
     nestedCue2.fontStyle = 'normal';
     nestedCue2.lineHeight = '1.5';
     nestedCue2.textAlign = 'right';
-    nestedCue2.writingMode = shaka.text.Cue.writingMode.HORIZONTAL_BOTTOM_TO_TOP;
+    nestedCue2.writingMode =
+      shaka.text.Cue.writingMode.HORIZONTAL_BOTTOM_TO_TOP;
 
     cue.nestedCues = [nestedCue1, nestedCue2];
 


### PR DESCRIPTION
## Description
Fixes #3524 by ignorning a parent cue with an infinite time range and just processsing its nested children so their respective time ranges are respected.
<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)
![image](https://user-images.githubusercontent.com/37144605/125613698-1b0a6bb0-0080-42e2-bfd3-71b4c72bbffe.png)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
