### PR TITLE
fix: Probe for containerless format support.

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -726,6 +726,9 @@ shakaDemo.Main = class {
     if (asset.features.includes(shakaAssets.Feature.MP2TS)) {
       mimeTypes.push('video/mp2t');
     }
+    if (asset.features.includes(shakaAssets.Feature.CONTAINERLESS)) {
+      mimeTypes.push('audio/aac');
+    }
     const hasSupportedMimeType = mimeTypes.some((type) => {
       return this.support_.media[type];
     });

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -18,6 +18,7 @@ goog.require('shaka.log');
 goog.require('shaka.media.DrmEngine');
 goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.ManifestParser');
+goog.require('shaka.media.MediaSourceEngine');
 goog.require('shaka.media.PresentationTimeline');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');
@@ -1442,9 +1443,7 @@ shaka.hls.HlsParser = class {
     }
 
     // MediaSource expects no codec strings combined with raw formats.
-    if (shaka.hls.HlsParser.RAW_FORMATS.includes(mimeType)) {
-      // TODO(#2337): Translate the raw codecs string to a corresponding
-      // containered version, so that audio-only raw format streams can work.
+    if (shaka.media.MediaSourceEngine.RAW_FORMATS.includes(mimeType)) {
       codecs = '';
     }
 
@@ -2409,19 +2408,6 @@ shaka.hls.HlsParser.AUDIO_EXTENSIONS_TO_MIME_TYPES_ = {
   'ec3': 'audio/ec3',
   'mp3': 'audio/mpeg',
 };
-
-
-/**
- * MIME types of raw formats.
- *
- * @const {!Array.<string>}
- */
-shaka.hls.HlsParser.RAW_FORMATS = [
-  'audio/aac',
-  'audio/ac3',
-  'audio/ec3',
-  'audio/mpeg',
-];
 
 
 /**

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -196,6 +196,8 @@ shaka.media.MediaSourceEngine = class {
       // TTML types
       'application/ttml+xml',
       'application/mp4; codecs="stpp"',
+      // Containerless types
+      ...shaka.media.MediaSourceEngine.RAW_FORMATS,
     ];
 
     const support = {};
@@ -1172,3 +1174,16 @@ shaka.media.MediaSourceEngine.SourceBufferMode_ = {
   SEQUENCE: 'sequence',
   SEGMENTS: 'segments',
 };
+
+
+/**
+ * MIME types of raw formats.
+ *
+ * @const {!Array.<string>}
+ */
+shaka.media.MediaSourceEngine.RAW_FORMATS = [
+  'audio/aac',
+  'audio/ac3',
+  'audio/ec3',
+  'audio/mpeg',
+];


### PR DESCRIPTION
Issue #2337

Change-Id: I909a1c09cac270cd4127a2ddd2ce5506d6ef0f35

## Description

We were not probing MediaSource for containerless format support before.
This meant that, among other things, the demo did not register the new raw AAC asset as playable.


## Screenshots (optional)

<!--
  If you change the UI, add before and after screenshots demonstrating your
  changes.
-->


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [ ] I have run `./build/test.py` and all tests pass
