### PR TITLE
test: Hide passing tests in GitHub actions runs.

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -67,4 +67,4 @@ jobs:
 
       - name: Test Player
         run: |
-          python build/test.py --browsers ${{ matrix.browser }} --reporter spec --drm ${{ matrix.extra_flags }}
+          python build/test.py --browsers ${{ matrix.browser }} --reporters spec --spec-hide-passed --drm ${{ matrix.extra_flags }}

--- a/build/test.py
+++ b/build/test.py
@@ -230,6 +230,11 @@ class Launcher:
         const=2,
         nargs='?')
     running_commands.add_argument(
+        '--spec-hide-passed',
+        help='If provided, configure the spec reporter to hide passing tests.',
+        action='store_true',
+        default=False)
+    running_commands.add_argument(
         '--test-custom-asset',
         help='Run asset playback tests on a custom manifest URI.',
         type=str,
@@ -358,6 +363,7 @@ class Launcher:
       'single_run',
       'uncompiled',
       'delay_tests',
+      'spec_hide_passed',
       'test_custom_asset',
       'test_custom_license_server',
       'test_timeout',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -336,6 +336,10 @@ module.exports = (config) => {
 
   config.set({reporters: reporters});
 
+  if (reporters.includes('spec') && settings.spec_hide_passed) {
+    config.set({specReporter: {suppressPassed: true}});
+  }
+
   if (settings.random) {
     // If --seed was specified use that value, else generate a seed so that the
     // exact order can be reproduced if it catches an issue.


### PR DESCRIPTION
This adds a new test configuration flag, `--spec-hide-passed`, which (if the test reporter is `spec`) causes passing tests to not produce any logs. This configuration flag is set on GitHub actions runs, so that the logs from them aren't so overwhelmingly long.