### PR TITLE
clear buffer on unbuffered seek for updating media states

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -628,7 +628,7 @@ shaka.media.StreamingEngine = class {
 
         // Don't clear the buffer unless something is buffered.  This extra
         // check prevents extra, useless calls to clear the buffer.
-        if (somethingBuffered) {
+        if (somethingBuffered || mediaState.performingUpdate) {
           this.forceClearBuffer_(mediaState);
           streamCleared = true;
         }


### PR DESCRIPTION


## Description

Ensure buffer is cleared on an unbuffered seek, for media states that are mid-update even if they have no buffer yet. This prevents the update operation from appending buffer for the old time and potentially getting one media state stuck buffering to catch up to the target seek position.

Fixes #3299

## Screenshots (optional)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
