### PR TITLE
test: Fix flaky player integration test

### DIFF
--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -445,8 +445,8 @@ describe('Player', () => {
 
       // Seek the video, and see if it can continue playing from that point.
       video.currentTime = 20;
-      await waiter.waitUntilPlayheadReachesOrFailOnTimeout(video, 30, 20);
-      expect(video.ended).toBe(true);
+      // Expect that we can then reach the end of the video.
+      await waiter.timeoutAfter(20).waitForEnd(video);
     });
 
     // Regression test for #2326.


### PR DESCRIPTION
Instead of waiting for the playhead to reach a specific time that we
know to be the end, then expecting ended to be true, we can use the
purpose-built waiter that waits for the ended event.

We also need to set the timeout explicitly, so that we have enough
time to play through to the end.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
