### PR TITLE
Fix download of some HLS assets

### DIFF
--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -690,7 +690,7 @@ shaka.offline.Storage = class {
 
     // Filter the manifest based on what we know MediaCapabilities will be able
     // to play later (no point storing something we can't play).
-    StreamUtils.filterManifestByMediaCapabilities(
+    await StreamUtils.filterManifestByMediaCapabilities(
         manifest, config.offline.usePersistentLicense);
 
     // Gather all tracks.

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -681,16 +681,15 @@ shaka.offline.Storage = class {
    * @private
    */
   async filterManifest_(manifest, drmEngine, config) {
-    const StreamUtils = shaka.util.StreamUtils;
-
     // Filter the manifest based on the restrictions given in the player
     // configuration.
     const maxHwRes = {width: Infinity, height: Infinity};
-    StreamUtils.filterByRestrictions(manifest, config.restrictions, maxHwRes);
+    shaka.util.StreamUtils.filterByRestrictions(
+        manifest, config.restrictions, maxHwRes);
 
     // Filter the manifest based on what we know MediaCapabilities will be able
     // to play later (no point storing something we can't play).
-    await StreamUtils.filterManifestByMediaCapabilities(
+    await shaka.util.StreamUtils.filterManifestByMediaCapabilities(
         manifest, config.offline.usePersistentLicense);
 
     // Gather all tracks.
@@ -702,24 +701,24 @@ shaka.offline.Storage = class {
     const preferredVideoCodecs = config.preferredVideoCodecs;
     const preferredAudioCodecs = config.preferredAudioCodecs;
 
-    StreamUtils.chooseCodecsAndFilterManifest(
+    shaka.util.StreamUtils.chooseCodecsAndFilterManifest(
         manifest, preferredVideoCodecs, preferredAudioCodecs,
         preferredAudioChannelCount, preferredDecodingAttributes);
 
     for (const variant of manifest.variants) {
       goog.asserts.assert(
-          StreamUtils.isPlayable(variant),
+          shaka.util.StreamUtils.isPlayable(variant),
           'We should have already filtered by "is playable"');
 
-      allTracks.push(StreamUtils.variantToTrack(variant));
+      allTracks.push(shaka.util.StreamUtils.variantToTrack(variant));
     }
 
     for (const text of manifest.textStreams) {
-      allTracks.push(StreamUtils.textStreamToTrack(text));
+      allTracks.push(shaka.util.StreamUtils.textStreamToTrack(text));
     }
 
     for (const image of manifest.imageStreams) {
-      allTracks.push(StreamUtils.imageStreamToTrack(image));
+      allTracks.push(shaka.util.StreamUtils.imageStreamToTrack(image));
     }
 
     // Let the application choose which tracks to store.


### PR DESCRIPTION
Fix download of https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8

The filterManifestByMediaCapabilities method is async, but the code doesn't wait for it to finish before continuing the download process. This PR fix it.