### PR TITLE
fix(UI): Align seek hover and drag time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -75,6 +75,7 @@ Mirego <*@mirego.com>
 Mohamed Rashid <ge_rashid@hotmail.co.uk>
 Morten Hansen <mimo@mimo-design.com>
 Nick Desaulniers <nick@mozilla.com>
+Nishant Chitkara <nishant6200@gmail.com>
 Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -112,6 +112,7 @@ Morten Hansen <mimo@mimo-design.com>
 Natalie Harris <natalieharris@google.com>
 Nick Desaulniers <nick@mozilla.com>
 Niklas Korz <nk@alugha.com>
+Nishant Chitkara <nishant6200@gmail.com>
 Oskar Arvidsson <oskar@irock.se>
 Patrick Cruikshank <patrick.cruikshank@gmail.com>
 Patrick Kunka <patrick@kunkalabs.com>


### PR DESCRIPTION
Align drag/click mapping with hover to remove the thumb-width offset, so that the hover and drag click point to the same timestamp in the video.


https://github.com/user-attachments/assets/1f7323d8-42a5-41d7-bf5e-0381dee85cff

