### PR TITLE
Don't jump over the gap at the beginning before the video is played so that the video poster doesn't disappear.

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -154,8 +154,10 @@ shaka.media.GapJumpingController = class {
     }
     // Don't gap jump while paused, so that you don't constantly jump ahead
     // while paused on a livestream.  We make an exception for time 0, since we
-    // may be _required_ to seek on startup before play can begin.
-    if (this.video_.paused && this.video_.currentTime != 0) {
+    // may be _required_ to seek on startup before play can begin, but only if
+    // autoplay is enabled.
+    if (this.video_.paused && (this.video_.currentTime != 0 ||
+      (!this.video_.autoplay && this.video_.currentTime == 0))) {
       return;
     }
 


### PR DESCRIPTION
Close: https://github.com/google/shaka-player/issues/3451