### PR TITLE
feat(hls): Update active streams only

### DIFF
--- a/externs/shaka/manifest.js
+++ b/externs/shaka/manifest.js
@@ -238,6 +238,7 @@ shaka.extern.CreateSegmentIndexFunction;
  *   id: number,
  *   originalId: ?string,
  *   createSegmentIndex: shaka.extern.CreateSegmentIndexFunction,
+ *   closeSegmentIndex: (function()|undefined),
  *   segmentIndex: shaka.media.SegmentIndex,
  *   mimeType: string,
  *   codecs: string,
@@ -280,6 +281,9 @@ shaka.extern.CreateSegmentIndexFunction;
  * @property {shaka.extern.CreateSegmentIndexFunction} createSegmentIndex
  *   <i>Required.</i> <br>
  *   Creates the Stream's segmentIndex (asynchronously).
+ * @property {(function()|undefined)} closeSegmentIndex
+ *   <i>Optional.</i> <br>
+ *   Closes the Stream's segmentIndex.
  * @property {shaka.media.SegmentIndex} segmentIndex
  *   <i>Required.</i> <br>
  *   May be null until createSegmentIndex() is complete.

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -196,6 +196,9 @@ shaka.hls.HlsParser = class {
 
     /** @private {boolean} */
     this.lowLatencyMode_ = false;
+
+    // The min timestamp of the earliest segment in all streams.
+    this.minFirstTimestamp_ = Infinity;
   }
 
 
