### PR TITLE
build: Avoid optimization in getLoadMode and isFullyLoaded on compiled builds

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4556,6 +4556,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @return {shaka.Player.LoadMode}
    * @export
+   * @noinline
    */
   getLoadMode() {
     return this.loadMode_;
@@ -4827,6 +4828,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    *
    * @return {boolean}
    * @export
+   * @noinline
    */
   isFullyLoaded() {
     return this.fullyLoaded_;


### PR DESCRIPTION
`@noinline` --> Denotes a function or variable that should not be inlined by the optimizations.

This is necessary when using CastProxy.