### PR TITLE
fix: Attach mediaKeys when the device does not force us to wait for the encrypted event.

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -599,19 +599,22 @@ shaka.drm.DrmEngine = class {
       ) || null) : null;
 
     const keySystem = this.currentDrmInfo_.keySystem;
-    const needWaitForEncryptedEvent = shaka.device.DeviceFactory.getDevice()
+    let needWaitForEncryptedEvent = shaka.device.DeviceFactory.getDevice()
         .needWaitForEncryptedEvent(keySystem);
     /**
      * We can attach media keys before the playback actually begins when:
-     *  - If we are not using FairPlay Modern EME
+     *  - The device does not force us to wait for the encrypted event
      *  - Some initData already has been generated (through the manifest)
      *  - In case of an offline session
      */
-    if (!needWaitForEncryptedEvent &&
-        (this.manifestInitData_ || this.storedPersistentSessions_.size ||
-        this.config_.parseInbandPsshEnabled)) {
+    if (this.manifestInitData_ || this.storedPersistentSessions_.size ||
+      this.config_.parseInbandPsshEnabled) {
+      needWaitForEncryptedEvent = false;
+    }
+    if (!needWaitForEncryptedEvent) {
       await this.attachMediaKeys_();
     } else {
+      // Wait for the next encrypted event. We'll attach the mediaKeys there.
       this.eventManager_.listen(
           this.video_, 'encrypted', (e) => this.onEncryptedEvent_(e));
     }


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/9032

In https://github.com/shaka-project/shaka-player/pull/8497, we'd enforce waiting for the encrypted event based on device detection. Previously, we'd always attach mediaKeys aslong as we're not dealing with `com.apple.fps` as key system.

This caused a regression when we'd have no initData available (eg; from the manifest, or offline storage) but we didn't have to wait for the encrypted event.
