### PR TITLE
fix(DRM): Fix cache keys to include encryption scheme

### DIFF
--- a/lib/drm/drm_utils.js
+++ b/lib/drm/drm_utils.js
@@ -198,11 +198,15 @@ shaka.drm.DrmUtils = class {
    * @param {string} videoCodec
    * @param {string} audioCodec
    * @param {string} keySystem
+   * @param {!Array<string>} encryptionSchemes
    * @return {string}
    * @private
    */
-  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem) {
-    return `${videoCodec}#${audioCodec}#${keySystem}`;
+  static generateKeySystemCacheKey_(videoCodec, audioCodec, keySystem,
+      encryptionSchemes) {
+    const uniqueSchemes = new Set(encryptionSchemes);
+    const schemeKey = [...uniqueSchemes].sort().join('#');
+    return `${videoCodec}#${audioCodec}#${keySystem}#${schemeKey}`;
   }
 
   /**
@@ -212,12 +216,14 @@ shaka.drm.DrmUtils = class {
    * @param {string} videoCodec
    * @param {string} audioCodec
    * @param {string} keySystem
+   * @param {!Array<string>} encryptionSchemes
    * @return {boolean}
    */
-  static hasMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+  static hasMediaKeySystemAccess(videoCodec, audioCodec, keySystem,
+      encryptionSchemes) {
     const DrmUtils = shaka.drm.DrmUtils;
     const key = DrmUtils.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
+        videoCodec, audioCodec, keySystem, encryptionSchemes);
     return DrmUtils.memoizedMediaKeySystemAccessRequests_.has(key);
   }
 
@@ -227,12 +233,14 @@ shaka.drm.DrmUtils = class {
    * @param {string} videoCodec
    * @param {string} audioCodec
    * @param {string} keySystem
+   * @param {!Array<string>} encryptionSchemes
    * @return {?MediaKeySystemAccess}
    */
-  static getMediaKeySystemAccess(videoCodec, audioCodec, keySystem) {
+  static getMediaKeySystemAccess(videoCodec, audioCodec, keySystem,
+      encryptionSchemes) {
     const DrmUtils = shaka.drm.DrmUtils;
     const key = DrmUtils.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
+        videoCodec, audioCodec, keySystem, encryptionSchemes);
     return DrmUtils.memoizedMediaKeySystemAccessRequests_.get(key) || null;
   }
 
@@ -242,12 +250,14 @@ shaka.drm.DrmUtils = class {
    * @param {string} videoCodec
    * @param {string} audioCodec
    * @param {string} keySystem
+   * @param {!Array<string>} encryptionSchemes
    * @param {!MediaKeySystemAccess} mksa
    */
-  static setMediaKeySystemAccess(videoCodec, audioCodec, keySystem, mksa) {
+  static setMediaKeySystemAccess(videoCodec, audioCodec, keySystem,
+      encryptionSchemes, mksa) {
     const DrmUtils = shaka.drm.DrmUtils;
     const key = DrmUtils.generateKeySystemCacheKey_(
-        videoCodec, audioCodec, keySystem);
+        videoCodec, audioCodec, keySystem, encryptionSchemes);
     DrmUtils.memoizedMediaKeySystemAccessRequests_.set(key, mksa);
   }
 

--- a/lib/polyfill/media_capabilities.js
+++ b/lib/polyfill/media_capabilities.js
@@ -190,6 +190,7 @@ shaka.polyfill.MediaCapabilities = class {
     const MimeUtils = shaka.util.MimeUtils;
     const audioCapabilities = [];
     const videoCapabilities = [];
+    const encryptionSchemes = [];
 
     if (mcapKeySystemConfig.audio) {
       const capability = {
@@ -209,6 +210,7 @@ shaka.polyfill.MediaCapabilities = class {
       if (mcapKeySystemConfig.audio.encryptionScheme) {
         capability.encryptionScheme =
             mcapKeySystemConfig.audio.encryptionScheme;
+        encryptionSchemes.push(mcapKeySystemConfig.audio.encryptionScheme);
       }
 
       audioCapabilities.push(capability);
@@ -219,10 +221,13 @@ shaka.polyfill.MediaCapabilities = class {
         robustness: mcapKeySystemConfig.video.robustness || '',
         contentType: videoConfig.contentType,
       };
+
       if (mcapKeySystemConfig.video.encryptionScheme) {
         capability.encryptionScheme =
             mcapKeySystemConfig.video.encryptionScheme;
+        encryptionSchemes.push(mcapKeySystemConfig.video.encryptionScheme);
       }
+
       videoCapabilities.push(capability);
     }
 
@@ -255,14 +260,15 @@ shaka.polyfill.MediaCapabilities = class {
     let keySystemAccess = null;
     try {
       if (shaka.drm.DrmUtils.hasMediaKeySystemAccess(
-          videoCodec, audioCodec, keySystem)) {
+          videoCodec, audioCodec, keySystem, encryptionSchemes)) {
         keySystemAccess = shaka.drm.DrmUtils.getMediaKeySystemAccess(
-            videoCodec, audioCodec, keySystem);
+            videoCodec, audioCodec, keySystem, encryptionSchemes);
       } else {
         keySystemAccess = await navigator.requestMediaKeySystemAccess(
             mcapKeySystemConfig.keySystem, [mediaKeySystemConfig]);
         shaka.drm.DrmUtils.setMediaKeySystemAccess(
-            videoCodec, audioCodec, keySystem, keySystemAccess);
+            videoCodec, audioCodec, keySystem, encryptionSchemes,
+            keySystemAccess);
       }
     } catch (e) {
       shaka.log.info('navigator.requestMediaKeySystemAccess failed.');


### PR DESCRIPTION
When caching a result from EME, it's important to consider the encryption scheme, which can affect the success or failure of a query.