### PR TITLE
build: Update version parsing to match new release automation

### DIFF
--- a/build/checkversion.py
+++ b/build/checkversion.py
@@ -37,7 +37,7 @@ def changelog_version():
   """Gets the version of the library from the CHANGELOG."""
   path = os.path.join(shakaBuildHelpers.get_source_base(), 'CHANGELOG.md')
   with shakaBuildHelpers.open_file(path, 'r') as f:
-    match = re.search(r'## (.*) \(', f.read())
+    match = re.search(r'^###? \[(.*?)\]\(', f.read(), re.MULTILINE)
     return match.group(1) if match else ''
 
 


### PR DESCRIPTION
We double-check the version in the changelog to make sure it matches
the npm and player versions.  But with our new release automation, we
have a new changelog format.  This updates the parsing so that release
checks can succeed.