### PR TITLE
chore: Make public the codec regexps

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -289,9 +289,8 @@ shaka.util.ManifestParserUtils.GAP_OVERLAP_TOLERANCE_SECONDS = 1 / 15;
  * A list of regexps to detect well-known video codecs.
  *
  * @const {!Array<!RegExp>}
- * @private
  */
-shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS_ = [
+shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS = [
   /^avc/,
   /^hev/,
   /^hvc/,
@@ -309,9 +308,8 @@ shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS_ = [
  * A list of regexps to detect well-known audio codecs.
  *
  * @const {!Array<!RegExp>}
- * @private
  */
-shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_ = [
+shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS = [
   /^vorbis$/,
   /^Opus$/, // correct codec string according to RFC 6381 section 3.3
   /^opus$/, // some manifests wrongfully use this
@@ -333,9 +331,8 @@ shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_ = [
  * A list of regexps to detect well-known text codecs.
  *
  * @const {!Array<!RegExp>}
- * @private
  */
-shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS_ = [
+shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS = [
   /^vtt$/,
   /^wvtt/,
   /^stpp/,
@@ -346,6 +343,6 @@ shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS_ = [
  * @const {!Map<string, !Array<!RegExp>>}
  */
 shaka.util.ManifestParserUtils.CODEC_REGEXPS_BY_CONTENT_TYPE_ = new Map()
-    .set('audio', shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS_)
-    .set('video', shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS_)
-    .set('text', shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS_);
+    .set('audio', shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS)
+    .set('video', shaka.util.ManifestParserUtils.VIDEO_CODEC_REGEXPS)
+    .set('text', shaka.util.ManifestParserUtils.TEXT_CODEC_REGEXPS);


### PR DESCRIPTION
This is useful for being able to use regular expressions elsewhere in the code without having to duplicate them.