### PR TITLE
fix: failing silently if all representations have `dependencyId` attrs

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -2100,7 +2100,7 @@ shaka.dash.DashParser = class {
       return parsedRepresentation;
     }).filter((s) => !!s);
 
-    if (streams.length == 0 && dependencyStreamMap.size == 0) {
+    if (streams.length == 0) {
       const isImage = context.adaptationSet.contentType == ContentType.IMAGE;
       // Ignore empty AdaptationSets if ignoreEmptyAdaptationSet is true
       // or they are for text/image content.


### PR DESCRIPTION
I encountered an issue with some dash streams getting infinite buffering on Shaka 4.14.0+, and discovered it was due to all video representations having faulty `dependencyId` attributes. Even the representation every other representation incorrectly identified as their `dependencyId`, had a `dependencyId` pointing to itself, and hence that too got filtered out.

The result of this is that the `streams` array ends up empty, but `dependencyStreamMap` does not, and instead of throwing `DASH_EMPTY_ADAPTATION_SET` it ends up in the buffering state infinitely.

~~So I think having a non-empty dependencyStreamMap doesn't matter for this. The way I read it, that means you have only enhancement layers that depends on base layers, but you have no base layers, so effectively you have an empty adaption set?~~

Seems not. Marking as draft and will try to fix it.