### PR TITLE
perf(DRM): Run expiration timer only when EME is in use

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -228,7 +228,7 @@ shaka.drm.DrmEngine = class {
     if (isPreload) {
       this.isPreload_ = isPreload;
     }
-    if (this.expirationTimer_) {
+    if (this.expirationTimer_ && this.initialized_ && this.currentDrmInfo_) {
       this.expirationTimer_.tickEvery(
           /* seconds= */ this.config_.updateExpirationTime);
     }
@@ -1012,6 +1012,9 @@ shaka.drm.DrmEngine = class {
         }
       }
       this.initialized_ = true;
+
+      this.expirationTimer_.tickEvery(
+          /* seconds= */ this.config_.updateExpirationTime);
 
       await this.setServerCertificate();
       this.destroyer_.ensureNotDestroyed();


### PR DESCRIPTION
There is no need to poll expiration if content is not encrypted or EME is not initialized yet.