### PR TITLE
feat(HLS): Remove enableAudioGroups usage

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -2009,9 +2009,6 @@ shaka.hls.HlsParser = class {
       const streamInfo =
           this.createStreamInfoFromVariantTags_(tags, allCodecs, type,
               supplementalCodecs);
-      if (globalGroupId && this.config_.enableAudioGroups) {
-        streamInfo.stream.groupId = globalGroupId;
-      }
       if (streamInfo.stream.type == ContentType.AUDIO &&
           type === ContentType.AUDIO &&
           res.audio.some((a) => a.stream.isAudioMuxedInVideo)) {
@@ -2453,9 +2450,6 @@ shaka.hls.HlsParser = class {
         streamId, verbatimMediaPlaylistUris, codecs, type, language,
         primary, name, channelsCount, /* closedCaptions= */ null,
         characteristics, forced, sampleRate, spatialAudio, supplementalCodecs);
-    if (streamInfo.stream && this.config_.enableAudioGroups) {
-      streamInfo.stream.groupId = globalGroupId;
-    }
     if (this.groupIdToStreamInfosMap_.has(globalGroupId)) {
       this.groupIdToStreamInfosMap_.get(globalGroupId).push(streamInfo);
     } else {

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -6759,8 +6759,5 @@ describe('HlsParser', () => {
 
     expect(audioLabels).toContain('audio128');
     expect(audioLabels).toContain('audio64');
-
-    // Also check that the audio group IDs are distinct and correct
-    expect(variant1.audio.groupId).not.toBe(variant2.audio.groupId);
   });
 });


### PR DESCRIPTION
Many HLS streams use different audio groups for SD, HD, or 4K, preventing the player from adapting correctly.