@@ -280,13 +283,17 @@ shaka.hls.HlsParser = class {
     // Reset the start time for the new media playlist.
     this.playlistStartTime_ = null;
     const streamInfos = Array.from(this.uriToStreamInfosMap_.values());
-    // Wait for the first stream info created, so that the start time is fetched
-    // and can be reused.
-    if (streamInfos.length) {
-      await this.updateStream_(streamInfos[0]);
+    const activeStreamInfos = streamInfos.filter((streamInfo) => {
+      return streamInfo.stream.segmentIndex != null;
+    });
+
+    // Wait for the first active stream info created, so that the start time is
+    // fetched and can be reused.
+    if (activeStreamInfos.length) {
+      await this.updateStream_(activeStreamInfos[0]);
     }
-    for (let i = 1; i < streamInfos.length; i++) {
-      updates.push(this.updateStream_(streamInfos[i]));
+    for (let i = 1; i < activeStreamInfos.length; i++) {
+      updates.push(this.updateStream_(activeStreamInfos[i]));
     }
 
     await Promise.all(updates);
@@ -334,14 +341,18 @@ shaka.hls.HlsParser = class {
         stream.mimeType, streamInfo.mediaSequenceToStartTime, mediaVariables,
         streamInfo.discontinuityToMediaSequence);
 
-    stream.segmentIndex.mergeAndEvict(
-        segments, this.presentationTimeline_.getSegmentAvailabilityStart());
+    if (stream.segmentIndex) {
+      stream.segmentIndex.mergeAndEvict(
+          segments, this.presentationTimeline_.getSegmentAvailabilityStart());
+    }
     if (segments.length) {
       const mediaSequenceNumber = shaka.hls.Utils.getFirstTagWithNameAsNumber(
           playlist.tags, 'EXT-X-MEDIA-SEQUENCE', 0);
       const playlistStartTime = streamInfo.mediaSequenceToStartTime.get(
           mediaSequenceNumber);
-      stream.segmentIndex.evict(playlistStartTime);
+      if (stream.segmentIndex) {
+        stream.segmentIndex.evict(playlistStartTime);
+      }
     }
     const newestSegment = segments[segments.length - 1];
     goog.asserts.assert(newestSegment, 'Should have segments!');
@@ -466,12 +477,11 @@ shaka.hls.HlsParser = class {
 
     // Find the min and max timestamp of the earliest segment in all streams.
     // Find the minimum duration of all streams as well.
-    let minFirstTimestamp = Infinity;
     let minDuration = Infinity;
 
     for (const streamInfo of this.uriToStreamInfosMap_.values()) {
-      minFirstTimestamp =
-          Math.min(minFirstTimestamp, streamInfo.minTimestamp);
+      this.minFirstTimestamp_ =
+          Math.min(this.minFirstTimestamp_, streamInfo.minTimestamp);
       if (streamInfo.stream.type != 'text') {
         minDuration = Math.min(minDuration,
             streamInfo.maxTimestamp - streamInfo.minTimestamp);
@@ -523,14 +533,16 @@ shaka.hls.HlsParser = class {
       // Use the minimum duration as the presentation duration.
       this.presentationTimeline_.setDuration(minDuration);
       // Use a negative offset to adjust towards 0.
-      this.presentationTimeline_.offset(-minFirstTimestamp);
+      this.presentationTimeline_.offset(-this.minFirstTimestamp_);
 
       for (const streamInfo of this.uriToStreamInfosMap_.values()) {
         // The segments were created with actual media times, rather than
         // presentation-aligned times, so offset them all now.
-        streamInfo.stream.segmentIndex.offset(-minFirstTimestamp);
-        // Finally, fit the segments to the playlist duration.
-        streamInfo.stream.segmentIndex.fit(/* periodStart= */ 0, minDuration);
+        if (streamInfo.stream.segmentIndex) {
+          streamInfo.stream.segmentIndex.offset(-this.minFirstTimestamp_);
+          // Finally, fit the segments to the playlist duration.
+          streamInfo.stream.segmentIndex.fit(/* periodStart= */ 0, minDuration);
+        }
       }
     }
 
@@ -1450,8 +1462,6 @@ shaka.hls.HlsParser = class {
 
     const minTimestamp = segments[0].startTime;
     const lastEndTime = segments[segments.length - 1].endTime;
-    /** @type {!shaka.media.SegmentIndex} */
-    const segmentIndex = new shaka.media.SegmentIndex(segments);
 
     const kind = (type == shaka.util.ManifestParserUtils.ContentType.TEXT) ?
         shaka.util.ManifestParserUtils.TextStreamKind.SUBTITLE : undefined;
@@ -1472,8 +1482,22 @@ shaka.hls.HlsParser = class {
     const stream = {
       id: this.globalId_++,
       originalId: name,
-      createSegmentIndex: () => Promise.resolve(),
-      segmentIndex,
+      createSegmentIndex: () => {
+        stream.segmentIndex = new shaka.media.SegmentIndex(segments);
+        if (!this.isLive_()) {
+          stream.segmentIndex.offset(-this.minFirstTimestamp_);
+          stream.segmentIndex.fit(/* periodStart= */ 0,
+              this.presentationTimeline_.getDuration());
+        }
+        return Promise.resolve();
+      },
+      closeSegmentIndex: () => {
+        if (stream.segmentIndex) {
+          stream.segmentIndex.release();
+          stream.segmentIndex = null;
+        }
+      },
+      segmentIndex: null,
       mimeType,
       codecs,
       kind,

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -431,6 +431,11 @@ shaka.media.StreamingEngine = class {
       this.playerInterface_.mediaSourceEngine.reinitText(fullMimeType);
     }
 
+    // Releases the segmentIndex of the old stream.
+    if (mediaState.stream.closeSegmentIndex) {
+      mediaState.stream.closeSegmentIndex();
+    }
+
     mediaState.stream = stream;
     mediaState.segmentIterator = null;
 
@@ -873,6 +878,12 @@ shaka.media.StreamingEngine = class {
         // We switched streams while in the middle of this async call to
         // createSegmentIndex.  Abandon this update and schedule a new one if
         // there's not already one pending.
+        // Releases the segmentIndex of the old stream.
+        if (mediaState.stream.closeSegmentIndex) {
+          goog.asserts.assert(!mediaState.stream.segmentIndex,
+              'mediastate.stream should not have segmentIndex yet.');
+          mediaState.stream.closeSegmentIndex();
+        }
         if (mediaState.updateTimer == null) {
           this.scheduleUpdate_(mediaState, 0);
         }

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -327,6 +327,8 @@ describe('HlsParser live', () => {
             .setResponseValue('test:/main.mp4', segmentData);
 
         const manifest = await parser.start('test:/master', playerInterface);
+        const video = manifest.variants[0].video;
+        await video.createSegmentIndex();
 
         expect(manifest.presentationTimeline.isLive()).toBe(true);
         fakeNetEngine
@@ -945,7 +947,9 @@ describe('HlsParser live', () => {
             .setResponseValue('test:/main3.mp4', segmentData);
 
         playerInterface.isLowLatencyMode = () => true;
-        await parser.start('test:/master', playerInterface);
+        const manifest = await parser.start('test:/master', playerInterface);
+        const video = manifest.variants[0].video;
+        await video.createSegmentIndex();
         // Replace the entries with the updated values.
 
         fakeNetEngine.request.calls.reset();


### PR DESCRIPTION
For HLS live manifest, we used to keep updating all the streams.
Instead, we can defer creating the segmentIndex of the streams until
StreamingEngine chooses the streams, and update only the streams that
have segment indexes. This would save bandwidth consumption during for
live streaming.

Issue #3363

Change-Id: Ic3e9509bd957fff911b013ebc9c39620798c5c62

## Description

Request to release this feature in version 3.2.x or 3.3.x we need this urgently.

<!--
  Give the PR a helpful title that summarizes what this PR changes. Here, include
  a summary of the change and which issue is fixed. Also, include relevant
  motivation and context. List any dependencies that are required for this
  change.

  If this fixes any issues, include lines like this:
  Fixes #123
-->

For HLS live manifest, we used to keep updating all the streams.
Instead, we can defer creating the segmentIndex of the streams until
StreamingEngine chooses the streams, and update only the streams that
have segment indexes. This would save bandwidth consumption during for
live streaming.

Issue #3363


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ x] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [ ] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [ ] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
