### PR TITLE
test: Fix flake in screenshot tests around native captions

### DIFF
--- a/test/ui/text_displayer_layout_unit.js
+++ b/test/ui/text_displayer_layout_unit.js
@@ -196,6 +196,7 @@ filterDescribe('TextDisplayer layout', supportsScreenshots, () => {
 
         // The video must be played a little now, after the cues were appended,
         // but before the screenshot.
+        video.playbackRate = 1;
         video.play();
         await waiter.failOnTimeout(false).timeoutAfter(5)
             .waitForMovement(video);
@@ -203,10 +204,13 @@ filterDescribe('TextDisplayer layout', supportsScreenshots, () => {
 
         // Seek to a time when cues should be showing.
         video.currentTime = time;
+        // Get into a playing state, but without movement.
+        video.playbackRate = 0;
+        video.play();
 
         // Add a short delay to ensure that the system has caught up and that
         // native text displayers have been updated by the browser.
-        await Util.shortDelay();
+        await Util.delay(0.1);
       };
     });
 


### PR DESCRIPTION
## Description

This fixes some missing cues in screenshot tests for native rendering in Safari.

## Type of change

Changes to tests only.

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [X] I have run `./build/test.py` and all tests pass
