### PR TITLE
fix: Return the correct getAudioTracks when only differs the codec

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5690,6 +5690,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           track.label,
           track.channelsCount,
           track.spatialAudio,
+          track.audioCodec || '',
         ].join('_');
         /** @type {shaka.extern.AudioTrack} */
         const audioTrack = {


### PR DESCRIPTION
This case is rare and may only occur in some HLS streams that use groups.