### PR TITLE
chore: implement requiresClearAndEncryptedInitSegments method for xbox

### DIFF
--- a/lib/device/xbox.js
+++ b/lib/device/xbox.js
@@ -68,6 +68,13 @@ shaka.device.Xbox = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  requiresClearAndEncryptedInitSegments() {
+    return true;
+  }
+
+  /**
+   * @override
+   */
   insertEncryptionDataBeforeClear() {
     return true;
   }


### PR DESCRIPTION
Cherry Picking [this PR](https://github.com/shaka-project/shaka-player/pull/9254) to be a part of the v4.16.x release. 