### PR TITLE
fix: Fix access violation in TimedMetadata handler

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -2757,7 +2757,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
               switch (track.kind) {
                 case 'metadata':
-                  this.processTimedMetadataSrcEquals_(track);
+                  this.processTimedMetadata_(track);
                   break;
 
                 case 'chapters':
@@ -3490,7 +3490,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @param {!TextTrack} track
    * @private
    */
-  processTimedMetadataSrcEquals_(track) {
+  processTimedMetadata_(track) {
     if (track.kind != 'metadata') {
       return;
     }
@@ -3504,7 +3504,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         const metadatas = [];
 
         for (const cue of track.cues) {
-          if (cue.startTime != null) {
+          // Ensure this is DataCue, not other TextTrackCue implementation.
+          if (cue.startTime != null && 'type' in cue) {
             let metadata = metadatas.find((i) => {
               return i.startTime == cue.startTime && i.endTime == cue.endTime;
             });


### PR DESCRIPTION
Fixing exception that might happen if anyone will add VTTCue as a metadata track cue.

<img width="855" height="626" alt="image" src="https://github.com/user-attachments/assets/93823c35-da79-4477-a167-880b68c9752f" />
