### PR TITLE
fix: Delay position change during codec switch

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -29,6 +29,7 @@ goog.require('shaka.util.Functional');
 goog.require('shaka.util.IDestroyable');
 goog.require('shaka.util.Id3Utils');
 goog.require('shaka.util.ManifestParserUtils');
+goog.require('shaka.util.MediaElementEvent');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
@@ -2350,30 +2351,39 @@ shaka.media.MediaSourceEngine = class {
       if (this.needSplitMuxedContent_ && !this.queues_.has(ContentType.AUDIO)) {
         this.queues_.set(ContentType.AUDIO, []);
       }
-
-      // Fake a seek to catchup the playhead.
-      this.video_.currentTime = currentTime;
-
       await sourceBufferAdded;
     } finally {
       this.reloadingMediaSource_ = false;
 
       this.destroyer_.ensureNotDestroyed();
 
-      this.eventManager_.listenOnce(this.video_, 'canplaythrough', () => {
-        // Don't use ensureNotDestroyed() from this event listener, because
-        // that results in an uncaught exception.  Instead, just check the
-        // flag.
-        if (this.destroyer_.destroyed()) {
-          return;
-        }
+      this.eventManager_.listenOnce(this.video_,
+          shaka.util.MediaElementEvent.LOADED_METADATA, () => {
+            // Don't use ensureNotDestroyed() from this event listener, because
+            // that results in an uncaught exception.  Instead, just check the
+            // flag.
+            if (this.destroyer_.destroyed()) {
+              return;
+            }
+            // Fake a seek to catchup the playhead.
+            this.video_.currentTime = currentTime;
+          });
 
-        this.video_.autoplay = previousAutoPlayState;
-        if (this.playAfterReset_) {
-          this.playAfterReset_ = false;
-          this.video_.play();
-        }
-      });
+      this.eventManager_.listenOnce(this.video_,
+          shaka.util.MediaElementEvent.CAN_PLAY_THROUGH, () => {
+            // Don't use ensureNotDestroyed() from this event listener, because
+            // that results in an uncaught exception.  Instead, just check the
+            // flag.
+            if (this.destroyer_.destroyed()) {
+              return;
+            }
+
+            this.video_.autoplay = previousAutoPlayState;
+            if (this.playAfterReset_) {
+              this.playAfterReset_ = false;
+              this.video_.play();
+            }
+          });
     }
   }
 


### PR DESCRIPTION
To prevent race condition on slower platforms, position change needs to be done on `loadedmetadata` event after MediaSource is swapped.