### PR TITLE
ac-3 added to content workarounds

### DIFF
--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -81,6 +81,12 @@ shaka.media.ContentWorkarounds = class {
             newType: ContentWorkarounds.BOX_TYPE_ENCV_,
           });
         })
+        .fullBox('ac-3', (box) => {
+          boxesToModify.push({
+            box,
+            newType: ContentWorkarounds.BOX_TYPE_ENCA_,
+          });
+        })
         .fullBox('ec-3', (box) => {
           boxesToModify.push({
             box,


### PR DESCRIPTION
`content_workarounds.js` was introduced for Tizen and Xbox platforms. We found that that meant a regression where certain streams were unable to be played.

This PR adds ac-3 into the content workarounds in the same was as ec-3 to ensure these streams can be played once more.

Related to https://github.com/google/shaka-player/pull/3625
