### PR TITLE
Add Support to iOS 12 in MediaCapabilities polyfill

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -59,7 +59,7 @@ shaka.polyfill.MediaCapabilities = class {
     }
 
     if (mediaDecodingConfig.type == 'media-source') {
-      if (!window.MediaSource) {
+      if (!shaka.util.Platform.supportsMediaSource()) {
         return res;
       }
       // Use 'MediaSource.isTypeSupported' to check if the stream is supported.

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -31,11 +31,6 @@ shaka.polyfill.MediaCapabilities = class {
       shaka.log.debug(
           'MediaCapabilities: Native mediaCapabilities support found.');
       return;
-    } else if (!window.MediaSource) {
-      shaka.log.debug(
-          'MediaSource must be available to install mediaCapabilities ',
-          'polyfill.');
-      return;
     }
 
     if (!navigator.mediaCapabilities) {
@@ -64,6 +59,9 @@ shaka.polyfill.MediaCapabilities = class {
     }
 
     if (mediaDecodingConfig.type == 'media-source') {
+      if (!window.MediaSource) {
+        return res;
+      }
       // Use 'MediaSource.isTypeSupported' to check if the stream is supported.
       if (mediaDecodingConfig['video']) {
         const contentType = mediaDecodingConfig['video'].contentType;


### PR DESCRIPTION
Maybe related to: #3530

Note: In iOS, since there is no support for MediaSource, if the type is 'media-source' it always returns false, but if the type is 'file' it is checked whether it is supported or not.

MediaCapabilities support: https://caniuse.com/mdn-api_mediacapabilities