### PR TITLE
fix: Don't cancel trick play on VOD end

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -7420,8 +7420,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       // Cancel trick play if we hit the beginning or end of the seekable
       // (Sub-second accuracy not required here)
       if (rate > 0) {
-        // If we are on VoD, we don't want cancel it. If the user presses play
-        // again, the trick play must be the same.
+        // If we are on VoD, we don’t want to cancel it. If the user presses
+        // play again, the trick play must be the same.
         // If we are in Live, and we are very close to the live edge with a rate
         // between 0 and 1, it is not necessary to cancel since we are moving
         // away from the edge.


### PR DESCRIPTION
Currently, when trick play is performed and the content ends, if the user presses play again, the trick play has been canceled. This is not desired.