### PR TITLE
fix: Bail out on other decodingInfos when we found a preferred and supported one.

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -742,7 +742,7 @@ shaka.util.StreamUtils = class {
           await shaka.util.StreamUtils.getDecodingInfosForVariant_(
               variant, configs);
         }
-        if (variant.decodingInfos.some(d => d.supported)) {
+        if (variant.decodingInfos.some((d) => d.supported)) {
           keySystemSatisfied = true;
         }
       } // for (const variant of variants)


### PR DESCRIPTION
Pick a multi DRM asset, set `preferredKeySystems` to prefer PlayReady over Widevine and run on a device that does not support PlayReady (eg; Chrome).

A `REQUESTED_KEY_SYSTEM_CONFIG_UNAVAILABLE` is thrown.

This is due to the logic in `getDecodingInfosForVariants` where we bail out on probing other decodingInfos when we found a prefered one, but we didn't check whether it was supported or not. As a result, Widevine was never checked and PlayReady was left marked as unsupported.