### PR TITLE
chore: Add @export annotations to polyfill install methods

### DIFF
--- a/lib/polyfill/aria.js
+++ b/lib/polyfill/aria.js
@@ -16,9 +16,13 @@ goog.require('shaka.polyfill');
  * for that platform, as it relies on getters and setters.
  * @see https://w3c.github.io/aria/#ARIAMixin
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Element
+ * @export
  */
 shaka.polyfill.Aria = class {
-  /** Install the polyfill if needed. */
+  /**
+   * Install the polyfill if needed.
+   * @export
+   */
   static install() {
     // eslint-disable-next-line no-restricted-syntax
     if (Object.getOwnPropertyDescriptor(Element.prototype, 'ariaHidden')) {

--- a/lib/polyfill/encryption_scheme.js
+++ b/lib/polyfill/encryption_scheme.js
@@ -13,12 +13,14 @@ goog.require('shaka.polyfill');
  * @see https://wicg.github.io/encrypted-media-encryption-scheme/
  * @see https://github.com/w3c/encrypted-media/pull/457
  * @see https://github.com/google/eme-encryption-scheme-polyfill
+ * @export
  */
 shaka.polyfill.EncryptionScheme = class {
   /**
    * Install the polyfill if needed.
    *
    * @suppress {missingRequire}
+   * @export
    */
   static install() {
     EncryptionSchemePolyfills.install();

--- a/lib/polyfill/fullscreen.js
+++ b/lib/polyfill/fullscreen.js
@@ -14,10 +14,12 @@ goog.require('shaka.polyfill');
  * Many browsers have prefixed fullscreen methods on Element and document.
  * See {@link https://mzl.la/2K0xcHo Using fullscreen mode} on MDN for more
  * information.
+ * @export
  */
 shaka.polyfill.Fullscreen = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.Document) {

--- a/lib/polyfill/mathround.js
+++ b/lib/polyfill/mathround.js
@@ -11,10 +11,12 @@ goog.require('shaka.polyfill');
 /**
  * @summary A polyfill to patch math round bug on some browsers.
  * @see https://stackoverflow.com/q/12830742
+ * @export
  */
 shaka.polyfill.MathRound = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     shaka.log.debug('mathRound.install');

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -15,11 +15,13 @@ goog.require('shaka.util.Platform');
  * @summary A polyfill to provide navigator.mediaCapabilities on all browsers.
  * This is necessary for Tizen 3, Xbox One and possibly others we have yet to
  * discover.
+ * @export
  */
 shaka.polyfill.MediaCapabilities = class {
   /**
    * Install the polyfill if needed.
    * @suppress {const}
+   * @export
    */
   static install() {
     shaka.log.debug('MediaCapabilities: install');

--- a/lib/polyfill/mediasource.js
+++ b/lib/polyfill/mediasource.js
@@ -13,10 +13,12 @@ goog.require('shaka.util.Platform');
 
 /**
  * @summary A polyfill to patch MSE bugs.
+ * @export
  */
 shaka.polyfill.MediaSource = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     shaka.log.debug('MediaSource.install');

--- a/lib/polyfill/orientation.js
+++ b/lib/polyfill/orientation.js
@@ -15,10 +15,12 @@ goog.require('shaka.polyfill');
  * @summary A polyfill for systems that do not implement screen.orientation.
  * For now, this only handles systems that implement the deprecated
  * window.orientation feature... e.g. iPad.
+ * @export
  */
 shaka.polyfill.Orientation = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (screen.orientation) {

--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -22,10 +22,12 @@ goog.require('shaka.util.StringUtils');
 /**
  * @summary A polyfill to implement modern, standardized EME on top of Apple's
  * prefixed EME in Safari.
+ * @export
  */
 shaka.polyfill.PatchedMediaKeysApple = class {
   /**
    * Installs the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.HTMLVideoElement || !window.WebKitMediaKeys) {

--- a/lib/polyfill/patchedmediakeys_ms.js
+++ b/lib/polyfill/patchedmediakeys_ms.js
@@ -24,10 +24,12 @@ goog.require('shaka.util.PublicPromise');
  * {@link https://bit.ly/EmeMar15 EME draft 12 March 2015}
  * on top of ms-prefixed
  * {@link https://www.w3.org/TR/2014/WD-encrypted-media-20140218/ EME v20140218}
+ * @export
  */
 shaka.polyfill.PatchedMediaKeysMs = class {
   /**
    * Installs the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.HTMLVideoElement || !window.MSMediaKeys ||

--- a/lib/polyfill/patchedmediakeys_nop.js
+++ b/lib/polyfill/patchedmediakeys_nop.js
@@ -16,10 +16,12 @@ goog.require('shaka.polyfill');
  * {@link https://bit.ly/EmeMar15 EME draft 12 March 2015} on browsers without
  * EME.
  * All methods will fail.
+ * @export
  */
 shaka.polyfill.PatchedMediaKeysNop = class {
   /**
    * Installs the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.HTMLVideoElement ||

--- a/lib/polyfill/patchedmediakeys_webkit.js
+++ b/lib/polyfill/patchedmediakeys_webkit.js
@@ -24,10 +24,12 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * @summary A polyfill to implement
  * {@link https://bit.ly/EmeMar15 EME draft 12 March 2015} on top of
  * webkit-prefixed {@link https://bit.ly/Eme01b EME v0.1b}.
+ * @export
  */
 shaka.polyfill.PatchedMediaKeysWebkit = class {
   /**
    * Installs the polyfill if needed.
+   * @export
    */
   static install() {
     // Alias.

--- a/lib/polyfill/pip_webkit.js
+++ b/lib/polyfill/pip_webkit.js
@@ -12,10 +12,12 @@ goog.require('shaka.polyfill');
 /**
  * @summary A polyfill to provide PiP support in Safari.
  * Note that Safari only supports PiP on video elements, not audio.
+ * @export
  */
 shaka.polyfill.PiPWebkit = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.HTMLVideoElement) {

--- a/lib/polyfill/storage_estimate.js
+++ b/lib/polyfill/storage_estimate.js
@@ -13,10 +13,12 @@ goog.require('shaka.polyfill');
  * @summary A polyfill to provide navigator.storage.estimate in old
  * webkit browsers.
  * See: https://developers.google.com/web/updates/2017/08/estimating-available-storage-space#the-present
+ * @export
  */
 shaka.polyfill.StorageEstimate = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (navigator.storage && navigator.storage.estimate) {

--- a/lib/polyfill/video_play_promise.js
+++ b/lib/polyfill/video_play_promise.js
@@ -12,10 +12,12 @@ goog.require('shaka.polyfill');
 
 /**
  * @summary A polyfill to silence the play() Promise in HTML5 video.
+ * @export
  */
 shaka.polyfill.VideoPlayPromise = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     shaka.log.debug('VideoPlayPromise.install');

--- a/lib/polyfill/videoplaybackquality.js
+++ b/lib/polyfill/videoplaybackquality.js
@@ -13,10 +13,12 @@ goog.require('shaka.polyfill');
  * @summary A polyfill to provide MSE VideoPlaybackQuality metrics.
  * Many browsers do not yet provide this API, and Chrome currently provides
  * similar data through individual prefixed attributes on HTMLVideoElement.
+ * @export
  */
 shaka.polyfill.VideoPlaybackQuality = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (!window.HTMLVideoElement) {

--- a/lib/polyfill/vttcue.js
+++ b/lib/polyfill/vttcue.js
@@ -12,10 +12,12 @@ goog.require('shaka.polyfill');
 
 /**
  * @summary A polyfill to provide VTTCue.
+ * @export
  */
 shaka.polyfill.VTTCue = class {
   /**
    * Install the polyfill if needed.
+   * @export
    */
   static install() {
     if (window.VTTCue) {


### PR DESCRIPTION
## Description
This change allows polyfills to be installed individually e.g. `shaka.polyfill.MediaCapabilities.install()` instead of `shaka.polyfill.installAll()`

Related to #2625

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [X] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
