### PR TITLE
fix(Transmuxer): Fix bad generation of silence frames

### DIFF
--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -411,14 +411,6 @@ shaka.transmuxer.TsTransmuxer = class {
     }
 
     if (!info || firstPts == null) {
-      if (!tsParser.getVideoData().length) {
-        throw new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.MEDIA,
-            shaka.util.Error.Code.TRANSMUXING_FAILED,
-            reference ? reference.getUris()[0] : null);
-      }
-
       firstPts = reference.startTime * timescale;
 
       const allCodecs = shaka.util.MimeUtils.splitCodecs(stream.codecs);


### PR DESCRIPTION
The code being removed is code that should have been removed previously since video data is no longer used to generate audio silence frames.

Fixes https://github.com/shaka-project/shaka-player/issues/8951