### PR TITLE
separation of (bg)color from other defaults

### DIFF
--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -303,12 +303,15 @@
   transition-delay: 500ms;
 
   /* These are defaults which are overridden by JS or cue styles. */
+  span:not(.shaka-text-wrapper, .shaka-text-wrapper span) {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: rgb(255, 255, 255);
+  }
+
   span:not(.shaka-text-wrapper) {
     display: inline;
     font-size: 20px;
     line-height: 1.4;  // relative to font size.
-    background-color: rgba(0, 0, 0, 0.8);
-    color: rgb(255, 255, 255);
   }
 
   span.shaka-text-wrapper {


### PR DESCRIPTION
## Description

Solution to loss of (bg)color for nested captions via simpler CSS (`.less` file) update:
- separation of default subtitle settings into colors and sizing/display properties.
- unchanged application of the latter (NOT for `shaka-text-wrapper` classed spans)
- change of application of the colors to be NOT for `shaka-text-wrapper` classed spans OR descendents of `shaka-text-wrapper` classed spans.
Fixes #3521 

## Screenshots (optional)
![Screenshot 2021-10-24 at 14 32 52](https://user-images.githubusercontent.com/37144605/138596483-1be9bfd2-8ebd-4cfc-a4ec-3e5928b1d8ab.png)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
