### PR TITLE
Fix thumbnails issues

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1222,7 +1222,7 @@ shaka.extern.LanguageRole;
  *    The image height in px. The image height could be different to height if
  *    the layout is different to 1x1.
  * @property {number} imageWidth
- *    The image width in px. The image width could be different to height if
+ *    The image width in px. The image width could be different to width if
  *    the layout is different to 1x1.
  * @property {number} height
  *    The thumbnail height in px.

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1207,6 +1207,8 @@ shaka.extern.LanguageRole;
 
 /**
  * @typedef {{
+ *   imageHeight: number,
+ *   imageWidth: number,
  *   height: number,
  *   positionX: number,
  *   positionY: number,
@@ -1216,6 +1218,12 @@ shaka.extern.LanguageRole;
  *   width: number
  * }}
  *
+ * @property {number} imageHeight
+ *    The image height in px. The image height could be different to height if
+ *    the layout is different to 1x1.
+ * @property {number} imageWidth
+ *    The image width in px. The image width could be different to height if
+ *    the layout is different to 1x1.
  * @property {number} height
  *    The thumbnail height in px.
  * @property {number} positionX

--- a/lib/player.js
+++ b/lib/player.js
@@ -3637,6 +3637,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         positionY = Math.floor(thumbnailPosition / columns) * height;
       }
       return {
+        imageHeight: fullImageHeight,
+        imageWidth: fullImageWidth,
         height: height,
         positionX: positionX,
         positionY: positionY,

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1041,7 +1041,7 @@ shaka.util.StreamUtils = class {
       channelsCount: null,
       audioSamplingRate: null,
       spatialAudio: false,
-      tilesLayout: stream.tilesLayout || null,
+      tilesLayout: layout,
       audioBandwidth: null,
       videoBandwidth: null,
       originalVideoId: null,

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -994,7 +994,13 @@ shaka.util.StreamUtils = class {
 
     // The stream width and height represent the size of the entire thumbnail
     // sheet, so divide by the layout.
-    const reference = stream.segmentIndex.get(0);
+    let reference = null;
+    // Note: segmentIndex is built by default for HLS, but not for DASH, but
+    // in DASH this information comes at the stream level and not at the
+    // segment level.
+    if (stream.segmentIndex) {
+      reference = stream.segmentIndex.get(0);
+    }
     let layout = stream.tilesLayout;
     if (reference) {
       layout = reference.getTilesLayout() || layout;

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1041,7 +1041,7 @@ shaka.util.StreamUtils = class {
       channelsCount: null,
       audioSamplingRate: null,
       spatialAudio: false,
-      tilesLayout: layout,
+      tilesLayout: layout || null,
       audioBandwidth: null,
       videoBandwidth: null,
       originalVideoId: null,

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -3544,24 +3544,32 @@ describe('Player', () => {
         const thumbnail2 = await player.getThumbnails(5, 21);
         const thumbnail5 = await player.getThumbnails(5, 51);
         expect(thumbnail0).toEqual(jasmine.objectContaining({
+          imageHeight: 150,
+          imageWidth: 200,
           positionX: 0,
           positionY: 0,
           width: 100,
           height: 50,
         }));
         expect(thumbnail1).toEqual(jasmine.objectContaining({
+          imageHeight: 150,
+          imageWidth: 200,
           positionX: 100,
           positionY: 0,
           width: 100,
           height: 50,
         }));
         expect(thumbnail2).toEqual(jasmine.objectContaining({
+          imageHeight: 150,
+          imageWidth: 200,
           positionX: 0,
           positionY: 50,
           width: 100,
           height: 50,
         }));
         expect(thumbnail5).toEqual(jasmine.objectContaining({
+          imageHeight: 150,
+          imageWidth: 200,
           positionX: 100,
           positionY: 100,
           width: 100,


### PR DESCRIPTION
The commit https://github.com/google/shaka-player/commit/264c84249684ee809f53fd4117f9aab4e0a599ac introduce 2 issues:
- `stream.segmentIndex` is not always constructed (eg: DASH)
- In Image track the size of the thumbnail itself is returned and not the size of the complete image, so it is necessary to return the size of the complete image in `getThumbnails` so that later the UI can correctly place the image if the layout is different to 1x1.