### PR TITLE
fix: Fix infinite evict loop on text unload

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2697,6 +2697,9 @@ shaka.media.StreamingEngine = class {
    * @private
    */
   async evict_(mediaState, presentationTime) {
+    if (this.lastTextMediaStateBeforeUnload_ == mediaState) {
+      this.lastTextMediaStateBeforeUnload_ = null;
+    }
     const segmentIndex = mediaState.stream.segmentIndex;
     /** @type {Array<number>} */
     let continuityTimelines;
@@ -2723,9 +2726,6 @@ shaka.media.StreamingEngine = class {
     const startTime =
         this.playerInterface_.mediaSourceEngine.bufferStart(mediaState.type);
     if (startTime == null) {
-      if (this.lastTextMediaStateBeforeUnload_ == mediaState) {
-        this.lastTextMediaStateBeforeUnload_ = null;
-      }
       shaka.log.v2(logPrefix,
           'buffer behind okay because nothing buffered:',
           'presentationTime=' + presentationTime,


### PR DESCRIPTION
Steps to retroduce:
1. Load content with CEA captions
2. Enable subtitles
3. Disable subtitles
4. Wait for a few minutes - application will hang due to recursive callbacks on text unload.

Issue is a regression introduced by combination of #7360 & #9068 