### PR TITLE
Fix dispose of ad manager on detach

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1321,7 +1321,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
 
     if (this.adManager_) {
-      // The ad manager is specific to the video, so dispose of it.
+      // The ad manager is specific to the video, so detach it too.
       this.adManager_.release();
     }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1323,7 +1323,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (this.adManager_) {
       // The ad manager is specific to the video, so dispose of it.
       this.adManager_.release();
-      this.adManager_ = null;
     }
 
     // Clear our cached copy of the media element.


### PR DESCRIPTION
Fix: https://github.com/google/shaka-player/commit/7b2a17276b495c7961fac1fdcbf944b613c542d1

The previous commit, when using the `detach` function, `this.adManager_` is destroyed and there is nowhere where it will be recreated. But this is not necessary, only with the call to `release` the dependencies of the video are eliminated, and the object is reusable.