### PR TITLE
Fix #3783 captions not working after a period transition on live DASH streams

### DIFF
--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -396,7 +396,10 @@ shaka.text.TextEngine = class {
       }
 
       captionsMap.get(id).get(startAndEndTime).push(cue);
-      if (id == this.selectedClosedCaptionId_) {
+      // With multiperiod live DASH DAI streams a comma is appended to the
+      // selectedClosedCaptionId string each time a new period appears in
+      // the manifest e.g. "CC1,,,"
+      if (this.selectedClosedCaptionId_.includes(id)) {
         this.displayer_.append([cue]);
       }
     }

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -398,8 +398,8 @@ shaka.text.TextEngine = class {
       captionsMap.get(id).get(startAndEndTime).push(cue);
       // With multiperiod live DASH DAI streams a comma is appended to the
       // selectedClosedCaptionId string each time a new period appears in
-      // the manifest e.g. "CC1,,,"
-      if (this.selectedClosedCaptionId_.includes(id)) {
+      // the manifest e.g. "CC1,,," while the id value remains "CC1"
+      if (this.selectedClosedCaptionId_.startsWith(id)) {
         this.displayer_.append([cue]);
       }
     }

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -396,10 +396,7 @@ shaka.text.TextEngine = class {
       }
 
       captionsMap.get(id).get(startAndEndTime).push(cue);
-      // With multiperiod live DASH DAI streams a comma is appended to the
-      // selectedClosedCaptionId string each time a new period appears in
-      // the manifest e.g. "CC1,,," while the id value remains "CC1"
-      if (this.selectedClosedCaptionId_.startsWith(id)) {
+      if (id == this.selectedClosedCaptionId_) {
         this.displayer_.append([cue]);
       }
     }

--- a/lib/util/periods.js
+++ b/lib/util/periods.js
@@ -80,7 +80,10 @@ shaka.util.PeriodCombiner = class {
 
   /** @return {!Array.<shaka.extern.Stream>} */
   getTextStreams() {
-    return this.textStreams_;
+    // Return a copy of the array because makeTextStreamsForClosedCaptions
+    // may make changes to the contents of the array. Those changes should not
+    // propagate back to the PeriodCombiner.
+    return this.textStreams_.slice();
   }
 
   /** @return {!Array.<shaka.extern.Stream>} */


### PR DESCRIPTION
## Description
Fixes #3783

Embedded CEA-608 captions don't work on multi period live DASH DAI streams after new periods appear in the manifest because commas are appended the streams originalId string, which disrupts some stream matching code in text_engine.js

The problem has been resolved by preventing makeTextStreamsForClosedCaptions() from altering the PeriodCombiner.textStreams_ array.

## Screenshots (optional)
NA

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [NA] I have made corresponding changes to the documentation
- [No] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
