### PR TITLE
fix(UI): Add LCEVC label in resolution menu

### DIFF
--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -198,6 +198,8 @@ shaka.util.MimeUtils = class {
       case base === 'dvc1':
       case base === 'dvi1':
         return 'dovi-vvc'; // Dolby Vision based in VVC
+      case base === 'lvc1':
+        return 'lcevc'; // LCEVC
     }
     return base;
   }

--- a/test/util/mime_utils_unit.js
+++ b/test/util/mime_utils_unit.js
@@ -71,6 +71,8 @@ describe('MimeUtils', () => {
 
     expect(getNormalizedCodec('dvc1.05')).toBe('dovi-vvc');
     expect(getNormalizedCodec('dvi1.05')).toBe('dovi-vvc');
+
+    expect(getNormalizedCodec('lvc1')).toBe('lcevc');
   });
 
   it('isHlsType', () => {

--- a/ui/resolution_selection.js
+++ b/ui/resolution_selection.js
@@ -492,7 +492,7 @@ shaka.ui.ResolutionSelection = class extends shaka.ui.SettingsMenu {
         return false;
       }
       const codec = shaka.util.MimeUtils.getNormalizedCodec(t.codecs);
-      return codec.startsWith('lvc');
+      return codec.startsWith('lcevc');
     };
     if (track.hdr == 'PQ' || track.hdr == 'HLG') {
       if (isDolbyVision(track)) {


### PR DESCRIPTION
This PR adds `isLCEVC` check to the `basicResolutionComparison` and appends `'LCEVC'` to the label text in `getResolutionLabel_` if the track is LCEVC. This makes it easier to tell LCEVC profiles apart and fixes an issue we were seeing when many different Dual-Track profiles are contained in the manifest, it might be hard to differentiate them (e.g. base and LCEVC profile with the same 1080p resolution).