### PR TITLE
build: Avoid optimization in getMediaElement on compiled builds

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4581,6 +4581,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @return {HTMLMediaElement}
    * @export
+   * @noinline
    */
   getMediaElement() {
     return this.video_;


### PR DESCRIPTION
`@noinline` --> Denotes a function or variable that should not be inlined by the optimizations.

This is necessary when using CastProxy and you want to call getMediaElement and have it return the proxied mediaElement.