### PR TITLE
ci: Use python3 explicitly

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -39,7 +39,7 @@ jobs:
           java-version: 21
 
       - name: Lint
-        run: python build/check.py
+        run: python3 build/check.py
 
   build_and_test:
     # Don't waste time doing a full matrix of test runs when there was an
@@ -165,7 +165,7 @@ jobs:
 
       - name: Build Player
         timeout-minutes: 20
-        run: python build/all.py
+        run: python3 build/all.py
 
       - name: Test Player
         timeout-minutes: 15
@@ -173,7 +173,7 @@ jobs:
         run: |
           browser=${{ matrix.browser }}
 
-          python build/test.py \
+          python3 build/test.py \
             --browsers "$browser" \
             --reporters spec --spec-hide-passed \
             ${{ matrix.extra_flags }}

--- a/.github/workflows/custom-actions/prep-for-appspot/action.yaml
+++ b/.github/workflows/custom-actions/prep-for-appspot/action.yaml
@@ -13,7 +13,7 @@ runs:
 
     - name: Build Shaka Player
       shell: bash
-      run: python build/all.py
+      run: python3 build/all.py
 
     - name: Extract git version
       shell: bash

--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -28,7 +28,7 @@ jobs:
         # parses it, compares it to the changed lines in the PR, and computes
         # the incremental code coverage.
         run: |
-          python .github/workflows/compute-incremental-coverage.py \
+          python3 .github/workflows/compute-incremental-coverage.py \
               --repo ${{ github.repository }} \
               --run-id ${{ github.event.workflow_run.id }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,13 +34,13 @@ just a few small guidelines you need to follow.
 
 7. Test all changes in both the compiler and linter with:
 ```sh
-   python build/all.py
+   python3 build/all.py
 ```
    Patches that do not compile or pass linter checks will not be accepted.
 
 8. Test all changes in the unit and integration tests with:
 ```sh
-   python build/test.py
+   python3 build/test.py
 ```
    Patches that do not pass unit and integration tests will not be accepted.
 

--- a/docs/tutorials/plugins.md
+++ b/docs/tutorials/plugins.md
@@ -98,16 +98,16 @@ You can start with the complete library (`+@complete`) and exclude any
 individual source file with a minus sign and a path:
 
 ```sh
-python build/build.py +@complete -lib/text/mp4_ttml_parser.js
+python3 build/build.py +@complete -lib/text/mp4_ttml_parser.js
 ```
 
 You can also exclude an entire category of plugins:
 
 ```sh
 # Build without polyfills:
-python build/build.py +@complete -@polyfill
+python3 build/build.py +@complete -@polyfill
 # Build without polyfills or text parsers:
-python build/build.py +@complete -@polyfill -@text
+python3 build/build.py +@complete -@polyfill -@text
 ```
 
 To see the complete list of categories, its in [`build/types/`](https://github.com/shaka-project/shaka-player/tree/main/build/types)
@@ -137,13 +137,13 @@ the bottom of the source file.
 To add a single source file, prefix it with a plus sign:
 
 ```sh
-python build/build.py +@complete +my_plugin.js
+python3 build/build.py +@complete +my_plugin.js
 ```
 
 You can add multiple sources as well:
 
 ```sh
-python build/build.py +@complete +my_plugin.js +/path/to/my_other_plugin.js
+python3 build/build.py +@complete +my_plugin.js +/path/to/my_other_plugin.js
 ```
 
 

--- a/docs/tutorials/selenium-grid-config.md
+++ b/docs/tutorials/selenium-grid-config.md
@@ -10,7 +10,7 @@ our lab at [build/shaka-lab.yaml](https://github.com/shaka-project/shaka-player/
 ## Usage
 
 ```sh
-python build/test.py \
+python3 build/test.py \
     --grid-config grid-config.yaml \
     --grid-address selenium-hub-hostname:4444
 ```

--- a/docs/tutorials/welcome.md
+++ b/docs/tutorials/welcome.md
@@ -61,7 +61,7 @@ cd shaka-player
 #### Compile the library and generate the docs
 
 ```sh
-python build/all.py
+python3 build/all.py
 ```
 
 Alternatively you can use a docker container:

--- a/package.json
+++ b/package.json
@@ -111,10 +111,10 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "build": "python build/all.py",
+    "build": "python3 build/all.py",
     "prepack": "clean-package",
     "postpack": "clean-package restore",
-    "prepublishOnly": "python build/checkversion.py && python build/all.py --force"
+    "prepublishOnly": "python3 build/checkversion.py && python3 build/all.py --force"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
As python v3 is now necessary in our build pipeline, use python3 explicitly in CI and tutorials, as not all OSes symlink `python` to `python3`.