### PR TITLE
chore: Remove redundant EMSG event

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1015,13 +1015,6 @@ shaka.media.MediaSourceEngine = class {
           messageData: messageData,
         };
 
-        // Dispatch an event to notify the application about the emsg box.
-        const eventName = shaka.util.FakeEvent.EventName.Emsg;
-        const data = (new Map()).set('detail', emsg);
-        const event = new shaka.util.FakeEvent(eventName, data);
-        // A user can call preventDefault() on a cancelable event.
-        event.cancelable = true;
-
         this.playerInterface_.onEmsg(emsg);
 
         // Additionally, ID3 events generate a 'metadata' event.  This is a


### PR DESCRIPTION
This event is a leftover and it's not needed since we are using RegionTimeline now for managing EMSG events. Additionally, it wasn't even fired, just being created and questioning its own existence.