### PR TITLE
test: Validate custom license server option in test.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Jesper Haug Karsrud <jesper.karsrud@gmail.com>
 Johan Sundström <oyasumi@gmail.com>
 Jonas Birmé <jonas.birme@eyevinn.se>
 Jozef Chúťka <jozefchutka@gmail.com>
+Jun Hong Chong <chongjunhong@gmail.com>
 JW Player <*@jwplayer.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matthias Van Parijs <matvp91@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -62,6 +62,7 @@ John Bowers <john.bowers@verizondigitalmedia.com>
 Jonas Birmé <jonas.birme@eyevinn.se>
 Jono Ward <jonoward@gmail.com>
 Jozef Chúťka <jozefchutka@gmail.com>
+Jun Hong Chong <chongjunhong@gmail.com>
 Leandro Ribeiro Moreira <leandro.ribeiro.moreira@gmail.com>
 Lucas Gabriel Sánchez <unkiwii@gmail.com>
 Matias Russitto <russitto@gmail.com>

--- a/build/test.py
+++ b/build/test.py
@@ -59,6 +59,34 @@ class _HandleKeyValuePairs(argparse.Action):
     merged[key] = value
     setattr(namespace, self.dest, merged)
 
+class _KeyValidatorType():
+  '''Type to validate the key for a key-value pair against a given string.
+
+     When you forget to provide a correct key for a key-value pair argument,
+     it reminds you by throwing an error before executing any tests.
+  '''
+
+  def __init__(self, expected_key = None):
+    if expected_key is None:
+      raise ValueError('Please provide a key to the _KeyValidatorType constructor')
+
+    self._expected_key = expected_key
+
+  def __call__(self, argument):
+    if not isinstance(argument, str):
+      raise argparse.ArgumentTypeError('Expecting a string but received %s' % argument)
+    
+    key = argument.split('=')[0]
+
+    if key == self._expected_key:
+      return argument
+    else:
+      raise argparse.ArgumentTypeError(
+        'Received %s but expecting %s' % (key, self._expected_key)
+      ) 
+
+
+
 
 def _IntGreaterThanZero(x):
   i = int(x)
@@ -239,7 +267,7 @@ class Launcher:
         help='Configure license servers for the custom asset playback test. '
              'May be specified multiple times to configure multiple key '
              'systems.',
-        type=str,
+        type=_KeyValidatorType('KEY_SYSTEM_ID'),
         metavar='KEY_SYSTEM_ID=LICENSE_SERVER_URI',
         action=_HandleKeyValuePairs)
     running_commands.add_argument(

--- a/build/test.py
+++ b/build/test.py
@@ -59,34 +59,21 @@ class _HandleKeyValuePairs(argparse.Action):
     merged[key] = value
     setattr(namespace, self.dest, merged)
 
-class _KeyValidatorType():
-  '''Type to validate the key for a key-value pair against a given string.
+def _KeyValueValidator(argument):
+    '''To validate the option has a key value pair format.
 
-     When you forget to provide a correct key for a key-value pair argument,
-     it reminds you by throwing an error before executing any tests.
-  '''
+      When you forget to provide the option in key=value format,
+      it reminds you by throwing an error before executing any tests.
+    '''
 
-  def __init__(self, expected_key = None):
-    if expected_key is None:
-      raise ValueError('Please provide a key to the _KeyValidatorType constructor')
+    keyValuePair = [str for str in argument.split('=') if str != ''];
 
-    self._expected_key = expected_key
-
-  def __call__(self, argument):
-    if not isinstance(argument, str):
-      raise argparse.ArgumentTypeError('Expecting a string but received %s' % argument)
-    
-    key = argument.split('=')[0]
-
-    if key == self._expected_key:
+    if len(keyValuePair) == 2:
       return argument
     else:
       raise argparse.ArgumentTypeError(
-        'Received %s but expecting %s' % (key, self._expected_key)
+        'Received %s but expecting format of key=value' % argument
       ) 
-
-
-
 
 def _IntGreaterThanZero(x):
   i = int(x)
@@ -267,7 +254,7 @@ class Launcher:
         help='Configure license servers for the custom asset playback test. '
              'May be specified multiple times to configure multiple key '
              'systems.',
-        type=_KeyValidatorType('KEY_SYSTEM_ID'),
+        type=_KeyValueValidator,
         metavar='KEY_SYSTEM_ID=LICENSE_SERVER_URI',
         action=_HandleKeyValuePairs)
     running_commands.add_argument(


### PR DESCRIPTION
## Description

Fixes #3079

When running custom asset tests with the custom license server parameter, it is easy to make mistakes on the argument value. The `--test-custom-license-server` option expects the user to pass in a key-value pair of `KEYSYSTEM_ID=LICENSE_SERVER_URL`. This change checks if the provided value has `KEYSYSTEM_ID` as its key through a custom argparse type.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
