### PR TITLE
fix(UI): Respect prefers-reduced-transparency for big play button

### DIFF
--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -70,6 +70,12 @@
   &[icon="replay"] {
     background-image: data-uri("images/replay.svg");
   }
+
+  @media (prefers-reduced-transparency: no-preference) {
+    .shaka-controls-container[shown="true"] & {
+      opacity: 0.75;
+    }
+  }
 }
 
 /* This button contains the current time and duration of the video.


### PR DESCRIPTION
This is currently only supported in Chromium browsers (it is behind a feature flag in Firefix and WebKit doesn't have it), if you don't want o enable the setting at the operating system level to test this, you can simulate it in the "Rendering" tab in the Chromium developer tools.