### PR TITLE
fix(text): Fix webvtt offset in sequence mode

### DIFF
--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -426,6 +426,13 @@ shaka.extern.TextParser = class {
    * @exportDoc
    */
   parseMedia(data, timeContext) {}
+
+  /**
+   * Notifies the stream if the manifest is in sequence mode or not.
+   *
+   * @param {boolean} sequenceMode
+   */
+  setSequenceMode(sequenceMode) {}
 };
 
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -332,7 +332,7 @@ shaka.media.MediaSourceEngine = class {
       let mimeType = shaka.util.MimeUtils.getFullType(
           stream.mimeType, stream.codecs);
       if (contentType == ContentType.TEXT) {
-        this.reinitText(mimeType);
+        this.reinitText(mimeType, sequenceMode);
       } else {
         if ((forceTransmuxTS || !MediaSource.isTypeSupported(mimeType)) &&
             shaka.media.Transmuxer.isSupported(mimeType, contentType)) {
@@ -361,12 +361,13 @@ shaka.media.MediaSourceEngine = class {
   /**
    * Reinitialize the TextEngine for a new text type.
    * @param {string} mimeType
+   * @param {boolean} sequenceMode
    */
-  reinitText(mimeType) {
+  reinitText(mimeType, sequenceMode) {
     if (!this.textEngine_) {
       this.textEngine_ = new shaka.text.TextEngine(this.textDisplayer_);
     }
-    this.textEngine_.initParser(mimeType);
+    this.textEngine_.initParser(mimeType, sequenceMode);
   }
 
   /**
@@ -535,7 +536,7 @@ shaka.media.MediaSourceEngine = class {
       // For HLS CEA-608/708 CLOSED-CAPTIONS, text data is embedded in
       // the video stream, so textEngine may not have been initialized.
       if (!this.textEngine_) {
-        this.reinitText('text/vtt');
+        this.reinitText('text/vtt', sequenceMode || false);
       }
 
       if (transmuxedData.metadata) {
@@ -562,7 +563,7 @@ shaka.media.MediaSourceEngine = class {
           contentType, () => this.append_(contentType, transmuxedSegment));
     } else if (hasClosedCaptions) {
       if (!this.textEngine_) {
-        this.reinitText('text/vtt');
+        this.reinitText('text/vtt', sequenceMode || false);
       }
       // If it is the init segment for closed captions, initialize the closed
       // caption parser.

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -234,7 +234,8 @@ shaka.media.StreamingEngine = class {
 
     const mimeType = shaka.util.MimeUtils.getFullType(
         stream.mimeType, stream.codecs);
-    this.playerInterface_.mediaSourceEngine.reinitText(mimeType);
+    this.playerInterface_.mediaSourceEngine.reinitText(
+        mimeType, this.manifest_.sequenceMode);
 
     const textDisplayer =
         this.playerInterface_.mediaSourceEngine.getTextDisplayer();
@@ -428,7 +429,8 @@ shaka.media.StreamingEngine = class {
       // init segment again.
       const fullMimeType = shaka.util.MimeUtils.getFullType(
           stream.mimeType, stream.codecs);
-      this.playerInterface_.mediaSourceEngine.reinitText(fullMimeType);
+      this.playerInterface_.mediaSourceEngine.reinitText(
+          fullMimeType, this.manifest_.sequenceMode);
     }
 
     // Releases the segmentIndex of the old stream.

--- a/lib/text/lrc_text_parser.js
+++ b/lib/text/lrc_text_parser.js
@@ -32,6 +32,14 @@ shaka.text.LrcTextParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const StringUtils = shaka.util.StringUtils;
     const LrcTextParser = shaka.text.LrcTextParser;

--- a/lib/text/mp4_ttml_parser.js
+++ b/lib/text/mp4_ttml_parser.js
@@ -59,6 +59,14 @@ shaka.text.Mp4TtmlParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const Mp4Parser = shaka.util.Mp4Parser;
 

--- a/lib/text/mp4_vtt_parser.js
+++ b/lib/text/mp4_vtt_parser.js
@@ -88,6 +88,14 @@ shaka.text.Mp4VttParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     if (!this.timescale_) {
       // Missing timescale for VTT content. We should have seen the init

--- a/lib/text/sbv_text_parser.js
+++ b/lib/text/sbv_text_parser.js
@@ -31,6 +31,14 @@ shaka.text.SbvTextParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const SbvTextParser = shaka.text.SbvTextParser;
     const StringUtils = shaka.util.StringUtils;

--- a/lib/text/srt_text_parser.js
+++ b/lib/text/srt_text_parser.js
@@ -39,6 +39,14 @@ shaka.text.SrtTextParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const SrtTextParser = shaka.text.SrtTextParser;
     const BufferUtils = shaka.util.BufferUtils;

--- a/lib/text/ssa_text_parser.js
+++ b/lib/text/ssa_text_parser.js
@@ -32,6 +32,14 @@ shaka.text.SsaTextParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const StringUtils = shaka.util.StringUtils;
     const SsaTextParser = shaka.text.SsaTextParser;

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -7,6 +7,7 @@
 goog.provide('shaka.text.TextEngine');
 
 goog.require('goog.asserts');
+goog.require('shaka.log');
 goog.require('shaka.text.Cue');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Functional');
@@ -128,8 +129,9 @@ shaka.text.TextEngine = class {
    * called at least once before appendBuffer.
    *
    * @param {string} mimeType
+   * @param {boolean} sequenceMode
    */
-  initParser(mimeType) {
+  initParser(mimeType, sequenceMode) {
     // No parser for CEA, which is extracted from video and side-loaded
     // into TextEngine and TextDisplayer.
     if (mimeType == shaka.util.MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE ||
@@ -141,6 +143,12 @@ shaka.text.TextEngine = class {
     goog.asserts.assert(
         factory, 'Text type negotiation should have happened already');
     this.parser_ = shaka.util.Functional.callFactory(factory);
+    if (this.parser_.setSequenceMode) {
+      this.parser_.setSequenceMode(sequenceMode);
+    } else {
+      shaka.log.alwaysWarn(
+          'Text parsers should have a "setSequenceMode" method!');
+    }
   }
 
   /**

--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -34,6 +34,14 @@ shaka.text.TtmlTextParser = class {
    * @override
    * @export
    */
+  setSequenceMode(sequenceMode) {
+    // Unused.
+  }
+
+  /**
+   * @override
+   * @export
+   */
   parseMedia(data, time) {
     const TtmlTextParser = shaka.text.TtmlTextParser;
     const XmlUtils = shaka.util.XmlUtils;

--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -22,12 +22,26 @@ goog.require('shaka.util.XmlUtils');
  * @export
  */
 shaka.text.VttTextParser = class {
+  /** Constructs a VTT parser. */
+  constructor() {
+    /** @private {boolean} */
+    this.sequenceMode_ = false;
+  }
+
   /**
    * @override
    * @export
    */
   parseInit(data) {
     goog.asserts.assert(false, 'VTT does not have init segments');
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  setSequenceMode(sequenceMode) {
+    this.sequenceMode_ = sequenceMode;
   }
 
   /**
@@ -52,7 +66,11 @@ shaka.text.VttTextParser = class {
     // It is no longer closely tied to periods, but the name stuck around.
     let offset = time.periodStart;
 
-    if (blocks[0].includes('X-TIMESTAMP-MAP')) {
+    // Do not honor the 'X-TIMESTAMP-MAP' value when in sequence mode.
+    // That is because it is used mainly (solely?) to account for the timestamp
+    // offset of the video/audio; when in sequence mode, we normalize that
+    // timestamp offset to 0, so we should not account for it.
+    if (blocks[0].includes('X-TIMESTAMP-MAP') && !this.sequenceMode_) {
       // https://bit.ly/2K92l7y
       // The 'X-TIMESTAMP-MAP' header is used in HLS to align text with
       // the rest of the media.

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -1120,7 +1120,7 @@ describe('MediaSourceEngine', () => {
     });
 
     it('destroys text engines', async () => {
-      mediaSourceEngine.reinitText('text/vtt');
+      mediaSourceEngine.reinitText('text/vtt', false);
 
       await mediaSourceEngine.destroy();
       expect(mockTextEngine).toBeTruthy();

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -25,6 +25,9 @@ describe('TextEngine', () => {
   let mockParseInit;
 
   /** @type {!jasmine.Spy} */
+  let mockSetSequenceMode;
+
+  /** @type {!jasmine.Spy} */
   let mockParseMedia;
 
   /** @type {!shaka.text.TextEngine} */
@@ -32,11 +35,13 @@ describe('TextEngine', () => {
 
   beforeEach(() => {
     mockParseInit = jasmine.createSpy('mockParseInit');
+    mockSetSequenceMode = jasmine.createSpy('mockSetSequenceMode');
     mockParseMedia = jasmine.createSpy('mockParseMedia');
     // eslint-disable-next-line no-restricted-syntax
     mockParserPlugIn = function() {
       return {
         parseInit: mockParseInit,
+        setSequenceMode: mockSetSequenceMode,
         parseMedia: mockParseMedia,
       };
     };
@@ -46,7 +51,7 @@ describe('TextEngine', () => {
 
     TextEngine.registerParser(dummyMimeType, mockParserPlugIn);
     textEngine = new TextEngine(mockDisplayer);
-    textEngine.initParser(dummyMimeType);
+    textEngine.initParser(dummyMimeType, false);
   });
 
   afterEach(() => {


### PR DESCRIPTION
When running in sequence mode, we ignore the normal timestamps
of video and audio segments. This lead to problems in some Apple-
encoded webvtt content, which used the X-TIMESTAMP-MAP tag to account
for the timestamp offsets in their video. Thus, those subtitles would
end up 10 seconds offset.
This changes the webvtt parser to ignore the X-TIMESTAMP-MAP when in
sequence mode.

Issue #2337

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] I have signed the Google CLA <https://cla.developers.google.com>
- [X] My code follows the style guidelines of this project
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have verified my change on multiple browsers on different platforms
- [X] I have run `./build/all.py` and the build passes
- [X] I have run `./build/test.py` and all tests pass
