### PR TITLE
feat(text-displayer): expose api force (re)render captions

### DIFF
--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -504,6 +504,11 @@ shaka.extern.TextDisplayer = class {
    * @exportDoc
    */
   setTextVisibility(on) {}
+
+  /**
+   * Force (re)render captions
+   */
+  updateCaptions() {}
 };
 
 

--- a/lib/text/simple_text_displayer.js
+++ b/lib/text/simple_text_displayer.js
@@ -234,6 +234,13 @@ shaka.text.SimpleTextDisplayer = class {
   }
 
   /**
+   * @override
+   * @export
+   */
+  updateCaptions() {
+  }
+
+  /**
    * @param {!shaka.extern.Cue} shakaCue
    * @return {TextTrackCue}
    * @private

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -185,6 +185,14 @@ shaka.text.UITextDisplayer = class {
   }
 
   /**
+   * @override
+   * @export
+   */
+  updateCaptions() {
+    this.updateCaptions_(/* forceUpdate= */ true);
+  }
+
+  /**
    * Display the current captions.
    * @param {boolean=} forceUpdate
    * @private

--- a/test/test/util/fake_text_displayer.js
+++ b/test/test/util/fake_text_displayer.js
@@ -31,6 +31,8 @@ shaka.test.FakeTextDisplayer = class {
         jasmine.createSpy('setTextVisibility').and.callFake((on) => {
           isVisible = on;
         });
+    /** @type {!jasmine.Spy} */
+    this.updateCaptionsSpy = jasmine.createSpy('updateCaptions');
   }
 
   /** @override */
@@ -61,5 +63,11 @@ shaka.test.FakeTextDisplayer = class {
   setTextVisibility(on) {
     const func = shaka.test.Util.spyFunc(this.setTextVisibilitySpy);
     return func(on);
+  }
+
+  /** @override */
+  updateCaptions() {
+    const func = shaka.test.Util.spyFunc(this.updateCaptionsSpy);
+    return func();
   }
 };


### PR DESCRIPTION
## Description
Currently, we do not have an external way to tell shaka-player (re)render text on player.

Even for internal, I've write a module that need to interact with text-displayer engine, but https://github.com/google/shaka-player/blob/master/lib/text/ui_text_displayer.js#L192
is not an exposed api (when I try calling from different module - it said property not defined).

Hence this proposition.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
