### PR TITLE
fix: text track `active` property with `SRC_EQUALS` load mode

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1617,7 +1617,7 @@ shaka.util.StreamUtils = class {
     /** @type {shaka.extern.TextTrack} */
     const track = {
       id: shaka.util.StreamUtils.html5TrackId(textTrack),
-      active: textTrack.mode != 'disabled',
+      active: textTrack.mode == 'showing',
       type: ContentType.TEXT,
       bandwidth: 0,
       language: shaka.util.LanguageUtils.normalize(textTrack.language || 'und'),


### PR DESCRIPTION
This fixes the `active` property on text tracks returned by `Player#getTextTracks()` still being `true` after calling `Player#selectTextTrack(null)` when the load mode is `SRC_EQUALS`, this was also causing the text track selector to still show the text track as selected after clicking `Off`.

The text track selector UI issue is only a problem on the main branch (v5.0) as #9048 hasn't been released in any of the release branches yet.