### PR TITLE
chore: Update python runtime in appengine

### DIFF
--- a/app-engine/demo-version-index/app.yaml
+++ b/app-engine/demo-version-index/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python39
+runtime: python313
 default_expiration: 1h
 
 handlers:

--- a/app-engine/shaka-player-demo/app.yaml
+++ b/app-engine/shaka-player-demo/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: python39
+runtime: python313
 default_expiration: 5m
 
 handlers:


### PR DESCRIPTION
Python 3.9 is EOL in app engine.

This should fix future deployments by moving to Python 3.13.  v4.15.17 and v4.16.5 have been deployed manually to compensate for these failed release workflows:

 - https://github.com/shaka-project/shaka-player/actions/runs/18526707807/job/52833355559
 - https://github.com/shaka-project/shaka-player/actions/runs/18526952863/job/52833356575
