### PR TITLE
fix(Xbox): Implement requiresClearAndEncryptedInitSegments method for xbox

### DIFF
--- a/lib/device/xbox.js
+++ b/lib/device/xbox.js
@@ -68,6 +68,13 @@ shaka.device.Xbox = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  requiresClearAndEncryptedInitSegments() {
+    return true;
+  }
+
+  /**
+   * @override
+   */
   insertEncryptionDataBeforeClear() {
     return true;
   }


### PR DESCRIPTION
### Summary
When playing a live HLS stream on Xbox, I was running into the following error as soon as the playhead hit a discontinuity:

```
CHUNK_DEMUXER_ERROR_APPEND_FAILED: Sample encryption info is not available.
```

I noticed that [this fix](https://github.com/shaka-project/shaka-player/pull/6719) was added a while back to address this exact issue. A few months ago, [another PR](https://github.com/shaka-project/shaka-player/pull/8210) was submitted to abstract the feature detection logic, which I believe unfortunately caused a regression.

The `requiresClearAndEncryptedInitSegments` helper was implemented in both the Abstract Device and the Default Browser, but it looks like it wasn't implemented in the Xbox class. This resulted in `requiresClearAndEncryptedInitSegments` always returning false on that platform (defaulting to the Abstract Device class's implementation, which returns `false`).

This made the following logic (that fixed the CHUNK_DEMUXER_ERROR_APPEND_FAILED error) fail:
```
if (device.requiresClearAndEncryptedInitSegments()) {
  const doubleInitSegment = new Uint8Array(initSegment.byteLength +
    modifiedInitSegment.byteLength);
  doubleInitSegment.set(modifiedInitSegment);
  doubleInitSegment.set(initSegment, modifiedInitSegment.byteLength);
  return doubleInitSegment;
}
```

### Fix
Overriding this function in the Xbox class fixes the problem. 

### Result
Playback now proceeds through HLS discontinuities on Xbox without CHUNK_DEMUXER_ERROR_APPEND_FAILED.
