### PR TITLE
perf: Allow update the segments on streaming engine more often

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1615,7 +1615,13 @@ shaka.media.StreamingEngine = class {
       // In any case just try again... if the manifest is incomplete or is not
       // being updated then we'll idle forever; otherwise, we'll end up getting
       // a SegmentReference eventually.
-      return updateIntervalSeconds;
+      let lastSegmentDuration = Infinity;
+      const lastSegmentReference = mediaState.lastSegmentReference;
+      if (lastSegmentReference) {
+        lastSegmentDuration =
+            lastSegmentReference.endTime - lastSegmentReference.startTime;
+      }
+      return Math.min(lastSegmentDuration / 2, updateIntervalSeconds);
     }
 
     // Update some values mid stream for the initSegmentReference.


### PR DESCRIPTION
This is useful when some segments are shorter than updateIntervalSeconds