### PR TITLE
fix: Add explicit release() for FakeEventTarget

### DIFF
--- a/lib/ads/ad_manager.js
+++ b/lib/ads/ad_manager.js
@@ -448,6 +448,7 @@ shaka.ads.AdManager = class extends shaka.util.FakeEventTarget {
       this.ssAdManager_.release();
       this.ssAdManager_ = null;
     }
+    super.release();
   }
 
 

--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -120,6 +120,9 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
     this.videoProxy_ = null;
     this.playerProxy_ = null;
 
+    // FakeEventTarget implements IReleasable
+    super.release();
+
     return Promise.all(waitFor);
   }
 

--- a/lib/cast/cast_receiver.js
+++ b/lib/cast/cast_receiver.js
@@ -238,6 +238,9 @@ shaka.cast.CastReceiver = class extends shaka.util.FakeEventTarget {
     this.shakaBus_ = null;
     this.genericBus_ = null;
 
+    // FakeEventTarget implements IReleasable
+    super.release();
+
     await Promise.all(waitFor);
 
     const manager = cast.receiver.CastReceiverManager.getInstance();

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -232,6 +232,10 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     this.destroyed_ = true;
     this.requestFilters_.clear();
     this.responseFilters_.clear();
+
+    // FakeEventTarget implements IReleasable
+    super.release();
+
     return this.operationManager_.destroy();
   }
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -787,6 +787,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       await this.networkingEngine_.destroy();
       this.networkingEngine_ = null;
     }
+
+    // FakeEventTarget implements IReleasable
+    super.release();
   }
 
   /**

--- a/lib/util/fake_event_target.js
+++ b/lib/util/fake_event_target.js
@@ -9,6 +9,7 @@ goog.provide('shaka.util.FakeEventTarget');
 goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.util.FakeEvent');
+goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.MultiMap');
 
 
@@ -18,13 +19,14 @@ goog.require('shaka.util.MultiMap');
  * to non-DOM classes.  Only FakeEvents should be dispatched.
  *
  * @implements {EventTarget}
+ * @implements {shaka.util.IReleasable}
  * @exportInterface
  */
 shaka.util.FakeEventTarget = class {
   /** */
   constructor() {
     /**
-     * @private {!shaka.util.MultiMap.<shaka.util.FakeEventTarget.ListenerType>}
+     * @private {shaka.util.MultiMap.<shaka.util.FakeEventTarget.ListenerType>}
      */
     this.listeners_ = new shaka.util.MultiMap();
 
@@ -46,6 +48,9 @@ shaka.util.FakeEventTarget = class {
    * @exportInterface
    */
   addEventListener(type, listener, options) {
+    if (!this.listeners_) {
+      return;
+    }
     this.listeners_.push(type, listener);
   }
 
@@ -73,6 +78,9 @@ shaka.util.FakeEventTarget = class {
    * @exportInterface
    */
   removeEventListener(type, listener, options) {
+    if (!this.listeners_) {
+      return;
+    }
     this.listeners_.remove(type, listener);
   }
 
@@ -89,6 +97,10 @@ shaka.util.FakeEventTarget = class {
     // Here we expect only to dispatch FakeEvents, which are simpler.
     goog.asserts.assert(event instanceof shaka.util.FakeEvent,
         'FakeEventTarget can only dispatch FakeEvents!');
+
+    if (!this.listeners_) {
+      return true;
+    }
 
     let listeners = this.listeners_.get(event.type) || [];
     const universalListeners =
@@ -128,6 +140,14 @@ shaka.util.FakeEventTarget = class {
     }
 
     return event.defaultPrevented;
+  }
+
+  /**
+   * @override
+   * @exportInterface
+   */
+  release() {
+    this.listeners_ = null;
   }
 };
 

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -254,6 +254,9 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
 
     this.localization_ = null;
     this.pressedKeys_.clear();
+
+    // FakeEventTarget implements IReleasable
+    super.release();
   }
 
 


### PR DESCRIPTION
## Description

Before, we would count on all event listeners for FakeEventTargets to
be cleaned up by the object that listens.  Now, FakeEventTarget
implements IReleasable, so that all listeners are removed when owners
call release().

For objects extending FakeEventTarget and also implementing
IDestroyable, the destroy() methods will call out to super.release()
to clean up listeners then.  The owner should use destroy() in those
cases.

Issue #3949 (memory leak in DASH live streams with inband EventStream)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] I have signed the Google CLA <https://cla.developers.google.com>
- [x] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have verified my change on multiple browsers on different platforms
- [x] I have run `./build/all.py` and the build passes
- [x] I have run `./build/test.py` and all tests pass
