### PR TITLE
test: Disable multi type variants test on some devices

### DIFF
--- a/test/dash/dash_parser_integration.js
+++ b/test/dash/dash_parser_integration.js
@@ -101,6 +101,15 @@ describe('DashParser', () => {
   });
 
   it('support multi type variants', async () => {
+    const DeviceType = shaka.device.IDevice.DeviceType;
+    if (deviceDetected.getDeviceType() === DeviceType.TV &&
+            deviceDetected.getDeviceName() === 'Tizen') {
+      pending('Disabled on Tizen.');
+    }
+    const BrowserEngine = shaka.device.IDevice.BrowserEngine;
+    if (deviceDetected.getBrowserEngine() === BrowserEngine.WEBKIT) {
+      pending('Disabled on Safari.');
+    }
     if (!await Util.isTypeSupported('video/webm; codecs="vp9"')) {
       pending('Codec VP9 is not supported by the platform.');
     }


### PR DESCRIPTION
Some tests are generated with old tools that produce random errors in decoding, so it is best to disable it for now. Due https://github.com/shaka-project/shaka-player/issues/2746