### PR TITLE
Select first audio stream based on the order in the manifest.

### DIFF
--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -145,15 +145,21 @@ shaka.abr.SimpleAbrManager = class {
     // Start by assuming that we will use the first Stream.
     let chosen = sortedVariants[0] || null;
 
-    const enumerate = (it) => shaka.util.Iterables.enumerate(it);
-    for (const {item, next} of enumerate(sortedVariants)) {
+    for (let i = 0; i < sortedVariants.length; i++) {
+      const item = sortedVariants[i];
       const playbackRate =
           !isNaN(this.playbackRate_) ? Math.abs(this.playbackRate_) : 1;
       const itemBandwidth = playbackRate * item.bandwidth;
       const minBandwidth =
           itemBandwidth / this.config_.bandwidthDowngradeTarget;
-      const nextBandwidth =
-          playbackRate * (next || {bandwidth: Infinity}).bandwidth;
+      let next = {bandwidth: Infinity};
+      for (let j = i + 1; j < sortedVariants.length; j++) {
+        if (item.bandwidth != sortedVariants[j].bandwidth) {
+          next = sortedVariants[j];
+          break;
+        }
+      }
+      const nextBandwidth = playbackRate * next.bandwidth;
       const maxBandwidth = nextBandwidth / this.config_.bandwidthUpgradeTarget;
       shaka.log.v2('Bandwidth ranges:',
           (itemBandwidth / 1e6).toFixed(3),
@@ -161,7 +167,8 @@ shaka.abr.SimpleAbrManager = class {
           (maxBandwidth / 1e6).toFixed(3));
 
       if (currentBandwidth >= minBandwidth &&
-          currentBandwidth <= maxBandwidth) {
+          currentBandwidth <= maxBandwidth &&
+          chosen.bandwidth != item.bandwidth) {
         chosen = item;
       }
     }


### PR DESCRIPTION
## Description

If a manifest lists 2 audio streams, select the first acceptable stream instead of the last one. For example below, previously the 2nd stream was selected, and now the first stream will be selected. Other players like roku, video.js and exoplayer select the first one.

```
#EXT-X-MEDIA:TYPE=AUDIO,URI="stream_1.m3u8",GROUP-ID="default-audio-group",NAME="128k",AUTOSELECT=YES,CHANNELS="2"
#EXT-X-MEDIA:TYPE=AUDIO,URI="stream_2.m3u8",GROUP-ID="default-audio-group",NAME="64k",CHANNELS="2"
(video streams snipped)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [ ] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
