### PR TITLE
Fix test in uncompiled mode

### DIFF
--- a/shaka-player.uncompiled.js
+++ b/shaka-player.uncompiled.js
@@ -44,6 +44,7 @@ goog.require('shaka.polyfill.PatchedMediaKeysMs');
 goog.require('shaka.polyfill.PatchedMediaKeysNop');
 goog.require('shaka.polyfill.PatchedMediaKeysWebkit');
 goog.require('shaka.polyfill.PiPWebkit');
+goog.require('shaka.polyfill.RandomUUID');
 goog.require('shaka.polyfill.VTTCue');
 goog.require('shaka.polyfill.VideoPlayPromise');
 goog.require('shaka.polyfill.VideoPlaybackQuality');


### PR DESCRIPTION
Some test are failing in Safari and Firefox due to the missing goog.require.