### PR TITLE
fix(Preload): Do not fetch license if delayLicenseRequestUntilPlayed is set

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -1376,9 +1376,10 @@ shaka.drm.DrmEngine = class {
    */
   delayLicenseRequest_() {
     if (!this.video_) {
-      // If there's no video, don't delay the license request; i.e., in the case
-      // of offline storage.
-      return false;
+      // If there's no video, don't delay the license request for offline
+      // scenario, otherwise respect the config.
+      return !this.initializedForStorage_ &&
+          this.config_.delayLicenseRequestUntilPlayed;
     }
     return (this.config_.delayLicenseRequestUntilPlayed &&
             this.video_.paused && !this.initialRequestsSent_);
@@ -1386,7 +1387,7 @@ shaka.drm.DrmEngine = class {
 
   /** @return {!Promise} */
   async waitForActiveRequests() {
-    if (this.hasInitData_) {
+    if (this.hasInitData_ && !this.delayLicenseRequest_()) {
       await this.allSessionsLoaded_;
       await Promise.all(this.activeRequests_.map((req) => req.promise));
     }


### PR DESCRIPTION
DRM license is always fetched prior to play when there is no video element. It was done like that to support offline scenario. But on preload, we should delay license request if that was specified in configuration.