### PR TITLE
fix(DRM): Apply initDataTransform before deduping

### DIFF
--- a/lib/drm/drm_engine.js
+++ b/lib/drm/drm_engine.js
@@ -830,6 +830,22 @@ shaka.drm.DrmEngine = class {
       return;
     }
 
+    try {
+      initData = this.config_.initDataTransform(
+          initData, initDataType, this.currentDrmInfo_);
+    } catch (error) {
+      let shakaError = error;
+      if (!(error instanceof shaka.util.Error)) {
+        shakaError = new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.DRM,
+            shaka.util.Error.Code.INIT_DATA_TRANSFORM_ERROR,
+            error);
+      }
+      this.onError_(shakaError);
+      return;
+    }
+
     // Suppress duplicate init data.
     // Note that some init data are extremely large and can't portably be used
     // as keys in a dictionary.
@@ -1307,22 +1323,6 @@ shaka.drm.DrmEngine = class {
       type: sessionType,
     };
     this.activeSessions_.set(session, metadata);
-
-    try {
-      initData = this.config_.initDataTransform(
-          initData, initDataType, this.currentDrmInfo_);
-    } catch (error) {
-      let shakaError = error;
-      if (!(error instanceof shaka.util.Error)) {
-        shakaError = new shaka.util.Error(
-            shaka.util.Error.Severity.CRITICAL,
-            shaka.util.Error.Category.DRM,
-            shaka.util.Error.Code.INIT_DATA_TRANSFORM_ERROR,
-            error);
-      }
-      this.onError_(shakaError);
-      return;
-    }
 
     if (this.config_.logLicenseExchange) {
       const str = shaka.util.Uint8ArrayUtils.toBase64(initData);


### PR DESCRIPTION
Before this, DRM engine would dedup using the old initData, then transform it via callback, then create sessions. So if the transformation creates duplicate initData, we get more DRM sessions than we should have otherwise.

This changes the order from "1. dedup, 2. transform, 3. create" to "1. transform, 2. dedup, 3. create", so that deduplication can also work on transformed init data.