### PR TITLE
avc3 added to content workarounds

### DIFF
--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -75,6 +75,12 @@ shaka.media.ContentWorkarounds = class {
             newType: ContentWorkarounds.BOX_TYPE_ENCV_,
           });
         })
+        .fullBox('avc3', (box) => {
+          boxesToModify.push({
+            box,
+            newType: ContentWorkarounds.BOX_TYPE_ENCV_,
+          });
+        })
         .fullBox('ec-3', (box) => {
           boxesToModify.push({
             box,


### PR DESCRIPTION
## Description

`content_workarounds.js` was introduced for Tizen and Xbox platforms.  We found that that meant a regression where certain streams were unable to be played.

This PR adds avc3 into the content workarounds in the same was as avc1 to ensure these streams can be played once more.

Fixes #3589 

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
