### PR TITLE
chore: Remove old code that is no longer needed

### DIFF
--- a/lib/media/segment_utils.js
+++ b/lib/media/segment_utils.js
@@ -168,29 +168,6 @@ shaka.media.SegmentUtils = class {
     const addCodec = (codec) => {
       const codecLC = codec.toLowerCase();
       switch (codecLC) {
-        case 'avc1':
-        case 'avc3':
-          videoCodecs.push(codecLC + '.42E01E');
-          hasVideo = true;
-          break;
-        case 'hev1':
-        case 'hvc1':
-          videoCodecs.push(codecLC + '.1.6.L93.90');
-          hasVideo = true;
-          break;
-        case 'dvh1':
-        case 'dvhe':
-          videoCodecs.push(codecLC + '.05.04');
-          hasVideo = true;
-          break;
-        case 'vp09':
-          videoCodecs.push(codecLC + '.00.10.08');
-          hasVideo = true;
-          break;
-        case 'av01':
-          videoCodecs.push(codecLC + '.0.01M.08');
-          hasVideo = true;
-          break;
         case 'mp4a':
           // We assume AAC, but this can be wrong since mp4a supports
           // others codecs


### PR DESCRIPTION
The exact codec is now calculated with the boxes directly, so we have not used generics for several releases.