### PR TITLE
fix(UI): Seek on double-tap regardless of player controls visibility

### DIFF
--- a/ui/hidden_seek_button.js
+++ b/ui/hidden_seek_button.js
@@ -103,7 +103,6 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
    * @private
    */
   onTouchStart_(event) {
-
     // If multiple touches, handle or ignore as needed. Here, we assume
     // single-touch.
     if (event.touches.length > 0) {


### PR DESCRIPTION
I think this is how double-tap seek works in most online and local media players. It is also making the double-tap seek to fail if the controls aren't visible on the very first touch start.

Closes #8949