### PR TITLE
Fix: Issues related to CC & MP4 H.264

### DIFF
--- a/lib/cea/sei_processor.js
+++ b/lib/cea/sei_processor.js
@@ -17,7 +17,13 @@ shaka.cea.SeiProcessor = class {
    * @return {!Iterable.<!Uint8Array>}
    */
   * process(naluData) {
-    const emuCount = this.removeEmu_(naluData);
+    // FIXME: Removing EPB here will make Chromium VDA crash
+    // VDA will complain about non-conformant stream
+    // Cleanup the code after deciding whether the player or the decoder
+    // do the wiping
+
+    // const emuCount = this.removeEmu_(naluData);
+    const emuCount = 0;
 
     // The following is an implementation of section 7.3.2.3.1
     // in Rec. ITU-T H.264 (06/2019), the H.264 spec.
@@ -54,24 +60,24 @@ shaka.cea.SeiProcessor = class {
    * @return {number} The number of removed emulation prevention bytes.
    * @private
    */
-  removeEmu_(naluData) {
-    let zeroCount = 0;
-    let src = 0;
-    let dst = 0;
-    while (src < naluData.length) {
-      if (zeroCount == 2 && naluData[src] == 0x03) {
-        zeroCount = 0;
-      } else {
-        if (naluData[src] == 0x00) {
-          zeroCount++;
-        } else {
-          zeroCount = 0;
-        }
-        naluData[dst] = naluData[src];
-        dst++;
-      }
-      src++;
-    }
-    return (src - dst);
-  }
+  // removeEmu_(naluData) {
+  //   let zeroCount = 0;
+  //   let src = 0;
+  //   let dst = 0;
+  //   while (src < naluData.length) {
+  //     if (zeroCount == 2 && naluData[src] == 0x03) {
+  //       zeroCount = 0;
+  //     } else {
+  //       if (naluData[src] == 0x00) {
+  //         zeroCount++;
+  //       } else {
+  //         zeroCount = 0;
+  //       }
+  //       naluData[dst] = naluData[src];
+  //       dst++;
+  //     }
+  //     src++;
+  //   }
+  //   return (src - dst);
+  // }
 };

--- a/lib/cea/sei_processor.js
+++ b/lib/cea/sei_processor.js
@@ -17,7 +17,7 @@ shaka.cea.SeiProcessor = class {
    * @return {!Iterable.<!Uint8Array>}
    */
   * process(naluData) {
-    const naluClone = this.removeEmu_(naluData);
+    const naluClone = this.removeEmu(naluData);
 
     // The following is an implementation of section 7.3.2.3.1
     // in Rec. ITU-T H.264 (06/2019), the H.264 spec.
@@ -56,9 +56,8 @@ shaka.cea.SeiProcessor = class {
    *
    * @param {!Uint8Array} naluData NALU from which EMUs should be removed.
    * @return {!Uint8Array} The number of removed emulation prevention bytes.
-   * @private
    */
-  removeEmu_(naluData) {
+  removeEmu(naluData) {
     let naluClone = naluData;
     let zeroCount = 0;
     let src = 0;

--- a/lib/cea/sei_processor.js
+++ b/lib/cea/sei_processor.js
@@ -55,7 +55,7 @@ shaka.cea.SeiProcessor = class {
    * about conformance. Recreating a new array solves it.
    *
    * @param {!Uint8Array} naluData NALU from which EMUs should be removed.
-   * @return {!Uint8Array} The number of removed emulation prevention bytes.
+   * @return {!Uint8Array} The NALU with the emulation prevention byte removed.
    */
   removeEmu(naluData) {
     let naluClone = naluData;
@@ -63,6 +63,7 @@ shaka.cea.SeiProcessor = class {
     let src = 0;
     while (src < naluClone.length) {
       if (zeroCount == 2 && naluClone[src] == 0x03) {
+        // 0x00, 0x00, 0x03 pattern detected
         zeroCount = 0;
 
         // Splice the array and recreate a new one, instead of shifting bytes

--- a/lib/cea/sei_processor.js
+++ b/lib/cea/sei_processor.js
@@ -17,37 +17,31 @@ shaka.cea.SeiProcessor = class {
    * @return {!Iterable.<!Uint8Array>}
    */
   * process(naluData) {
-    // FIXME: Removing EPB here will make Chromium VDA crash
-    // VDA will complain about non-conformant stream
-    // Cleanup the code after deciding whether the player or the decoder
-    // do the wiping
-
-    // const emuCount = this.removeEmu_(naluData);
-    const emuCount = 0;
+    const naluClone = this.removeEmu_(naluData);
 
     // The following is an implementation of section 7.3.2.3.1
     // in Rec. ITU-T H.264 (06/2019), the H.264 spec.
     let offset = 0;
 
-    while (offset + emuCount < naluData.length) {
+    while (offset < naluClone.length) {
       let payloadType = 0; // SEI payload type as defined by H.264 spec
-      while (naluData[offset] == 0xFF) {
+      while (naluClone[offset] == 0xFF) {
         payloadType += 255;
         offset++;
       }
-      payloadType += naluData[offset++];
+      payloadType += naluClone[offset++];
 
       let payloadSize = 0; // SEI payload size as defined by H.264 spec
-      while (naluData[offset] == 0xFF) {
+      while (naluClone[offset] == 0xFF) {
         payloadSize += 255;
         offset++;
       }
-      payloadSize += naluData[offset++];
+      payloadSize += naluClone[offset++];
 
       // Payload type 4 is user_data_registered_itu_t_t35, as per the H.264
       // spec. This payload type contains caption data.
       if (payloadType == 0x04) {
-        yield naluData.subarray(offset, offset + payloadSize);
+        yield naluClone.subarray(offset, offset + payloadSize);
       }
       offset += payloadSize;
     }
@@ -56,28 +50,35 @@ shaka.cea.SeiProcessor = class {
 
   /**
    * Removes H.264 emulation prevention bytes from the byte array.
+   *
+   * Note: Remove bytes by shifting will cause Chromium (VDA) to complain
+   * about conformance. Recreating a new array solves it.
+   *
    * @param {!Uint8Array} naluData NALU from which EMUs should be removed.
-   * @return {number} The number of removed emulation prevention bytes.
+   * @return {!Uint8Array} The number of removed emulation prevention bytes.
    * @private
    */
-  // removeEmu_(naluData) {
-  //   let zeroCount = 0;
-  //   let src = 0;
-  //   let dst = 0;
-  //   while (src < naluData.length) {
-  //     if (zeroCount == 2 && naluData[src] == 0x03) {
-  //       zeroCount = 0;
-  //     } else {
-  //       if (naluData[src] == 0x00) {
-  //         zeroCount++;
-  //       } else {
-  //         zeroCount = 0;
-  //       }
-  //       naluData[dst] = naluData[src];
-  //       dst++;
-  //     }
-  //     src++;
-  //   }
-  //   return (src - dst);
-  // }
+  removeEmu_(naluData) {
+    let naluClone = naluData;
+    let zeroCount = 0;
+    let src = 0;
+    while (src < naluClone.length) {
+      if (zeroCount == 2 && naluClone[src] == 0x03) {
+        zeroCount = 0;
+
+        // Splice the array and recreate a new one, instead of shifting bytes
+        const newArr = [...naluClone];
+        newArr.splice(src, 1);
+        naluClone = new Uint8Array(newArr);
+      } else {
+        if (naluClone[src] == 0x00) {
+          zeroCount++;
+        } else {
+          zeroCount = 0;
+        }
+      }
+      src++;
+    }
+    return naluClone;
+  }
 };

--- a/lib/util/mp4_box_parsers.js
+++ b/lib/util/mp4_box_parsers.js
@@ -176,7 +176,7 @@ shaka.util.Mp4BoxParsers = class {
     if (version == 1) {
       reader.skip(8); // Skip "creation_time"
       reader.skip(8); // Skip "modification_time"
-      trackId = reader.readUint64();
+      trackId = reader.readUint32();
     } else {
       reader.skip(4); // Skip "creation_time"
       reader.skip(4); // Skip "modification_time"

--- a/test/cea/mp4_cea_parser_unit.js
+++ b/test/cea/mp4_cea_parser_unit.js
@@ -27,6 +27,23 @@ describe('Mp4CeaParser', () => {
     ceaSegment = responses[1];
   });
 
+  it('parses CEA-608 SEI data from MP4 H.264 stream', () => {
+    const seiProcessor = new shaka.cea.SeiProcessor();
+
+    const cea608Packet = new Uint8Array([
+      0x00, 0x09, 0x80, 0x00, 0xAF, 0xC8,
+      0x00, 0x00, 0x03, 0x00, 0x00, 0x40, // Emulation prevention byte
+      0x06, 0x01, 0xC4, 0x01, 0x04, 0x00,
+      0x3A, 0x81, 0x01, 0x80,
+    ]);
+
+    const naluData = seiProcessor.removeEmu(cea608Packet);
+    expect(naluData).toBeDefined();
+
+    // EPB should be removed by returning new array, not by shifting bytes
+    expect(naluData.length).toBe(21);
+  });
+
   it('parses cea data from mp4 stream', () => {
     const cea708Parser = new shaka.cea.Mp4CeaParser();
 

--- a/test/cea/mp4_cea_parser_unit.js
+++ b/test/cea/mp4_cea_parser_unit.js
@@ -27,21 +27,30 @@ describe('Mp4CeaParser', () => {
     ceaSegment = responses[1];
   });
 
+  /**
+   * Test only the functionality of removing EPB
+   * Expect removeEmu() to return the NALU with correct length
+   *
+   * Chromium VDA has a strict standard on NALU length
+   * It will complain about conformance if the array is malformed
+   *
+   * If EPB is removed by shifting bytes, it will return the original NALU
+   * length, which will fail this test
+   *
+   * Note that the CEA-608 packet in this test is incomplete
+   */
   it('parses CEA-608 SEI data from MP4 H.264 stream', () => {
     const seiProcessor = new shaka.cea.SeiProcessor();
 
     const cea608Packet = new Uint8Array([
-      0x00, 0x09, 0x80, 0x00, 0xAF, 0xC8,
-      0x00, 0x00, 0x03, 0x00, 0x00, 0x40, // Emulation prevention byte
-      0x06, 0x01, 0xC4, 0x01, 0x04, 0x00,
-      0x3A, 0x81, 0x01, 0x80,
+      0x00, 0x00, 0x03, // Emulation prevention byte
     ]);
 
     const naluData = seiProcessor.removeEmu(cea608Packet);
     expect(naluData).toBeDefined();
 
     // EPB should be removed by returning new array, not by shifting bytes
-    expect(naluData.length).toBe(21);
+    expect(naluData.length).toBe(2);
   });
 
   it('parses cea data from mp4 stream', () => {

--- a/test/util/mp4_box_parsers_unit.js
+++ b/test/util/mp4_box_parsers_unit.js
@@ -150,15 +150,31 @@ describe('Mp4BoxParsers', () => {
     expect(baseMediaDecodeTime).toBe(expectedBaseMediaDecodeTime);
   });
 
+  /**
+   * Test on parsing an incomplete TKHD V1 box, since the parser doesn't
+   * parse the other fields
+   *
+   * Explanation on the Uint8Array:
+   * [
+   * <creation_time, 8 bytes>,
+   * <modification_time, 8 bytes>,
+   * <track_id, 4 bytes>
+   * ]
+   *
+   * Time is a 32B integer expressed in seconds since Jan 1, 1904, 0000 UTC
+   *
+   */
   it('parses TKHD v1 box', () => {
     const tkhdBox = new Uint8Array([
-      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7,
-      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7,
-      0x00, 0x00, 0x00, 0x01,
+      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7, // Creation time
+      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7, // Modification time
+      0x00, 0x00, 0x00, 0x01, // Track ID
+      // Remaining fields are not processed in parseTKHD()
     ]);
     const reader = new shaka.util.DataViewReader(
         tkhdBox, shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
-    const parsedTkhd = shaka.util.Mp4BoxParsers.parseTKHD(reader, 1);
+    const parsedTkhd = shaka.util.Mp4BoxParsers
+        .parseTKHD(reader, /* version= */ 1);
     expect(parsedTkhd.trackId).toBe(1);
   });
 });

--- a/test/util/mp4_box_parsers_unit.js
+++ b/test/util/mp4_box_parsers_unit.js
@@ -149,4 +149,16 @@ describe('Mp4BoxParsers', () => {
     expect(defaultSampleDuration).toBe(expectedDefaultSampleDuration);
     expect(baseMediaDecodeTime).toBe(expectedBaseMediaDecodeTime);
   });
+
+  it('parses TKHD v1 box', () => {
+    const tkhdBox = new Uint8Array([
+      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7,
+      0x00, 0x00, 0x00, 0x00, 0xDC, 0xBF, 0x0F, 0xD7,
+      0x00, 0x00, 0x00, 0x01,
+    ]);
+    const reader = new shaka.util.DataViewReader(
+        tkhdBox, shaka.util.DataViewReader.Endianness.BIG_ENDIAN);
+    const parsedTkhd = shaka.util.Mp4BoxParsers.parseTKHD(reader, 1);
+    expect(parsedTkhd.trackId).toBe(1);
+  });
 });


### PR DESCRIPTION
## Description

This PR fixes two issues:

1. CEA-608 subtitles not showing up
2. Decoder error (Code 3016) occasionally thrown by Chromium VDA

For issue 1, the root cause is incorrect MP4 TKHD unboxing. Track ID should be 4 bytes instead of 8. That causes a mismatch in track ID and timescale mappings. Timescale value will then fallback to default (90,000) and parse to MDAT unboxing. All CC packets will use the wrong timescale for calculating the timestamp.

For issue 2, it's caused by the method of removing emulation prevention bytes from MP4 H.264 SEI NALU packets. Removing the byte by shifting all elements will cause Chromium VDA to complain about conformance (likely it has a lower tolerance than other browsers). Note that Safari and Firefox seem to allow such modification.

This is solved by creating a new byte array with that byte removed. 


## Screenshots (optional)

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
