### PR TITLE
fix(ui): Control panel alignment

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -157,6 +157,9 @@
     /* 32px tall controls. */
     height: 32px;
 
+    /* Consistent alignment of buttons. */
+    line-height: 0.5;
+
     /* Consistent margins (external) and padding (internal) between controls. */
     .bottom-panels-elements-margin();
 


### PR DESCRIPTION
The present pull request aims to provide a solution to a minor visual bug present in the control panel displaying unaligned "sub-menu" buttons (i.e: `quality`, `language`, `playback_rate`). 

In the following example, the green and orange rectangles are exactly the same size and dimensions for both images. Note how the alignment of both rectangles and the size of the red areas change between the before (top) and after (bottom) images.

## Example

<p align=center>
  <img src="https://nbcl.github.io/images/buttons.png" width=900>
</p>

## How to preview

Initialize the client with a config that contains sub-menu buttons (i.e: `quality`, `language`, `playback_rate`) and control panel buttons (i.e: `fast_forward`, `fullscreen`, `overflow_menu`) in the `controlPanelElements`.

 ```js
const config = {
  'controlPanelElements': ['quality', 'loop', 'fast_forward', 'language', 
                           'playback_rate', 'fullscreen', 'overflow_menu'],
}
ui.configure(config);
```

## Changelog

<details>
  <summary><code>ui/less/containers.less</code></summary>

Fixes the line-height of elements inside of the control panel, which specifically adjusts the vertical alignment of "sub-menu" buttons.
</details>

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made the corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run ./build/all.py and the build passes
- [x] I have run ./build/test.py and all tests pass