### PR TITLE
fix: Allow change NativeTextDisplayer on runtime

### DIFF
--- a/lib/text/native_text_displayer.js
+++ b/lib/text/native_text_displayer.js
@@ -187,6 +187,8 @@ shaka.text.NativeTextDisplayer = class {
 
     this.eventManager_.listen(player, shaka.util.FakeEvent.EventName.Loaded,
         () => this.enableTextDisplayer());
+
+    this.enableTextDisplayer();
   }
 
   /**


### PR DESCRIPTION
This is required to be able to switch at runtime from UITextDisplayer to NativeTextDisplayer and allow subtitles to be displayed correctly.