### PR TITLE
ci: Expand PR test triggers

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -2,7 +2,7 @@ name: Build and Test PR
 
 on:
   pull_request: # Trigger for pull requests.
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
     branches:
       - master
       - v[0-9]*

--- a/.github/workflows/validate_pr_title.yaml
+++ b/.github/workflows/validate_pr_title.yaml
@@ -1,18 +1,8 @@
 name: "Validate PR Title"
 
 on:
-  # NOTE: Force-pushes from automated PRs (like release-please) do not seem to
-  # trigger any of the normal PR triggers (opened, edited, synchronize).  In
-  # fact, even an exhaustive list of types will not work.  So here we add
-  # triggers for reviews, so that the validation will run after someone
-  # approves such a PR.  This is critical since this is a required status check
-  # in most of our repos.  If it doesn't run, the PR can't be merged.
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-  pull_request_review:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   main:


### PR DESCRIPTION
I found that the auto-release PRs don't trigger tests for some reason.
This makes it so that we don't get the required "validate PR title"
run, and we also don't get automated test passes against release
candidates.

This replaces the PR triggers for both workflows with a set that
includes "edited" and "ready_for_review".  Now any PR that doesn't get
properly tested can have tests triggered by either editing the body or
taking it in and out of draft mode.
