### PR TITLE
Deduplication of init data to reduce memory usage

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -1825,9 +1825,16 @@ shaka.media.DrmEngine = class {
         // audio adaptations, so we shouldn't have to worry about checking
         // robustness.
         if (drm1.keySystem == drm2.keySystem) {
+          /** @type {Array<shaka.extern.InitDataOverride>} */
           let initData = [];
           initData = initData.concat(drm1.initData || []);
           initData = initData.concat(drm2.initData || []);
+          initData = initData.filter((d, i) => {
+            return d.keyId === undefined || i === initData.findIndex((d2) => {
+              return d2.keyId === d.keyId;
+            });
+          });
+
           const keyIds = drm1.keyIds && drm2.keyIds ?
               new Set([...drm1.keyIds, ...drm2.keyIds]) :
               drm1.keyIds || drm2.keyIds;

--- a/test/media/drm_engine_unit.js
+++ b/test/media/drm_engine_unit.js
@@ -2152,6 +2152,50 @@ describe('DrmEngine', () => {
           [drmInfoAudio]);
       expect(returned).toEqual([drmInfoDesired]);
     });
+
+    it('dedupes the merged init data based on keyId matching', () => {
+      const serverCert = new Uint8Array(0);
+      const drmInfoVideo = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: false,
+        persistentStateRequired: true,
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}],
+        keyIds: new Set(['deadbeefdeadbeefdeadbeefdeadbeef']),
+      };
+      const drmInfoAudio = {
+        keySystem: 'drm.abc',
+        licenseServerUri: undefined,
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: false,
+        audioRobustness: 'good',
+        serverCertificate: undefined,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}, {keyId: 'a-init'}],
+        keyIds: new Set(['eadbeefdeadbeefdeadbeefdeadbeefd']),
+      };
+      const drmInfoDesired = {
+        keySystem: 'drm.abc',
+        licenseServerUri: 'http://abc.drm/license',
+        distinctiveIdentifierRequired: true,
+        persistentStateRequired: true,
+        audioRobustness: 'good',
+        videoRobustness: 'really_really_ridiculously_good',
+        serverCertificate: serverCert,
+        serverCertificateUri: '',
+        initData: [{keyId: 'v-init'}, {keyId: 'a-init'}],
+        keyIds: new Set([
+          'deadbeefdeadbeefdeadbeefdeadbeef',
+          'eadbeefdeadbeefdeadbeefdeadbeefd',
+        ]),
+      };
+      const returned = shaka.media.DrmEngine.getCommonDrmInfos([drmInfoVideo],
+          [drmInfoAudio]);
+      expect(returned).toEqual([drmInfoDesired]);
+    });
   }); // describe('getCommonDrmInfos')
 
   describe('configure', () => {


### PR DESCRIPTION
## Description
Linear streams accumulate init data over time because the init data is pushed to an array regardless of whether or not it already exists as part of the logic to combine periods. This PR will dedupe the init data based on keyId to help reduce memory usage over extended playouts.

<!--
  Give the PR a helpful title that summaries what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
