### PR TITLE
Geo failover robustness

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,7 @@ Code It <*@code-it.fr>
 Charter Communications Inc <*@charter.com>
 Damien Deis <developer.deis@gmail.com>
 Dany L'Hébreux <danylhebreux@gmail.com>
+Enson Choy <enson.choy@harmonicinc.com>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 Google Inc. <*@google.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -43,6 +43,7 @@ Damien Deis <developer.deis@gmail.com>
 Dany L'Hébreux <danylhebreux@gmail.com>
 Donato Borrello <donato@jwplayer.com>
 Duc Pham <duc.pham@edgeware.tv>
+Enson Choy <enson.choy@harmonicinc.com>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
 François Beaufort <fbeaufort@google.com>

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -105,7 +105,7 @@ shaka.dash.DashParser = class {
      * Period IDs seen in previous manifest.
      * @private {!Array.<number>}
      */
-    this.seenPeriodIds_ = [];
+    this.lastManifestUpdatePeriodIds_ = [];
 
     /**
      * The minimum of the availabilityTimeOffset values among the adaptation
@@ -603,7 +603,7 @@ shaka.dash.DashParser = class {
       if (this.largestPeriodStartTime_ !== null &&
         periodId !== null && start !== null &&
         start < this.largestPeriodStartTime_ &&
-        !this.seenPeriodIds_.includes(periodId) &&
+        !this.lastManifestUpdatePeriodIds_.includes(periodId) &&
         i + 1 != periodNodes.length) {
         shaka.log.debug(
             `Skipping Period with ID ${periodId} as its start time is smaller` +
@@ -652,7 +652,7 @@ shaka.dash.DashParser = class {
     } // end of period parsing loop
 
     // Replace previous seen periods with the current one.
-    this.seenPeriodIds_ = periods.map((el) => el.id);
+    this.lastManifestUpdatePeriodIds_ = periods.map((el) => el.id);
 
     if (presentationDuration != null) {
       if (prevEnd != presentationDuration) {

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -99,13 +99,13 @@ shaka.dash.DashParser = class {
      * Largest period start time seen.
      * @private {?number}
      */
-    this.largestPeriodId_ = null;
+    this.largestPeriodStartTime_ = null;
 
     /**
-     * Period start times seen in previous manifest.
+     * Period IDs seen in previous manifest.
      * @private {!Array.<number>}
      */
-    this.seenPeriodIds = [];
+    this.seenPeriodIds_ = [];
 
     /**
      * The minimum of the availabilityTimeOffset values among the adaptation
@@ -542,7 +542,6 @@ shaka.dash.DashParser = class {
         mpd, 'mediaPresentationDuration', XmlUtils.parseDuration);
 
     const periods = [];
-    const periodIds = [];
     let prevEnd = 0;
     const periodNodes = XmlUtils.findChildren(mpd, 'Period');
     // This uses a for-loop rather than a for-of loop because this needs to look
@@ -551,7 +550,7 @@ shaka.dash.DashParser = class {
     for (const {i, item: elem, next} of enumerate(periodNodes)) {
       const start = /** @type {number} */ (
         XmlUtils.parseAttr(elem, 'start', XmlUtils.parseDuration, prevEnd));
-      const periodId = Number(elem.id);
+      const periodId = elem.id;
       const givenDuration =
           XmlUtils.parseAttr(elem, 'duration', XmlUtils.parseDuration);
 
@@ -594,32 +593,31 @@ shaka.dash.DashParser = class {
        *
        * Skip periods that match all of the following criteria:
        * - Start time is earlier than latest period start time ever seen
-       * - Start time is never seen in the previous manifest
+       * - Period ID is never seen in the previous manifest
        * - Not the last period in the manifest
        *
        * Periods that meet the aforementioned criteria are considered invalid
        * and should be safe to discard.
        */
-      if (this.largestPeriodId_ !== null && periodId !== null) {
-        if (periodId < this.largestPeriodId_ &&
-          !this.seenPeriodIds.includes(periodId) &&
-          i + 1 != periodNodes.length) {
-          shaka.log.debug(
-              `Skipping Period ${i+1} as its period ID is smaller than ` +
-              'the largest period ID that has been seen, and ID ' +
-              'is unseen before');
-          continue;
-        } else {
-          periodIds.push(periodId);
-        }
+
+      if (this.largestPeriodStartTime_ !== null &&
+        periodId !== null && start !== null &&
+        start < this.largestPeriodStartTime_ &&
+        !this.seenPeriodIds_.includes(periodId) &&
+        i + 1 != periodNodes.length) {
+        shaka.log.debug(
+            `Skipping Period with ID ${periodId} as its start time is smaller` +
+            ' than the largest period start time that has been seen, and ID ' +
+            'is unseen before');
+        continue;
       }
 
 
       // Save maximum period start time if it is the last period
-      if (periodId !== null &&
-          (this.largestPeriodId_ === null ||
-            periodId > this.largestPeriodId_)) {
-        this.largestPeriodId_ = periodId;
+      if (start !== null &&
+        (this.largestPeriodStartTime_ === null ||
+          start > this.largestPeriodStartTime_)) {
+        this.largestPeriodStartTime_ = start;
       }
 
       // Parse child nodes.
@@ -653,8 +651,8 @@ shaka.dash.DashParser = class {
       prevEnd = start + periodDuration;
     } // end of period parsing loop
 
-    // Replace previous seen start time with the current one.
-    this.seenPeriodIds = periodIds;
+    // Replace previous seen periods with the current one.
+    this.seenPeriodIds_ = periods.map((el) => el.id);
 
     if (presentationDuration != null) {
       if (prevEnd != presentationDuration) {

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -99,13 +99,13 @@ shaka.dash.DashParser = class {
      * Largest period start time seen.
      * @private {?number}
      */
-    this.largestPeriodStartTime_ = null;
+    this.largestPeriodId_ = null;
 
     /**
      * Period start times seen in previous manifest.
      * @private {!Array.<number>}
      */
-    this.seenPeriodStartTime_ = [];
+    this.seenPeriodIds = [];
 
     /**
      * The minimum of the availabilityTimeOffset values among the adaptation
@@ -542,7 +542,7 @@ shaka.dash.DashParser = class {
         mpd, 'mediaPresentationDuration', XmlUtils.parseDuration);
 
     const periods = [];
-    const periodStartTime = [];
+    const periodIds = [];
     let prevEnd = 0;
     const periodNodes = XmlUtils.findChildren(mpd, 'Period');
     // This uses a for-loop rather than a for-of loop because this needs to look
@@ -551,6 +551,7 @@ shaka.dash.DashParser = class {
     for (const {i, item: elem, next} of enumerate(periodNodes)) {
       const start = /** @type {number} */ (
         XmlUtils.parseAttr(elem, 'start', XmlUtils.parseDuration, prevEnd));
+      const periodId = Number(elem.id);
       const givenDuration =
           XmlUtils.parseAttr(elem, 'duration', XmlUtils.parseDuration);
 
@@ -585,9 +586,11 @@ shaka.dash.DashParser = class {
       }
 
       /**
-       * This is to improve the robustness of the player
-       * when it received bad content/manifest, while still supporting
-       * modification of previous periods.
+       * This is to improve robustness when the player observes manifest with
+       * past periods that are inconsistent to previous ones.
+       *
+       * This may happen when a CDN or proxy server switches its upstream from
+       * one encoder to another redundant encoder.
        *
        * Skip periods that match all of the following criteria:
        * - Start time is earlier than latest period start time ever seen
@@ -597,26 +600,26 @@ shaka.dash.DashParser = class {
        * Periods that meet the aforementioned criteria are considered invalid
        * and should be safe to discard.
        */
-      if (this.largestPeriodStartTime_ !== null && start !== null) {
-        if (start < this.largestPeriodStartTime_ &&
-          !this.seenPeriodStartTime_.includes(start) &&
+      if (this.largestPeriodId_ !== null && periodId !== null) {
+        if (periodId < this.largestPeriodId_ &&
+          !this.seenPeriodIds.includes(periodId) &&
           i + 1 != periodNodes.length) {
           shaka.log.debug(
-              `Skipping Period ${i+1} as its start time is smaller than ` +
-              'the largest period start time that has been seen, and start ' +
-              'time is unseen before');
+              `Skipping Period ${i+1} as its period ID is smaller than ` +
+              'the largest period ID that has been seen, and ID ' +
+              'is unseen before');
           continue;
         } else {
-          periodStartTime.push(start);
+          periodIds.push(periodId);
         }
       }
 
 
       // Save maximum period start time if it is the last period
-      if (start !== null &&
-          (this.largestPeriodStartTime_ === null ||
-          start > this.largestPeriodStartTime_)) {
-        this.largestPeriodStartTime_ = start;
+      if (periodId !== null &&
+          (this.largestPeriodId_ === null ||
+            periodId > this.largestPeriodId_)) {
+        this.largestPeriodId_ = periodId;
       }
 
       // Parse child nodes.
@@ -651,7 +654,7 @@ shaka.dash.DashParser = class {
     } // end of period parsing loop
 
     // Replace previous seen start time with the current one.
-    this.seenPeriodStartTime_ = periodStartTime;
+    this.seenPeriodIds = periodIds;
 
     if (presentationDuration != null) {
       if (prevEnd != presentationDuration) {

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -102,10 +102,10 @@ shaka.dash.DashParser = class {
     this.largestPeriodStartTime_ = null;
 
     /**
-     * Period IDs that have seen before.
+     * Period start times seen in previous manifest.
      * @private {!Array.<number>}
      */
-    this.seenPeriodIds_ = [];
+    this.seenPeriodStartTime_ = [];
 
     /**
      * The minimum of the availabilityTimeOffset values among the adaptation
@@ -542,6 +542,7 @@ shaka.dash.DashParser = class {
         mpd, 'mediaPresentationDuration', XmlUtils.parseDuration);
 
     const periods = [];
+    const periodStartTime = [];
     let prevEnd = 0;
     const periodNodes = XmlUtils.findChildren(mpd, 'Period');
     // This uses a for-loop rather than a for-of loop because this needs to look
@@ -583,20 +584,33 @@ shaka.dash.DashParser = class {
         periodDuration = givenDuration;
       }
 
-      // Skip all periods with start time < maximum period start time, excepts
-      // the last period in manifest
-      if (this.largestPeriodStartTime_ !== null && start !== null &&
-          start < this.largestPeriodStartTime_ &&
-          !this.seenPeriodIds_.includes(start) &&
+      /**
+       * This is to improve the robustness of the player
+       * when it received bad content/manifest, while still supporting
+       * modification of previous periods.
+       *
+       * Skip periods that match all of the following criteria:
+       * - Start time is earlier than latest period start time ever seen
+       * - Start time is never seen in the previous manifest
+       * - Not the last period in the manifest
+       *
+       * Periods that meet the aforementioned criteria are considered invalid
+       * and should be safe to discard.
+       */
+      if (this.largestPeriodStartTime_ !== null && start !== null) {
+        if (start < this.largestPeriodStartTime_ &&
+          !this.seenPeriodStartTime_.includes(start) &&
           i + 1 != periodNodes.length) {
-        shaka.log.debug(
-            `Skipping Period ${i+1} as its start time is smaller than ` +
-            'the largest period start time that has been seen, and start ' +
-            'time is unseen before');
-        continue;
-      } else if (!this.seenPeriodIds_.includes(start)) {
-        this.seenPeriodIds_.push(start);
+          shaka.log.debug(
+              `Skipping Period ${i+1} as its start time is smaller than ` +
+              'the largest period start time that has been seen, and start ' +
+              'time is unseen before');
+          continue;
+        } else {
+          periodStartTime.push(start);
+        }
       }
+
 
       // Save maximum period start time if it is the last period
       if (start !== null &&
@@ -635,6 +649,9 @@ shaka.dash.DashParser = class {
 
       prevEnd = start + periodDuration;
     } // end of period parsing loop
+
+    // Replace previous seen start time with the current one.
+    this.seenPeriodStartTime_ = periodStartTime;
 
     if (presentationDuration != null) {
       if (prevEnd != presentationDuration) {

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -96,6 +96,12 @@ shaka.dash.DashParser = class {
     this.operationManager_ = new shaka.util.OperationManager();
 
     /**
+     * Largest period start time seen.
+     * @private {?number}
+     */
+    this.largestPeriodStartTime_ = null;
+
+    /**
      * The minimum of the availabilityTimeOffset values among the adaptation
      * sets.
      * @private {number}
@@ -569,6 +575,24 @@ shaka.dash.DashParser = class {
       // aren't gaps between Periods.
       if (periodDuration == null) {
         periodDuration = givenDuration;
+      }
+
+      // Skip all periods with start time < maximum period start time, excepts
+      // the last period in manifest
+      if (this.largestPeriodStartTime_ !== null && start !== null &&
+          start < this.largestPeriodStartTime_ &&
+          i + 1 != periodNodes.length) {
+        shaka.log.debug(
+            'Skipping Period', i + 1, ' as its start time is smaller than ' +
+            'the largest period start time that has been seen.');
+        continue;
+      }
+
+      // Save maximum period start time if it is the last period
+      if (start !== null &&
+          (this.largestPeriodStartTime_ === null ||
+          start > this.largestPeriodStartTime_)) {
+        this.largestPeriodStartTime_ = start;
       }
 
       // Parse child nodes.

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -102,6 +102,12 @@ shaka.dash.DashParser = class {
     this.largestPeriodStartTime_ = null;
 
     /**
+     * Period IDs that have seen before.
+     * @private {!Array.<number>}
+     */
+    this.seenPeriodIds_ = [];
+
+    /**
      * The minimum of the availabilityTimeOffset values among the adaptation
      * sets.
      * @private {number}
@@ -581,11 +587,15 @@ shaka.dash.DashParser = class {
       // the last period in manifest
       if (this.largestPeriodStartTime_ !== null && start !== null &&
           start < this.largestPeriodStartTime_ &&
+          !this.seenPeriodIds_.includes(start) &&
           i + 1 != periodNodes.length) {
         shaka.log.debug(
-            'Skipping Period', i + 1, ' as its start time is smaller than ' +
-            'the largest period start time that has been seen.');
+            `Skipping Period ${i+1} as its start time is smaller than ` +
+            'the largest period start time that has been seen, and start ' +
+            'time is unseen before');
         continue;
+      } else if (!this.seenPeriodIds_.includes(start)) {
+        this.seenPeriodIds_.push(start);
       }
 
       // Save maximum period start time if it is the last period

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2155,7 +2155,7 @@ describe('DashParser Manifest', () => {
      * @param {!Array.<number>} periods Start time of multiple periods
      * @return {string}
      */
-  function buildManifestWithPeriodId(periods) {
+  function buildManifestWithPeriodStartTime(periods) {
     const mpdTemplate = [
       `<MPD type="dynamic"`,
       'availabilityStartTime="1970-01-01T00:00:00Z"',
@@ -2179,6 +2179,8 @@ describe('DashParser Manifest', () => {
     };
     const periodXmls = periods.map((period, i) => {
       const duration = i+1 === periods.length ? 10 : periods[i+1] - period;
+      // Period start time as ID here. If we use index then there will be
+      // periods with same period ID and different start time which are invalid.
       return periodTemplate(period, period, duration);
     });
     return sprintf(mpdTemplate, {
@@ -2195,9 +2197,9 @@ describe('DashParser Manifest', () => {
 
   it('skip periods that are earlier than max period start time', async () => {
     const sources = [
-      buildManifestWithPeriodId([5, 15]),
-      buildManifestWithPeriodId([6, 15]), // simulate out-of-sync of -1s
-      buildManifestWithPeriodId([4, 15]), // simulate out-of-sync of +1s
+      buildManifestWithPeriodStartTime([5, 15]),
+      buildManifestWithPeriodStartTime([6, 15]), // simulate out-of-sync of +1s
+      buildManifestWithPeriodStartTime([4, 15]), // simulate out-of-sync of -1s
     ];
     const segments = [];
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2198,7 +2198,8 @@ describe('DashParser Manifest', () => {
   it('skip periods that are earlier than max period start time', async () => {
     const sources = [
       buildManifestWithPeriodStartTime([5, 15]),
-      buildManifestWithPeriodStartTime([4, 15]), // simulate out-of-sync of -1s
+      buildManifestWithPeriodStartTime([6, 15]), // simulate out-of-sync of -1s
+      buildManifestWithPeriodStartTime([4, 15]), // simulate out-of-sync of +1s
     ];
     const segments = [];
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2251,9 +2251,11 @@ describe('DashParser Manifest', () => {
     }
 
     // Expect identical segments
-    expect(segments[0][0].startTime).toBe(5);
-    expect(segments[1][0].startTime).toBe(5);
     expect(segments[0].length).toBe(2);
     expect(segments[1].length).toBe(2);
+    expect(segments[0][0].startTime).toBe(5);
+    expect(segments[1][0].startTime).toBe(5);
+    expect(segments[0][1].startTime).toBe(15);
+    expect(segments[1][1].startTime).toBe(15);
   });
 });

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2151,44 +2151,6 @@ describe('DashParser Manifest', () => {
     }
   });
 
-  it('parses ServiceConfiguration', async () => {
-    const manifestText = [
-      `<MPD type="dynamic"`,
-      '     availabilityStartTime="1970-01-01T00:00:00Z"',
-      '     timeShiftBufferDepth="PT60S"',
-      '     maxSegmentDuration="PT5S"',
-      '     suggestedPresentationDelay="PT0S">',
-      '  <ServiceDescription>',
-      '    <Scope schemeIdUri="1" value="scope1" />',
-      '    <Latency target="5000" max="7000" min="4000" />',
-      '    <PlaybackRate max="1.1" min="0.9" />',
-      '  </ServiceDescription>',
-      '  <Period id="1" duration="PT30S">',
-      '    <AdaptationSet id="2" mimeType="video/mp4">',
-      '      <SegmentTemplate media="$Number$.mp4" duration="1" />',
-      '      <Representation id="3" width="640" height="480">',
-      '        <BaseURL>http://example.com/p1/</BaseURL>',
-      '      </Representation>',
-      '    </AdaptationSet>',
-      '  </Period>',
-      '</MPD>',
-    ].join('\n');
-
-    fakeNetEngine.setResponseText('dummy://foo', manifestText);
-
-    await parser.start('dummy://foo', playerInterface);
-
-    const serviceDescription = parser.getServiceDescription();
-    expect(serviceDescription).toBeDefined();
-    expect(serviceDescription.scope.schemeIdUri).toBe('1');
-    expect(serviceDescription.scope.value).toBe('scope1');
-    expect(serviceDescription.latency.target).toBe(5000);
-    expect(serviceDescription.latency.max).toBe(7000);
-    expect(serviceDescription.latency.min).toBe(4000);
-    expect(serviceDescription.playbackRate.max).toBe(1.1);
-    expect(serviceDescription.playbackRate.min).toBe(0.9);
-  });
-
   /**
      * @param {!Array.<number>} periods Start time of multiple periods
      * @return {string}
@@ -2242,11 +2204,13 @@ describe('DashParser Manifest', () => {
 
     for (const source of sources) {
       fakeNetEngine.setResponseText('dummy://foo', source);
+      /** @type {shaka.extern.Manifest} */
       // eslint-disable-next-line no-await-in-loop
       const manifest = await parser.start('dummy://foo', playerInterface);
       const video = manifest.variants[0].video;
       // eslint-disable-next-line no-await-in-loop
       await video.createSegmentIndex();
+      goog.asserts.assert(video.segmentIndex, 'Null segmentIndex!');
       segments.push(Array.from(video.segmentIndex));
     }
 

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -2155,7 +2155,7 @@ describe('DashParser Manifest', () => {
      * @param {!Array.<number>} periods Start time of multiple periods
      * @return {string}
      */
-  function buildManifestWithPeriodStartTime(periods) {
+  function buildManifestWithPeriodId(periods) {
     const mpdTemplate = [
       `<MPD type="dynamic"`,
       'availabilityStartTime="1970-01-01T00:00:00Z"',
@@ -2179,7 +2179,7 @@ describe('DashParser Manifest', () => {
     };
     const periodXmls = periods.map((period, i) => {
       const duration = i+1 === periods.length ? 10 : periods[i+1] - period;
-      return periodTemplate(i+1, period, duration);
+      return periodTemplate(period, period, duration);
     });
     return sprintf(mpdTemplate, {
       periods: periodXmls.join('\n'),
@@ -2193,13 +2193,11 @@ describe('DashParser Manifest', () => {
   // redundant servers. The period start time might become out of sync
   // during the switch-over/recovery.
 
-  // Solution: Ignore old DASH periods that are older than the latest one.
-
   it('skip periods that are earlier than max period start time', async () => {
     const sources = [
-      buildManifestWithPeriodStartTime([5, 15]),
-      buildManifestWithPeriodStartTime([6, 15]), // simulate out-of-sync of -1s
-      buildManifestWithPeriodStartTime([4, 15]), // simulate out-of-sync of +1s
+      buildManifestWithPeriodId([5, 15]),
+      buildManifestWithPeriodId([6, 15]), // simulate out-of-sync of -1s
+      buildManifestWithPeriodId([4, 15]), // simulate out-of-sync of +1s
     ];
     const segments = [];
 


### PR DESCRIPTION
## Description

This is for fixing a case in geo-redundant streams failover:

1. ShakaPlayer identifies DASH period based on period id
1. Period ids generated by two synchronized packager could be inconsistent temporarily in some negative scenarios
1. After the scenario the packagers resync at the live edge, but the inconsistency is preserved in the manifest for the length of the DVR window
1. When ShakaPlayer receives a new mpd with inconsistent period ids (i.e. jumping between mpds from two packagers), it might result in
    - Wrong presentation time
    - Wrong buffer ahead estimation
    - Old segment references added into segment index
1. Consequently, playback gets stalled and requires end-user to refresh the player (i.e. VPF)


## Screenshots (optional)

N/A


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
