### PR TITLE
ci: Simplify PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,10 @@
-## Description
-
 <!--
-  Give the PR a helpful title that summaries what this PR changes. Here, include
-  a summary of the change and which issue is fixed. Also include relevant
-  motivation and context. List any dependencies that are required for this
-  change.
+Please remember to:
 
-  If this fixes any issues, include lines like this:
-  Fixes #123
+1. Use Conventional Commits syntax (fix: ..., feat: ..., etc.) in commits and
+   PR title (https://www.conventionalcommits.org/)
+2. Tag any related or fixed issues ("Issue #123", "Closes #420")
+3. Sign the Google CLA if you haven't (https://cla.developers.google.com)
+
+You may delete this comment from the PR description.
 -->
-
-
-## Screenshots (optional)
-
-<!--
-  If you change the UI, add before and after screenshots demonstrating your
-  changes.
--->
-
-
-## Type of change
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to
-  not work as expected)
-- [ ] This change requires a documentation update
-
-## Checklist:
-
-- [ ] I have signed the Google CLA <https://cla.developers.google.com>
-- [ ] My code follows the style guidelines of this project
-- [ ] I have made corresponding changes to the documentation
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have verified my change on multiple browsers on different platforms
-- [ ] I have run `./build/all.py` and the build passes
-- [ ] I have run `./build/test.py` and all tests pass


### PR DESCRIPTION
The old template is bulky and does not reflect the new workflows we
have on GitHub.  All that is really critical is that users start using
Conventional Commits syntax and tag issue numbers.