### PR TITLE
add null check for emsgSchemeIdUris in streaming engine parseEMSG_

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1659,7 +1659,7 @@ shaka.media.StreamingEngine = class {
     // See DASH sec. 5.10.3.3.1
     // If a DASH client detects an event message box with a scheme that is not
     // defined in MPD, the client is expected to ignore it.
-    if (emsgSchemeIdUris.includes(schemeId) ||
+    if ((emsgSchemeIdUris && emsgSchemeIdUris.includes(schemeId)) ||
         this.config_.dispatchAllEmsgBoxes) {
       // See DASH sec. 5.10.4.1
       // A special scheme in DASH used to signal manifest updates.


### PR DESCRIPTION
## Description

Add null check for emsgSchemeIdUris when EMSG boxes are parsed, as this value is null for HLS streams
Fixes #3886

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
