### PR TITLE
fix: Detect and skip stall correctly

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -319,7 +319,7 @@ shaka.media.GapJumpingController = class {
         this.video_.currentTime += skip;
       } else {
         shaka.log.debug(
-            'Awaiting for play in order to avoid reject ongoing play.');
+            'Wait for play to avoid reject a possible other play call.');
         await this.video_.play();
         if (!this.video_) {
           return;


### PR DESCRIPTION
Fixes `play() request was interrupted` errors in test runs on certain devices like GTV Streamer.