### PR TITLE
build: Configure types path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     ]
   },
   "main": "dist/shaka-player.compiled.js",
+  "types": "dist/shaka-player.compiled.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/shaka-project/shaka-player.git"


### PR DESCRIPTION
this allows typescript to pick up the types in dist. See [publishing typescript](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).

avoids requiring typescript global declaration workarounds described [here](https://stackoverflow.com/questions/74672369/how-to-import-shaka-player-with-typescript) and [here](https://dev.to/vanyaxk/shaka-player-for-media-playback-implementation-use-cases-pros-and-cons-3b87)