### PR TITLE
fix(typo): misspelling default

### DIFF
--- a/build/misspellings.txt
+++ b/build/misspellings.txt
@@ -34,4 +34,5 @@
     r'(?i)@returns': '@return',
     r'(?i)varint': 'variant',
     r'(?i)asynchronus': 'asynchronous',
+    r'(?i)deafult': 'default',
 }

--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -122,7 +122,7 @@ shaka.text.VttTextParser = class {
   }
 
   /**
-   * Add deafult color
+   * Add default color
    *
    * @param {!Map.<string, shaka.text.Cue>} styles
    * @private


### PR DESCRIPTION
## Description
Typo: misspelling 'default'

- [x] I have signed the Google CLA <https://cla.developers.google.com>