### PR TITLE
ci: Fix ffmpeg install failure for Linux+Firefox

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -55,7 +55,7 @@ jobs:
       # tests assume will be supported.
       - name: Install FFmpeg
         if: matrix.os == 'ubuntu-latest' && matrix.browser == 'Firefox'
-        run: sudo apt -y install ffmpeg
+        run: sudo apt -y update && sudo apt -y install ffmpeg
 
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
CI for Firefox on Linux is failing because of (I suspect) an outdated
package index in Ubuntu.  This addresses it by updating the package
list before installing ffmpeg.
