### PR TITLE
feat!: Remove `enableTextDisplayer` from `TextDisplayer` plugins

### DIFF
--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -127,6 +127,7 @@ application:
     - `TextDisplayer` plugins must implement the `configure()` method.
     - `TextParser` plugins must implement the `setManifestType()` and `setSequenceMode()` methods.
     - `Transmuxer` plugins now has three new parameters in `transmux()` method.
+    - Removed `enableTextDisplayer` from `TextDisplayer` plugins
 
   - Player API Changes:
     - The constructor no longer takes `mediaElement` as a parameter; use the `attach` method to attach to a media element instead. (Deprecated in v4.6)

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -189,13 +189,6 @@ shaka.extern.TextDisplayer = class {
    * @exportDoc
    */
   setTextLanguage(language) {}
-
-  /**
-   * Enable the current text displayer.
-   *
-   * @exportDoc
-   */
-  enableTextDisplayer() {}
 };
 
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -1905,10 +1905,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           }, 'initializeMediaSourceEngineInner_');
         }
 
-        if (this.manifest_ && this.manifest_.textStreams.length) {
-          this.textDisplayer_.enableTextDisplayer();
-        }
-
         // Wait for the preload manager to do all of the loading it can do.
         await mutexWrapOperation(async () => {
           await preloadManager.waitForFinish();
@@ -3342,10 +3338,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           if (
             !(this.textDisplayer_ instanceof shaka.text.NativeTextDisplayer)
           ) {
-            if (textTracks.length) {
-              this.textDisplayer_.enableTextDisplayer();
-            }
-
             let enabledNativeTrack = false;
             for (const track of textTracks) {
               if (track.mode !== 'disabled') {

--- a/lib/text/native_text_displayer.js
+++ b/lib/text/native_text_displayer.js
@@ -183,9 +183,9 @@ shaka.text.NativeTextDisplayer = class {
     };
 
     this.eventManager_.listen(player, shaka.util.FakeEvent.EventName.Loaded,
-        () => this.enableTextDisplayer());
+        () => this.checkMsePlayback_());
 
-    this.enableTextDisplayer();
+    this.checkMsePlayback_();
   }
 
   /**
@@ -302,10 +302,9 @@ shaka.text.NativeTextDisplayer = class {
   }
 
   /**
-   * @override
-   * @export
+   * @private
    */
-  enableTextDisplayer() {
+  checkMsePlayback_() {
     // shaka.Player.LoadMode.MEDIA_SOURCE
     if (!this.video_ && this.player_ && this.player_.getLoadMode() === 2) {
       this.video_ = this.player_.getMediaElement();

--- a/lib/text/stub_text_displayer.js
+++ b/lib/text/stub_text_displayer.js
@@ -62,11 +62,4 @@ shaka.text.StubTextDisplayer = class {
    */
   setTextLanguage(language) {
   }
-
-  /**
-   * @override
-   * @export
-   */
-  enableTextDisplayer() {
-  }
 };

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -276,13 +276,6 @@ shaka.text.UITextDisplayer = class {
   }
 
   /**
-   * @override
-   * @export
-   */
-  enableTextDisplayer() {
-  }
-
-  /**
    * @private
    */
   configureCaptionsTimer_() {

--- a/test/test/util/fake_text_displayer.js
+++ b/test/test/util/fake_text_displayer.js
@@ -68,7 +68,4 @@ shaka.test.FakeTextDisplayer = class {
     const func = shaka.test.Util.spyFunc(this.setTextLanguageSpy);
     return func(language);
   }
-
-  /** @override */
-  enableTextDisplayer() {}
 };

--- a/test/test/util/layout_tests.js
+++ b/test/test/util/layout_tests.js
@@ -396,7 +396,6 @@ shaka.test.NativeTextLayoutTests = class extends shaka.test.TextLayoutTests {
   recreateTextDisplayer() {
     /** @suppress {checkTypes} */
     this.textDisplayer = new shaka.text.NativeTextDisplayer(this.player);
-    this.textDisplayer.enableTextDisplayer();
     this.textDisplayer.setTextVisibility(true);
   }
 

--- a/test/text/native_text_displayer_unit.js
+++ b/test/text/native_text_displayer_unit.js
@@ -39,7 +39,6 @@ describe('NativeTextDisplayer', () => {
     video = new shaka.test.FakeVideo();
     /** @suppress {checkTypes} */
     displayer = new NativeTextDisplayer(player);
-    displayer.enableTextDisplayer();
 
     expect(video.textTracks.length).toBe(1);
     mockTrack = /** @type {!shaka.test.FakeTextTrack} */ (video.textTracks[0]);


### PR DESCRIPTION
This is no longer necessary since we have removed shaka.text.SimpleTextDisplayer