### PR TITLE
fix(Xbox): Enable little-endian PlayReady key IDs to resolve DRM error

### DIFF
--- a/lib/device/xbox.js
+++ b/lib/device/xbox.js
@@ -144,6 +144,14 @@ shaka.device.Xbox = class extends shaka.device.AbstractDevice {
     return config;
   }
 
+
+  /**
+   * @override
+   */
+  returnLittleEndianUsingPlayReady() {
+    return true;
+  }
+
   /**
    * @override
    */


### PR DESCRIPTION
This pull request introduces a small change to the `Xbox` device class, specifically related to PlayReady DRM support.

* Device DRM support: Added the `returnLittleEndianUsingPlayReady` method to the `shaka.device.Xbox` class, which always returns `true`, indicating that PlayReady should use little-endian byte order on Xbox devices.

Fixes https://github.com/shaka-project/shaka-player/issues/9347