### PR TITLE
test: Disable ChromecastGTV in the lab

### DIFF
--- a/build/shaka-lab.yaml
+++ b/build/shaka-lab.yaml
@@ -239,6 +239,9 @@ ChromecastUltra:
 ChromecastGTV:
   browser: chromecast
   version: GTV
+  # Currently broken in some unknown manner.  Joey is trying to fix and/or
+  # replace it.
+  disabled: true
 
 ChromecastHub:
   browser: chromecast


### PR DESCRIPTION
This device appears to be broken.  It may need to be replaced.