### PR TITLE
fix(tests): Skip Ad UI tests if less is not loaded.

### DIFF
--- a/test/ui/ad_ui_unit.js
+++ b/test/ui/ad_ui_unit.js
@@ -15,7 +15,17 @@ goog.require('shaka.ui.Locales');
 goog.require('shaka.util.EventManager');
 goog.requireType('shaka.ui.Localization');
 
-describe('Ad UI', () => {
+/** @return {boolean} */
+function skipIfNoLess() {
+  if (!(window['less'])) {
+    // Sometimes, in GitHub actions test runs, "less" is not loaded by now.
+    // In that case, just skip these tests.
+    return false;
+  }
+  return true;
+}
+
+filterDescribe('Ad UI', skipIfNoLess, () => {
   const UiUtils = shaka.test.UiUtils;
   /** @type {!HTMLLinkElement} */
   let cssLink;
@@ -27,7 +37,6 @@ describe('Ad UI', () => {
   let ad;
   /** @type {!shaka.test.FakeAdManager} */
   let adManager;
-
 
   beforeAll(async () => {
     // Add css file


### PR DESCRIPTION
We've been seeing this specific error a lot in the Github Actions test runs, where less.js occasionally fails to load in the tests for whatever reason. This causes a bunch of errors that are not really the fault of the PR.
This filters the test if less.js was not loaded.

This is identical to #3861, which I accidentally closed after making a mistake rebasing the fork.