### PR TITLE
fix(LCEVC): Add remove buffer functionality for LCEVCdecJS

### DIFF
--- a/externs/lcevc.js
+++ b/externs/lcevc.js
@@ -44,6 +44,14 @@ LCEVCdec.LCEVCdec = class {
   appendBuffer(data, type, variantId, timestampOffset, isMuxed) {}
 
   /**
+   * Flush (remove) the video buffers from the LCEVC decoder.
+   *
+   * @param {number} startTime The start time of the data to be removed.
+   * @param {number} endTime The end time of the data to be removed.
+   */
+  flushBuffer(startTime, endTime) {}
+
+  /**
    * Set current variant as variantId to the LCEVC decoder
    * @param {!number} variantId
    * @param {!boolean} autoBufferSwitch is lcevcDec mode that switches variant

--- a/lib/lcevc/lcevc_dec.js
+++ b/lib/lcevc/lcevc_dec.js
@@ -80,6 +80,23 @@ shaka.lcevc.Dec = class {
   }
 
   /**
+   * Remove data from the LCEVC Dec.
+   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {number} startTime relative to the start of the presentation
+   * @param {number} endTime relative to the start of the presentation
+   */
+  removeBuffer(contentType, startTime, endTime) {
+    const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    // LCEVC only supports VIDEO.
+    if (contentType !== ContentType.VIDEO) {
+      return;
+    }
+    if (this.dec_) {
+      this.dec_.flushBuffer(startTime, endTime);
+    }
+  }
+
+  /**
    * Hide the canvas specifically in the case of a DRM Content
    */
   hideCanvas() {

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1753,6 +1753,19 @@ shaka.media.MediaSourceEngine = class {
   }
 
   /**
+   * Remove dependency data.
+   * @param {shaka.util.ManifestParserUtils.ContentType} contentType
+   * @param {number} startTime relative to the start of the presentation
+   * @param {number} endTime relative to the start of the presentation
+   */
+  removeDependency(contentType, startTime, endTime) {
+    if (this.lcevcDec_) {
+      // Remove buffers from the LCEVC Dec.
+      this.lcevcDec_.removeBuffer(contentType, startTime, endTime);
+    }
+  }
+
+  /**
    * Append data to the SourceBuffer.
    * @param {shaka.util.ManifestParserUtils.ContentType} contentType
    * @param {BufferSource} data
@@ -1781,6 +1794,7 @@ shaka.media.MediaSourceEngine = class {
       this.onUpdateEnd_(contentType);
       return;
     }
+    this.removeDependency(contentType, startTime, endTime);
 
     // This will trigger an 'updateend' event.
     this.sourceBuffers_.get(contentType).remove(startTime, endTime);


### PR DESCRIPTION
Add remove buffer functionality to Shaka Player for LCEVCdecJS. This method would clear the buffers appended to LCEVCdecJS via appendBuffer. For `LCEVCdecJS` we would like to get a `removeBuffer` event on profile (variant) switch, both in Dual-Track and SEI modes.