### PR TITLE
chore: Fix Java version in one last appspot workflow

### DIFF
--- a/.github/workflows/github-pages-nightly-demo.yaml
+++ b/.github/workflows/github-pages-nightly-demo.yaml
@@ -26,6 +26,11 @@ jobs:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 21
+
       - name: Install dependencies
         shell: bash
         run: npm ci


### PR DESCRIPTION
This one used "npm run build" instead of "build/...py", so it didn't come up in my first search.