### PR TITLE
fix(webOS): Disable smooth codec switch on webOS

### DIFF
--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -99,9 +99,7 @@ shaka.device.WebOS = class extends shaka.device.AbstractDevice {
    * @override
    */
   supportsSmoothCodecSwitching() {
-    const version = this.getVersion();
-    return version !== null ?
-        version > 6 : super.supportsSmoothCodecSwitching();
+    return false;
   }
 
   /**


### PR DESCRIPTION
During my tests I wasn't able to find a webOS TV which could handle smooth codec switching properly. Let's disable it on all platform, similar to what we've done on Tizen back in the day.