### PR TITLE
Add response HTTP status to Networking engine responses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,8 +13,8 @@
 #
 # Please keep the list sorted.
 
-AdsWizz <*@adswizz.com>
 Adrián Gómez Llorente <adgllorente@gmail.com>
+AdsWizz <*@adswizz.com>
 Alex Jones <alexedwardjones@gmail.com>
 Alugha GmbH <*@alugha.com>
 Alvaro Velad Galvan <alvaro.velad@mirada.tv>
@@ -23,16 +23,16 @@ Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Benjamin Wallberg <me@bwallberg.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
-Code It <*@code-it.fr>
 Charter Communications Inc <*@charter.com>
+Code It <*@code-it.fr>
 Damien Deis <developer.deis@gmail.com>
 Dany L'Hébreux <danylhebreux@gmail.com>
+Edgeware AB <*@edgeware.tv>
 Esteban Dosztal <edosztal@gmail.com>
 Fadomire <fadomire@gmail.com>
-Google Inc. <*@google.com>
-Edgeware AB <*@edgeware.tv>
 Gil Gonen <gil.gonen@gmail.com>
 Giuseppe Samela <giuseppe.samela@gmail.com>
+Google Inc. <*@google.com>
 Itay Kinnrot <Itay.Kinnrot@Kaltura.com>
 Jason Palmer <jason@jason-palmer.com>
 Jesper Haug Karsrud <jesper.karsrud@gmail.com>
@@ -50,6 +50,7 @@ Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>
 Paul Jordaan <pdjordaan@gmail.com>
+Pavel Zablockij <epavelas@gmail.com>
 Percy Tse <percy.tse@gmail.com>
 Peter Nycander <peter.nycander@gmail.com>
 Philo Inc. <*@philo.com>
@@ -71,4 +72,3 @@ uStudio Inc. <*@ustudio.com>
 Verizon Digital Media Services <*@verizondigitalmedia.com>
 Vincent Valot <valot.vince@gmail.com>
 Wayne Morgan <wayne.morgan.dev@gmail.com>
-

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -31,8 +31,8 @@ Amila Sampath <lucksy@gmail.com>
 Andy Hochhaus <ahochhaus@samegoal.com>
 Anthony Stansbridge <github@anthonystansbridge.co.uk>
 Ashutosh Kumar Mukhiya <ashukm4@gmail.com>
-Benjamin Wallberg <me@bwallberg.com>
 Benjamin Wallberg <benjamin.wallberg@bonnierbroadcasting.com>
+Benjamin Wallberg <me@bwallberg.com>
 Boris Cupac <borisrt2309@gmail.com>
 Brad Nadler <bnadler@swankmp.com>
 Bryan Huh <bhh1988@gmail.com>
@@ -78,6 +78,7 @@ Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>
 Paul Jordaan <pdjordaan@gmail.com>
+Pavel Zablockij <epavelas@gmail.com>
 Percy Tse <percy.tse@gmail.com>
 Peter Nycander <peter.nycander@gmail.com>
 Prakash Duggaraju <duggaraju@gmail.com>

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -101,7 +101,7 @@ shaka.extern.Request;
  * @typedef {{
  *   uri: string,
  *   data: BufferSource,
- *   status: (number|undefined)
+ *   status: (number|undefined),
  *   headers: !Object.<string, string>,
  *   timeMs: (number|undefined),
  *   fromCache: (boolean|undefined)

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -118,9 +118,9 @@ shaka.extern.Request;
  *   The original URI passed to the browser for networking. This is before any
  *   redirects, but after request filters are executed.
  * @property {BufferSource} data
- *   The response HTTP status code.
-  * @property {number} status
  *   The body of the response.
+  * @property {number} status
+ *   The response HTTP status code.
  * @property {!Object.<string, string>} headers
  *   A map of response headers, if supported by the underlying protocol.
  *   All keys should be lowercased.

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -101,6 +101,7 @@ shaka.extern.Request;
  * @typedef {{
  *   uri: string,
  *   data: BufferSource,
+ *   status: (number|undefined)
  *   headers: !Object.<string, string>,
  *   timeMs: (number|undefined),
  *   fromCache: (boolean|undefined)
@@ -119,7 +120,7 @@ shaka.extern.Request;
  *   redirects, but after request filters are executed.
  * @property {BufferSource} data
  *   The body of the response.
-  * @property {number} status
+ * @property {(number|undefined)} status
  *   The response HTTP status code.
  * @property {!Object.<string, string>} headers
  *   A map of response headers, if supported by the underlying protocol.

--- a/externs/shaka/net.js
+++ b/externs/shaka/net.js
@@ -118,6 +118,8 @@ shaka.extern.Request;
  *   The original URI passed to the browser for networking. This is before any
  *   redirects, but after request filters are executed.
  * @property {BufferSource} data
+ *   The response HTTP status code.
+  * @property {number} status
  *   The body of the response.
  * @property {!Object.<string, string>} headers
  *   A map of response headers, if supported by the underlying protocol.

--- a/lib/net/http_plugin_utils.js
+++ b/lib/net/http_plugin_utils.js
@@ -34,6 +34,7 @@ shaka.net.HttpPluginUtils = class {
         uri: responseURL || uri,
         originalUri: uri,
         data: data,
+        status: status,
         headers: headers,
         fromCache: !!headers['x-shaka-from-cache'],
       };


### PR DESCRIPTION
## Description
This pull request fixes the issue: #3640 

Basically I just added response status to response filter, it can be useful for someone who needs to check response status and based on that do some actions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
