### PR TITLE
chore: Simplify codec switch check

### DIFF
--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -204,7 +204,10 @@ shaka.device.AbstractDevice = class {
    * @override
    */
   supportsSmoothCodecSwitching() {
-    return true;
+    const sourceBuffer = window.ManagedSourceBuffer || window.SourceBuffer;
+    return !!sourceBuffer &&
+        // eslint-disable-next-line no-restricted-syntax
+        !!sourceBuffer.prototype && !!sourceBuffer.prototype.changeType;
   }
 
   /**

--- a/lib/device/chromecast.js
+++ b/lib/device/chromecast.js
@@ -89,7 +89,8 @@ shaka.device.Chromecast = class extends shaka.device.AbstractDevice {
    * @override
    */
   supportsSmoothCodecSwitching() {
-    return this.osType_.value() !== shaka.device.Chromecast.OsType_.LINUX;
+    return super.supportsSmoothCodecSwitching() &&
+      this.osType_.value() !== shaka.device.Chromecast.OsType_.LINUX;
   }
 
   /**

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -61,6 +61,9 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
 
     /** @private {!shaka.util.Lazy<boolean>} */
     this.supportsSmoothCodecSwitching_ = new shaka.util.Lazy(() => {
+      if (!super.supportsSmoothCodecSwitching()) {
+        return false;
+      }
       if (!navigator.userAgent.match(/Edge?\//)) {
         return true;
       }

--- a/lib/media/media_source_capabilities.js
+++ b/lib/media/media_source_capabilities.js
@@ -33,17 +33,6 @@ shaka.media.Capabilities = class {
   }
 
   /**
-   * Determine support for SourceBuffer.changeType
-   * @return {boolean}
-   */
-  static isChangeTypeSupported() {
-    const sourceBuffer = window.ManagedSourceBuffer || window.SourceBuffer;
-    return !!sourceBuffer &&
-        // eslint-disable-next-line no-restricted-syntax
-        !!sourceBuffer.prototype && !!sourceBuffer.prototype.changeType;
-  }
-
-  /**
    * Determine support for MediaSource.setLiveSeekableRange and
    * MediaSource.clearLiveSeekableRange, which can allow for a media element
    * duration of Infinite by providing a non-infinite seekable range.

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2228,7 +2228,8 @@ shaka.media.MediaSourceEngine = class {
     const sourceBuffer = this.sourceBufferTypes_.get(contentType);
     shaka.log.debug(
         `Change Type: ${sourceBuffer} -> ${mimeType}`);
-    if (shaka.media.Capabilities.isChangeTypeSupported()) {
+    const device = shaka.device.DeviceFactory.getDevice();
+    if (device.supportsSmoothCodecSwitching()) {
       if (this.transmuxers_.has(contentType)) {
         this.transmuxers_.get(contentType).destroy();
         this.transmuxers_.delete(contentType);
@@ -2529,9 +2530,10 @@ shaka.media.MediaSourceEngine = class {
       allowChangeType = false;
     }
 
+    const device = shaka.device.DeviceFactory.getDevice();
     if (allowChangeType && this.config_.codecSwitchingStrategy ===
         shaka.config.CodecSwitchingStrategy.SMOOTH &&
-          shaka.media.Capabilities.isChangeTypeSupported()) {
+          device.supportsSmoothCodecSwitching()) {
       return {
         type: shaka.media.MediaSourceEngine.ResetMode_.CHANGE_TYPE,
         newMimeType,

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -10,7 +10,6 @@ goog.require('shaka.config.CodecSwitchingStrategy');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.log');
 goog.require('shaka.media.AdaptationSet');
-goog.require('shaka.media.Capabilities');
 goog.require('shaka.util.LanguageUtils');
 
 
@@ -186,10 +185,11 @@ shaka.media.PreferenceBasedCriteria = class {
       }
     }
 
+    const device = shaka.device.DeviceFactory.getDevice();
     const supportsSmoothCodecTransitions =
       this.config_.codecSwitchingStrategy ==
       shaka.config.CodecSwitchingStrategy.SMOOTH &&
-        shaka.media.Capabilities.isChangeTypeSupported();
+        device.supportsSmoothCodecSwitching();
 
     this.lastAdaptationSet_ = new shaka.media.AdaptationSet(current[0], current,
         !supportsSmoothCodecTransitions);

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3231,8 +3231,7 @@ shaka.media.StreamingEngine = class {
       return true;
     }
     const device = shaka.device.DeviceFactory.getDevice();
-    if (!shaka.media.Capabilities.isChangeTypeSupported() ||
-        !device.supportsSmoothCodecSwitching() ) {
+    if (!device.supportsSmoothCodecSwitching()) {
       for (const type of this.mediaStates_.keys()) {
         const mediaState = this.mediaStates_.get(type);
         const ContentType = shaka.util.ManifestParserUtils.ContentType;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -16,7 +16,6 @@ goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.FairPlay');
 goog.require('shaka.log');
-goog.require('shaka.media.Capabilities');
 goog.require('shaka.media.PreferenceBasedCriteria');
 goog.require('shaka.net.NetworkingEngine');
 goog.require('shaka.util.ConfigUtils');
@@ -102,8 +101,7 @@ shaka.util.PlayerConfiguration = class {
     };
 
     let codecSwitchingStrategy = shaka.config.CodecSwitchingStrategy.RELOAD;
-    if (shaka.media.Capabilities.isChangeTypeSupported() &&
-        device.supportsSmoothCodecSwitching()) {
+    if (device.supportsSmoothCodecSwitching()) {
       codecSwitchingStrategy = shaka.config.CodecSwitchingStrategy.SMOOTH;
     }
 

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -12,7 +12,6 @@ goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.lcevc.Dec');
 goog.require('shaka.log');
-goog.require('shaka.media.Capabilities');
 goog.require('shaka.media.ManifestParser');
 goog.require('shaka.text.TextEngine');
 goog.require('shaka.util.Functional');
@@ -178,8 +177,8 @@ shaka.util.StreamUtils = class {
           return v1.bandwidth - v2.bandwidth;
         });
 
-    const isChangeTypeSupported =
-      shaka.media.Capabilities.isChangeTypeSupported();
+    const device = shaka.device.DeviceFactory.getDevice();
+    const supportsSmoothSwitch = device.supportsSmoothCodecSwitching();
 
     const validVideoIds = [];
     const validVideoStreamsMap = new Map();
@@ -203,7 +202,7 @@ shaka.util.StreamUtils = class {
         validVideoIds.push(stream.id);
       } else {
         const previousStream = validVideoStreams[validVideoStreams.length - 1];
-        if (!isChangeTypeSupported) {
+        if (!supportsSmoothSwitch) {
           const previousCodec =
             MimeUtils.getNormalizedCodec(previousStream.codecs);
           const currentCodec =

--- a/test/codec_switching/codec_switching_integration.js
+++ b/test/codec_switching/codec_switching_integration.js
@@ -93,12 +93,8 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!shaka.media.Capabilities.isChangeTypeSupported()) {
-        pending('SourceBuffer.changeType is not supported');
-      }
       if (!deviceDetected.supportsSmoothCodecSwitching()) {
-        pending('SourceBuffer.changeType is not considered ' +
-          'reliable on this device');
+        pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/webm; codecs="opus"')) {
         pending('Codec OPUS in WEBM is not supported by the platform.');
@@ -169,12 +165,8 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!shaka.media.Capabilities.isChangeTypeSupported()) {
-        pending('SourceBuffer.changeType is not supported');
-      }
       if (!deviceDetected.supportsSmoothCodecSwitching()) {
-        pending('SourceBuffer.changeType is not considered ' +
-          'reliable on this device');
+        pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/webm; codecs="opus"')) {
         pending('Codec OPUS in WEBM is not supported by the platform.');
@@ -245,12 +237,8 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!shaka.media.Capabilities.isChangeTypeSupported()) {
-        pending('SourceBuffer.changeType is not supported');
-      }
       if (!deviceDetected.supportsSmoothCodecSwitching()) {
-        pending('SourceBuffer.changeType is not considered ' +
-          'reliable on this device');
+        pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/mp4; codecs="ec-3"')) {
         pending('Codec EC3 in MP4 is not supported by the platform.');
@@ -322,12 +310,8 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!shaka.media.Capabilities.isChangeTypeSupported()) {
-        pending('SourceBuffer.changeType is not supported');
-      }
       if (!deviceDetected.supportsSmoothCodecSwitching()) {
-        pending('SourceBuffer.changeType is not considered ' +
-          'reliable on this device');
+        pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/mp4; codecs="ec-3"')) {
         pending('Codec EC3 in MP4 is not supported by the platform.');

--- a/test/media/adaptation_set_criteria_unit.js
+++ b/test/media/adaptation_set_criteria_unit.js
@@ -122,11 +122,11 @@ describe('AdaptationSetCriteria', () => {
         });
       });
 
-      const originalIsChangeTypeSupported = shaka.media.Capabilities
-          .isChangeTypeSupported;
+      const originalSupportsSmoothCodecSwitching =
+        deviceDetected.supportsSmoothCodecSwitching;
 
       try {
-        shaka.media.Capabilities.isChangeTypeSupported = () => {
+        deviceDetected.supportsSmoothCodecSwitching = () => {
           return true;
         };
 
@@ -157,8 +157,8 @@ describe('AdaptationSetCriteria', () => {
 
         expect(set).toBe(builder.getLastAdaptationSet());
       } finally {
-        shaka.media.Capabilities
-            .isChangeTypeSupported = originalIsChangeTypeSupported;
+        deviceDetected.supportsSmoothCodecSwitching =
+          originalSupportsSmoothCodecSwitching;
       }
     });
 


### PR DESCRIPTION
Move all logic related to smooth switch check to device API.