### PR TITLE
[fix] polyfill webOS vp09 (#3540)

### DIFF
--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -206,6 +206,12 @@ shaka.polyfill.MediaSource = class {
   static patchVp09_() {
     const originalIsTypeSupported = MediaSource.isTypeSupported;
 
+    if (shaka.util.Platform.isWebOS()) {
+      // Don't do this on LG webOS as otherwise it is unable
+      // to play vp09 at all.
+      return;
+    }
+
     MediaSource.isTypeSupported = (mimeType) => {
       // Split the MIME type into its various parameters.
       const pieces = mimeType.split(/ *; */);


### PR DESCRIPTION
## Description

Avoiding faking `vp09` as `vp9` codec on LG webOS to ensure such streams can still be played.

Fixes #3540
<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)
N/A
<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
