### PR TITLE
Dash hdr signalling via essential or supplemental property

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Peter Nycander <peter.nycander@gmail.com>
 Philo Inc. <*@philo.com>
 Prakash <duggaraju@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
+Robert Galluccio <robertnw5@gmail.com>
 Roi Lipman <roilipman@gmail.com>
 Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>
 Rostislav Hejduk <Ross-cz@users.noreply.github.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -84,6 +84,7 @@ Percy Tse <percy.tse@gmail.com>
 Peter Nycander <peter.nycander@gmail.com>
 Prakash Duggaraju <duggaraju@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
+Robert Galluccio <robertnw5@gmail.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>
 Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -822,6 +822,25 @@ shaka.dash.DashParser = class {
       }
     }
 
+    // Parallel for HLS VIDEO-RANGE as defined in DASH-IF IOP v4.3 6.2.5.1.
+    let videoRange;
+    const videoRangeScheme = 'urn:mpeg:mpegB:cicp:TransferCharacteristics';
+    const getVideoRangeFromTransferCharacteristicCICP = (cicp) => {
+      switch (cicp) {
+        case 1:
+        case 6:
+        case 13:
+        case 14:
+        case 15:
+          return 'SDR';
+        case 16:
+          return 'PQ';
+        case 18:
+          return 'HLG';
+      }
+      return undefined;
+    };
+
     const essentialProperties =
         XmlUtils.findChildren(elem, 'EssentialProperty');
     // ID of real AdaptationSet if this is a trick mode set:
@@ -831,8 +850,23 @@ shaka.dash.DashParser = class {
       const schemeId = prop.getAttribute('schemeIdUri');
       if (schemeId == 'http://dashif.org/guidelines/trickmode') {
         trickModeFor = prop.getAttribute('value');
+      } else if (schemeId == videoRangeScheme) {
+        videoRange = getVideoRangeFromTransferCharacteristicCICP(
+            parseInt(prop.getAttribute('value'), 10),
+        );
       } else {
         unrecognizedEssentialProperty = true;
+      }
+    }
+
+    const supplementalProperties =
+        XmlUtils.findChildren(elem, 'SupplementalProperty');
+    for (const prop of supplementalProperties) {
+      const schemeId = prop.getAttribute('schemeIdUri');
+      if (schemeId == videoRangeScheme) {
+        videoRange = getVideoRangeFromTransferCharacteristicCICP(
+            parseInt(prop.getAttribute('value'), 10),
+        );
       }
     }
 
@@ -961,8 +995,13 @@ shaka.dash.DashParser = class {
     // Parse Representations into Streams.
     const representations = XmlUtils.findChildren(elem, 'Representation');
     const streams = representations.map((representation) => {
-      return this.parseRepresentation_(context, contentProtection, kind,
-          language, label, main, roleValues, closedCaptions, representation);
+      const parsedRepresentation = this.parseRepresentation_(context,
+          contentProtection, kind, language, label, main, roleValues,
+          closedCaptions, representation);
+      if (parsedRepresentation) {
+        parsedRepresentation.hdr = parsedRepresentation.hdr || videoRange;
+      }
+      return parsedRepresentation;
     }).filter((s) => !!s);
 
     if (streams.length == 0) {


### PR DESCRIPTION
## Description
Fixes #3726

Now we parse value of descriptor for `urn:mpeg:mpegB:cicp:TransferCharacteristics` in `AdaptationSet` to indicate `hdr` property on `shaka.extern.Stream` which seems equivalent to HLS definition given in `VIDEO-RANGE` attribute within [`EXT-X-STREAM-INF`](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis-09#section-4.4.6.2).

This is done by reading the supplemental / essential property in the parsing of `AdaptationSet`, then mutating the `hdr` property on `shaka.extern.Stream` if no `hdr` exists after `parseRepresentation_`.

The alternative considered was to parse all essential / supplemental properties on any `shaka.dash.DashParser.InheritanceFrame` and then carrying that through to the `parseRepresentaiton_` function; this can be seen [here](https://github.com/google/shaka-player/compare/master...theRealRobG:extract-hdr-signalling-via-dash-essential-or-supplemental-property). The problem with the alternative approach was that the essential property in the adaptation set would have had to have been "let through" on the assumption that we would parse it within the `parseRepresentation_` method... But this to me seemed somewhat risky to change, and also looks messy with the empty `else if` condition, plus was a much larger change (with more calls to XmlUtils, though not familiar with how that is implemented, so not sure if there was any penalty because of that).

## Screenshots (optional)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
