### PR TITLE
Pass HDR information when getting decoding info from media capabilities

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ Peter Nycander <peter.nycander@gmail.com>
 Philo Inc. <*@philo.com>
 Prakash <duggaraju@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
+Robert Galluccio <robertnw5@gmail.com>
 Roi Lipman <roilipman@gmail.com>
 Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>
 Rostislav Hejduk <Ross-cz@users.noreply.github.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -84,6 +84,7 @@ Percy Tse <percy.tse@gmail.com>
 Peter Nycander <peter.nycander@gmail.com>
 Prakash Duggaraju <duggaraju@gmail.com>
 Robert Colantuoni <rgc@colantuoni.com>
+Robert Galluccio <robertnw5@gmail.com>
 Rohit Makasana <rohitbm@google.com>
 Roi Lipman <roilipman@gmail.com>
 Roksolana Ivanyshyn <roksolana.ivanyshyn.pub@gmail.com>

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -547,6 +547,19 @@ shaka.util.StreamUtils = class {
         // framerate must be greater than 0, otherwise the config is invalid.
         framerate: video.frameRate || 1,
       };
+      if (video.hdr) {
+        switch (video.hdr) {
+          case 'SDR':
+            mediaDecodingConfig.video.transferFunction = 'srgb';
+            break;
+          case 'PQ':
+            mediaDecodingConfig.video.transferFunction = 'pq';
+            break;
+          case 'HLG':
+            mediaDecodingConfig.video.transferFunction = 'hlg';
+            break;
+        }
+      }
     }
     if (audio) {
       // Some Tizen devices seem to misreport AC-3 support, but correctly


### PR DESCRIPTION
## Description

Fixes #3729

If the video variant stream contains information about `hdr`, then we now use that to provide a value for `transferFunction`, when constructing the [`VideoConfiguration`](https://w3c.github.io/media-capabilities/#videoconfiguration) object used to get decoding info from media capabilities API.

The following applies:
```js
switch (video.hdr) {
  case 'SDR':
    mediaDecodingConfig.video.transferFunction = 'srgb';
    break;
  case 'PQ':
    mediaDecodingConfig.video.transferFunction = 'pq';
    break;
  case 'HLG':
    mediaDecodingConfig.video.transferFunction = 'hlg';
    break;
}
```

## Screenshots (optional)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
