### PR TITLE
test: Make screenshot comparisons more tolerant

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pwacompat": "^2.0.10",
     "rimraf": "^2.6.3",
     "sprintf-js": "^1.1.2",
+    "ssim.js": "^3.5.0",
     "stylelint": "^13.8.0",
     "stylelint-config-standard": "^20.0.0",
     "tippy.js": "^4.3.1",

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -452,8 +452,11 @@ shaka.test.Util = class {
 
     // If the minimum similarity is not met, you can review the new screenshot
     // and the diff image in the screenshots folder.  Look for images that end
-    // with "-new" and "-diff".  If cropping doesn't work right, you can view
-    // the full-page screenshot in the image that ends with "-full".
+    // with "-new" and "-diff".  (NOTE: The diff is a pixel-wise diff for human
+    // review, and is not produced with the same structural similarity
+    // algorithm used to detect changes in the test.)  If cropping doesn't work
+    // right, you can view the full-page screenshot in the image that ends with
+    // "-full".
     expect(similarity).withContext(name).not.toBeLessThan(minSimilarity);
   }
 };

--- a/test/test/util/util.js
+++ b/test/test/util/util.js
@@ -401,10 +401,10 @@ shaka.test.Util = class {
    *   within the bounds of the viewport.
    * @param {string} name An identifier for the screenshot.  Use alphanumeric
    *   plus dash and underscore only.
-   * @param {number} threshold A change threshold in pixels.
+   * @param {number} minSimilarity A minimum similarity score between 0 and 1.
    * @return {!Promise}
    */
-  static async checkScreenshot(element, name, threshold=0) {
+  static async checkScreenshot(element, name, minSimilarity=1) {
     // Make sure the DOM is up-to-date and layout has settled before continuing.
     // Without this delay, or with a shorter delay, we sometimes get missing
     // elements in our UITextDisplayer tests on some platforms.
@@ -448,13 +448,13 @@ shaka.test.Util = class {
     const buffer = await shaka.test.Util.fetch(
         '/screenshot/diff' + parentUrlParams + paramsString);
     const json = shaka.util.StringUtils.fromUTF8(buffer);
-    const pixelsChanged = /** @type {number} */(JSON.parse(json));
+    const similarity = /** @type {number} */(JSON.parse(json));
 
-    // If the change threshold is exceeded, you can review the new screenshot
+    // If the minimum similarity is not met, you can review the new screenshot
     // and the diff image in the screenshots folder.  Look for images that end
     // with "-new" and "-diff".  If cropping doesn't work right, you can view
     // the full-page screenshot in the image that ends with "-full".
-    expect(pixelsChanged).withContext(name).not.toBeGreaterThan(threshold);
+    expect(similarity).withContext(name).not.toBeLessThan(minSimilarity);
   }
 };
 

--- a/test/ui/text_displayer_layout_unit.js
+++ b/test/ui/text_displayer_layout_unit.js
@@ -34,11 +34,8 @@ filterDescribe('TextDisplayer layout', supportsScreenshots, () => {
    */
   let beforeScreenshot;
 
-  // Legacy Edge seems to have inconsistent font kerning.  A one-pixel offset in
-  // the position of one character appears about 60% of the time, requiring us
-  // to have this change tolerance in our tests.  So far, all past bugs in our
-  // implementation that we have tests for would exceed this threshold by a lot.
-  const threshold = 160;  // px
+  // A minimum similarity score for screenshots, between 0 and 1.
+  const minSimilarity = 0.95;
 
   const originalCast = window.chrome && window.chrome.cast;
 
@@ -475,6 +472,6 @@ filterDescribe('TextDisplayer layout', supportsScreenshots, () => {
     return Util.checkScreenshot(
         /* element= */ videoContainer,
         prefix + '-' + baseName,
-        threshold);
+        minSimilarity);
   }
 });


### PR DESCRIPTION
## Description

Instead of pixel-wise comparison with a change threshold, we now use a
structural similarity (ssim) module to decide how much a screenshot
has changed.  This better tolerates small rendering differences due to
differences in GPUs across machines.


## Type of change

Changes to tests only.


## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [X] I have run `./build/test.py` and all tests pass
