### PR TITLE
chore(Demo): Enable LCEVC on demo cast receiver

### DIFF
--- a/demo/cast_receiver/index.html
+++ b/demo/cast_receiver/index.html
@@ -31,6 +31,8 @@
 
     <!-- MSS support is enabled by including this: -->
     <script defer src="../../node_modules/codem-isoboxer/dist/iso_boxer.min.js"></script>
+    <!-- MPEG-5 Part2 LCEVC support is enabled by including this: -->
+    <script defer src="../../node_modules/lcevc_dec.js/dist/lcevc_dec.min.js"></script>
 
     <script defer src="https://www.gstatic.com/cast/sdk/libs/receiver/2.0.0/cast_receiver.js"></script>
 


### PR DESCRIPTION
Very few devices are supported, but it allows for testing.