### PR TITLE
fix(Ads): Update HLS ad skip control

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -1607,21 +1607,23 @@ shaka.ads.InterstitialAdManager = class {
       canJump = !data.includes('JUMP');
     }
     let skipOffset = isSkippable ? 0 : null;
-    const enableSkipAfter =
-        hlsMetadata.values.find((v) => v.key == 'X-ENABLE-SKIP-AFTER');
-    if (enableSkipAfter) {
-      const enableSkipAfterString = /** @type {string} */(enableSkipAfter.data);
-      skipOffset = parseFloat(enableSkipAfterString);
+    const skipControlOffset =
+        hlsMetadata.values.find((v) => v.key == 'X-SKIP-CONTROL-OFFSET');
+    if (skipControlOffset) {
+      const skipControlOffsetString =
+      /** @type {string} */(skipControlOffset.data);
+      skipOffset = parseFloat(skipControlOffsetString);
       if (isNaN(skipOffset)) {
         skipOffset = isSkippable ? 0 : null;
       }
     }
     let skipFor = null;
-    const enableSkipFor =
-        hlsMetadata.values.find((v) => v.key == 'X-ENABLE-SKIP-FOR');
-    if (enableSkipFor) {
-      const enableSkipForString = /** @type {string} */(enableSkipFor.data);
-      skipFor = parseFloat(enableSkipForString);
+    const skipControlDuration =
+        hlsMetadata.values.find((v) => v.key == 'X-SKIP-CONTROL-DURATION');
+    if (skipControlDuration) {
+      const skipControlDurationString =
+      /** @type {string} */(skipControlDuration.data);
+      skipFor = parseFloat(skipControlDurationString);
       if (isNaN(skipOffset)) {
         skipFor = null;
       }
@@ -1718,17 +1720,17 @@ shaka.ads.InterstitialAdManager = class {
             JSON.parse(data));
         const skipControl = dataAsJson['SKIP-CONTROL'];
         if (skipControl) {
-          const enableSkipAfterValue = skipControl['ENABLE-SKIP-AFTER'];
-          if ((typeof enableSkipAfterValue) == 'number') {
-            skipOffset = parseFloat(enableSkipAfterValue);
-            if (isNaN(enableSkipAfterValue)) {
+          const skipControlOffsetList = skipControl['OFFSET'];
+          if ((typeof skipControlOffsetList) == 'number') {
+            skipOffset = parseFloat(skipControlOffsetList);
+            if (isNaN(skipControlOffsetList)) {
               skipOffset = isSkippable ? 0 : null;
             }
           }
-          const enableSkipForValue = skipControl['ENABLE-SKIP-FOR'];
-          if ((typeof enableSkipForValue) == 'number') {
-            skipFor = parseFloat(enableSkipForValue);
-            if (isNaN(enableSkipForValue)) {
+          const skipControlDurationList = skipControl['DURATION'];
+          if ((typeof skipControlDurationList) == 'number') {
+            skipFor = parseFloat(skipControlDurationList);
+            if (isNaN(skipFor)) {
               skipFor = null;
             }
           }
@@ -2263,11 +2265,11 @@ shaka.ads.InterstitialAdManager.Asset;
 
 /**
  * @typedef {{
- *   ENABLE-SKIP-AFTER: number,
- *   ENABLE-SKIP-FOR: number,
+ *   OFFSET: number,
+ *   DURATION: number,
  * }}
  *
- * @property {number} ENABLE-SKIP-AFTER
- * @property {number} ENABLE-SKIP-FOR
+ * @property {number} OFFSET
+ * @property {number} DURATION
  */
 shaka.ads.InterstitialAdManager.SkipControl;

--- a/test/ads/interstitial_ad_manager_unit.js
+++ b/test/ads/interstitial_ad_manager_unit.js
@@ -526,7 +526,7 @@ describe('Interstitial Ad manager', () => {
       expect(interstitials[0]).toEqual(expectedInterstitial);
     });
 
-    it('supports X-ENABLE-SKIP-AFTER and X-ENABLE-SKIP-FOR', async () => {
+    it('supports X-SKIP-CONTROL-OFFSET, X-SKIP-CONTROL-DURATION', async () => {
       const metadata = {
         type: 'com.apple.quicktime.HLS',
         startTime: 0,
@@ -541,11 +541,11 @@ describe('Interstitial Ad manager', () => {
             data: 'test.m3u8',
           },
           {
-            key: 'X-ENABLE-SKIP-AFTER',
+            key: 'X-SKIP-CONTROL-OFFSET',
             data: 5,
           },
           {
-            key: 'X-ENABLE-SKIP-FOR',
+            key: 'X-SKIP-CONTROL-DURATION',
             data: 10,
           },
         ],
@@ -901,7 +901,7 @@ describe('Interstitial Ad manager', () => {
       expect(interstitials[0]).toEqual(expectedInterstitial);
     });
 
-    it('supports ENABLE-SKIP-AFTER and ENABLE-SKIP-FOR', async () => {
+    it('supports SKIP-CONTROL OFFSET and DURATION', async () => {
       const assetsList = JSON.stringify({
         'ASSETS': [
           {
@@ -909,8 +909,8 @@ describe('Interstitial Ad manager', () => {
           },
         ],
         'SKIP-CONTROL': {
-          'ENABLE-SKIP-AFTER': 5,
-          'ENABLE-SKIP-FOR': 10,
+          OFFSET: 5,
+          DURATION: 10,
         },
       });
 


### PR DESCRIPTION
In Shaka we were using  the draft spec instead the final

Spec: https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#appendix-D.7