### PR TITLE
Always polyfill MediaCapabilities for Apple browsers

### DIFF
--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -27,7 +27,12 @@ shaka.polyfill.MediaCapabilities = class {
     // Since MediaCapabilities is not fully supported on Chromecast yet, we
     // should always install polyfill for Chromecast.
     // TODO: re-evaluate MediaCapabilities in the future versions of Chromecast.
-    if (!shaka.util.Platform.isChromecast() && navigator.mediaCapabilities) {
+    // Since MediaCapabilities is not fully supported on Apple browsers yet, we
+    // should always install polyfill for Apple browsers.
+    // TODO: re-evaluate MediaCapabilities in the future versions of Apple Browsers.
+    if (!shaka.util.Platform.isChromecast() &&
+      !shaka.util.Platform.isApple() &&
+      navigator.mediaCapabilities) {
       shaka.log.debug(
           'MediaCapabilities: Native mediaCapabilities support found.');
       return;

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -27,8 +27,9 @@ shaka.polyfill.MediaCapabilities = class {
     // Since MediaCapabilities is not fully supported on Chromecast yet, we
     // should always install polyfill for Chromecast.
     // TODO: re-evaluate MediaCapabilities in the future versions of Chromecast.
-    // Since MediaCapabilities is not fully supported on Apple browsers yet, we
+    // Since MediaCapabilities implementation is buggy in Apple browsers, we
     // should always install polyfill for Apple browsers.
+    // See: https://github.com/google/shaka-player/issues/3530
     // TODO: re-evaluate MediaCapabilities in the future versions of Apple
     // Browsers.
     if (!shaka.util.Platform.isChromecast() &&

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -29,7 +29,8 @@ shaka.polyfill.MediaCapabilities = class {
     // TODO: re-evaluate MediaCapabilities in the future versions of Chromecast.
     // Since MediaCapabilities is not fully supported on Apple browsers yet, we
     // should always install polyfill for Apple browsers.
-    // TODO: re-evaluate MediaCapabilities in the future versions of Apple Browsers.
+    // TODO: re-evaluate MediaCapabilities in the future versions of Apple
+    // Browsers.
     if (!shaka.util.Platform.isChromecast() &&
       !shaka.util.Platform.isApple() &&
       navigator.mediaCapabilities) {


### PR DESCRIPTION
Related to: #3530

Errors found in Apple browsers about MediaCapabilities 
- HLS is not supported using file type.
- TS is not supporting using media-source type.