### PR TITLE
Github Actions macOS Integration Tests

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -35,10 +35,6 @@ jobs:
           # Run Linux with xvfb, so they're headless.
           - os: ubuntu-latest
             extra_flags: "--use-xvfb"
-          # Run macOS with --quick for now, since the integration tests crash.
-          # TODO: Figure out the source of the crash and fix that instead.
-          - os: macos-latest
-            extra_flags: "--quick"
           # Also test Edge on Windows.
           - os: windows-latest
             browser: Edge

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -287,7 +287,7 @@ describe('StreamingEngine', () => {
       streamingEngine.switchVariant(variant);
       await streamingEngine.start();
       video.play();
-      await waiter.timeoutAfter(90).waitForEnd(video);
+      await waiter.timeoutAfter(120).waitForEnd(video);
     });
 
     it('plays at high playback rates', async () => {


### PR DESCRIPTION
Allows Github Action tests to run integration tests on macOS.