### PR TITLE
fix parsing of HLS 'DEFAULT' attribute

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1207,7 +1207,7 @@ shaka.hls.HlsParser = class {
     // "AUTOSELECT=YES".  A value of "AUTOSELECT=NO" would imply that it may
     // only be selected explicitly by the user, and we don't have a way to
     // represent that in our model.
-    const defaultAttrValue = tag.getAttribute('DEFAULT');
+    const defaultAttrValue = tag.getAttributeValue('DEFAULT');
     const primary = defaultAttrValue == 'YES';
 
     const channelsCount = type == 'audio' ? this.getChannelsCount_(tag) : null;

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -785,7 +785,7 @@ describe('HlsParser', () => {
       'RESOLUTION=960x540,FRAME-RATE=120,AUDIO="aud2"\n',
       'video2\n',
       '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud1",LANGUAGE="eng",',
-      'URI="audio"\n',
+      'DEFAULT=YES,URI="audio"\n',
       '#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aud2",LANGUAGE="fr",',
       'URI="audio2"\n',
     ].join('');
@@ -803,6 +803,7 @@ describe('HlsParser', () => {
       manifest.anyTimeline();
       manifest.addPartialVariant((variant) => {
         variant.bandwidth = 200;
+        variant.primary = true;
         variant.addPartialStream(ContentType.VIDEO, (stream) => {
           stream.size(960, 540);
         });
@@ -812,6 +813,7 @@ describe('HlsParser', () => {
       });
       manifest.addPartialVariant((variant) => {
         variant.bandwidth = 300;
+        variant.primary = false;
         variant.addPartialStream(ContentType.VIDEO, (stream) => {
           stream.size(960, 540);
         });


### PR DESCRIPTION
## Description

Correctly obtain value of DEFAULT tag so variants can be tagged as primary, to avoid arbitrary audio language selection in multi-variant playlists.

Fixes #3769


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
