### PR TITLE
feat!(hls): HLS disabled in old browsers/platforms due to incompatibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ DASH features **not** supported:
 
 ## HLS features
 
+**Only supported on browsers with SourceBuffer.mode=sequence support**
+
 HLS features supported:
  - VOD, Live, and Event types
  - Low-latency streaming with partial segments, preload hints, and delta updates

--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2497,10 +2497,13 @@ shaka.hls.HlsParser.PresentationType_ = {
   LIVE: 'LIVE',
 };
 
-
-shaka.media.ManifestParser.registerParserByExtension(
-    'm3u8', () => new shaka.hls.HlsParser());
-shaka.media.ManifestParser.registerParserByMime(
-    'application/x-mpegurl', () => new shaka.hls.HlsParser());
-shaka.media.ManifestParser.registerParserByMime(
-    'application/vnd.apple.mpegurl', () => new shaka.hls.HlsParser());
+if (!shaka.util.Platform.isTizen3() &&
+    !shaka.util.Platform.isTizen2() &&
+    !shaka.util.Platform.isWebOS3()) {
+  shaka.media.ManifestParser.registerParserByExtension(
+      'm3u8', () => new shaka.hls.HlsParser());
+  shaka.media.ManifestParser.registerParserByMime(
+      'application/x-mpegurl', () => new shaka.hls.HlsParser());
+  shaka.media.ManifestParser.registerParserByMime(
+      'application/vnd.apple.mpegurl', () => new shaka.hls.HlsParser());
+}

--- a/lib/util/platform.js
+++ b/lib/util/platform.js
@@ -143,6 +143,18 @@ shaka.util.Platform = class {
   }
 
   /**
+   * Check if the current platform is a WebOS 3.
+   *
+   * @return {boolean}
+   */
+  static isWebOS3() {
+    // See: http://webostv.developer.lge.com/discover/specifications/web-engine/
+    return shaka.util.Platform.userAgentContains_('Web0S') &&
+        shaka.util.Platform.userAgentContains_(
+            'Chrome/38.0.2125.122 Safari/537.36');
+  }
+
+  /**
    * Check if the current platform is a Google Chromecast.
    *
    * @return {boolean}


### PR DESCRIPTION
In Tizen 2/3 and WebOS 3.x there is no support for SourceBuffer.mode=sequence so as a result of change https://github.com/google/shaka-player/issues/2337, it necessary disable support for the HLS parser so that the user can at least use the native one with src= .