### PR TITLE
fix: Call modifyCueCallback in src= mode

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -35,6 +35,7 @@ goog.require('shaka.media.StreamingEngine');
 goog.require('shaka.media.TimeRangesUtils');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.net.NetworkingUtils');
+goog.require('shaka.text.Cue');
 goog.require('shaka.text.SimpleTextDisplayer');
 goog.require('shaka.text.StubTextDisplayer');
 goog.require('shaka.text.TextEngine');
@@ -5421,22 +5422,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const removeEnd = Math.max(0,
           this.video_.currentTime - this.config_.streaming.bufferBehind);
       this.textDisplayer_.remove(0, removeEnd);
-      const cues = Array.from(track.activeCues || [])
-          .map(shaka.text.Utils.mapNativeCueToShakaCue)
-          .filter(shaka.util.Functional.isNotNull);
       const time = {
         periodStart: 0,
         segmentStart: 0,
         segmentEnd: this.video_.duration,
         vttOffset: 0,
       };
-      for (const cue of cues) {
-        if (!cue) {
-          continue;
+      /** @type {!Array<shaka.text.Cue>} */
+      const allCues = [];
+      const nativeCues = Array.from(track.activeCues || []);
+      for (const nativeCue of nativeCues) {
+        const cue = shaka.text.Utils.mapNativeCueToShakaCue(nativeCue);
+        if (cue) {
+          this.config_.mediaSource.modifyCueCallback(cue, null, time);
+          allCues.push(cue);
         }
-        this.config_.mediaSource.modifyCueCallback(cue, null, time);
       }
-      this.textDisplayer_.append(cues);
+      this.textDisplayer_.append(allCues);
     });
     track.mode = document.pictureInPictureElement ? 'showing' : 'hidden';
   }


### PR DESCRIPTION
`modifyCueCallback` is not getting called in `src=` mode. I'm not sure whether this belongs in the `mediaSource` config, but changing that would be a breaking change. I'm calling the method on each `cuechange` event.

This is similar to what `TextEngine` does:

https://github.com/shaka-project/shaka-player/blob/de4bb9e8a80d3cf9f51947f55b295b87a36498f9/lib/text/text_engine.js#L212-L222