### PR TITLE
fix(DASH): Fix segmentSequenceCadence default value

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2756,7 +2756,7 @@ shaka.dash.DashParser = class {
       numChannels: null,
       audioSamplingRate: null,
       availabilityTimeOffset: 0,
-      segmentSequenceCadence: 0,
+      segmentSequenceCadence: 1,
       encrypted: false,
     });
     getBaseUris = getBaseUris || parent.getBaseUris;


### PR DESCRIPTION
According to the latest draft of DASH 6th edition, the default value is 1, not 0.