### PR TITLE
fix: Return the correct getVideoTracks when only differs the audioId

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5781,12 +5781,29 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!active) {
       return [];
     }
-    const filteredTracks = variants.filter((t) => {
-      return t.originalAudioId === active.originalAudioId &&
-          t.audioId === active.audioId &&
-          t.audioGroupId === active.audioGroupId &&
-          t.videoCodec;
-    });
+    let filteredTracks = variants;
+    if (!this.isVideoOnly()) {
+      filteredTracks = variants.filter((t) => {
+        const ArrayUtils = shaka.util.ArrayUtils;
+        const MimeUtils = shaka.util.MimeUtils;
+
+        if (!t.videoCodec || t.audioGroupId !== active.audioGroupId ||
+            t.originalAudioId !== active.originalAudioId) {
+          return false;
+        }
+        if (t.audioId === active.audioId) {
+          return true;
+        }
+        return t.language === active.language &&
+            t.label === active.label &&
+            t.channelsCount === active.channelsCount &&
+            t.spatialAudio === active.spatialAudio &&
+            t.audioMimeType === active.audioMimeType &&
+            MimeUtils.getNormalizedCodec(t.audioCodec || '') ===
+              MimeUtils.getNormalizedCodec(active.audioCodec || '') &&
+            ArrayUtils.equal(t.audioRoles, active.audioRoles);
+      });
+    }
     if (!filteredTracks.length) {
       return [];
     }


### PR DESCRIPTION
It also optimizes performance on video-only streams.

This case is rare and may only occur in some HLS streams that use groups.