### PR TITLE
chore(Ads): Remove useless log

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -477,8 +477,6 @@ shaka.ads.InterstitialAdManager = class {
     }
     if (adInterstitials.length) {
       this.addInterstitials(adInterstitials);
-    } else {
-      shaka.log.alwaysWarn('Unsupported HLS interstitial', hlsMetadata);
     }
   }
 


### PR DESCRIPTION
The problem is that this log is displayed when any DATE-RANGE is received so it is not useful because not all DATE-RANGE are intersittials.