### PR TITLE
fix(Ads): Limit interstitial duration to actual duration if available

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -676,7 +676,8 @@ shaka.ads.InterstitialAdManager = class {
     try {
       this.updatePlayerConfig_();
       // playRangeEnd in src= causes the ended event not to be fired when that
-      // position is reached.
+      // position is reached. So we don't use it because we would never go back
+      // to the main stream.
       const loadMode = this.basePlayer_.getLoadMode();
       if (loadMode == shaka.Player.LoadMode.MEDIA_SOURCE &&
           interstitial.startTime && interstitial.endTime &&


### PR DESCRIPTION
Currently, if the interstitial lasts 30 and we have a stream that lasts 31 seconds, we would go back to live after the interstitial, but with 1 extra second of latency.  This PR solves this by limiting the play range to 30.