### PR TITLE
ci: Fix several release workflow bugs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,9 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       # Create/update release PR
-      - uses: google-github-actions/release-please-action@v3
+      # TODO: Switch back to upstream release after this fix is available:
+      # https://github.com/google-github-actions/release-please-action/pull/444
+      - uses: joeyparrish/release-please-action@1c11660970e1ddbdc40c040b5f65453e5ab08d8f
         id: release
         with:
           # Without this command, the manifest file will be ignored.  At least
@@ -28,8 +30,45 @@ jobs:
           # Make sure we create the PR against the correct branch.
           default-branch: ${{ github.ref_name }}
 
+      # If we didn't create a release, we may have created or updated a PR.
+      - uses: actions/checkout@v2
+        if: ${{ ! steps.release.outputs.release_created }}
+      - name: Custom update Player version
+        if: ${{ ! steps.release.outputs.release_created }}
+        run: |
+          # Check out the branch that release-please created, if it exists.
+          git fetch
+          git checkout release-please--branches--${{ github.ref_name }} || exit 0
+          # If it does exist, update lib/player.js in the PR branch, so that the
+          # -uncompiled tag remains in the player version in that context.
+          VERSION="v$(jq -r .version package.json)-uncompiled"
+          sed -e "s/^\\(shaka.Player.version =\\).*/\\1 '$VERSION';/" \
+              -i lib/player.js
+          git add lib/player.js
+          # Emulate the actions bot.
+          git config user.email "github-actions[bot]"
+          git config user.name "41898282+github-actions[bot]@users.noreply.github.com"
+          # Update the PR.
+          git commit --amend --no-edit
+          git push -f
+
   # The jobs below are all conditional on a release having been created by
   # someone merging the release PR.  They all run in parallel.
+
+  tag-master:
+    runs-on: ubuntu-latest
+    needs: release
+    if: ${{ needs.release.outputs.release_created }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Tag the master branch
+        run: |
+          # Emulate the actions bot.
+          git config user.email "github-actions[bot]"
+          git config user.name "41898282+github-actions[bot]@users.noreply.github.com"
+          VERSION=${{ needs.release.outputs.tag_name }}
+          git tag -m "$VERSION-master" "$VERSION-master"
+          git push origin "$VERSION-master"
 
   npm:
     runs-on: ubuntu-latest
@@ -39,8 +78,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
+      # Without this, git describe won't work in the npm prepublish steps
+      - run: git fetch --unshallow
       - run: npm ci
       - run: npm publish
         env:


### PR DESCRIPTION
1. When release-please creates release PRs, it removes the -uncompiled
tag in the version number in lib/player.js.  This adds a step to the
workflow to maintain the player.js version manually.

2. This also adds a new job that tags the master branch after a
release PR is merged.  We maintain the -master tags on the master
branch corresponding to each release so that it is easier to manage
the range of commits for cherry-picks.

3. The "npm ci" step was failing because our package-lock.json was not
compatible with v12 of NodeJS.  This updates our workflow to use v16.
The npm release workflow has now been tested in a fork up until the
publish step.

4. The tagging and GitHub release publication parts of the workflow
were previously failing due to an issue with release-please parsing
the branch name.  This has now been fixed, and is awaiting an upstream
merge.  For now, we can use my forked version.

Closes #3968 (branch parsing failure)
Issue #3969 (npm release is now tested up to the publish step)
Closes #3971 (master branch tags)
Closes #3974 (missing -uncompiled in lib/player.js)