### PR TITLE
fix(DRM): Fix multikey playback on devices with SW DRM only

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -8685,16 +8685,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     if (tracksChanged) {
       this.onTracksChanged_();
-      const variantsUpdated = this.updateAbrManagerVariants_();
-      if (!variantsUpdated) {
-        return;
-      }
-    }
 
-    const currentVariant = this.streamingEngine_.getCurrentVariant();
-    if (currentVariant && !currentVariant.allowedByKeySystem) {
-      shaka.log.debug('Choosing new streams after key status changed');
-      this.chooseVariantAndSwitch_();
+      const currentVariant = this.streamingEngine_.getCurrentVariant();
+      if (currentVariant && !currentVariant.allowedByKeySystem) {
+        shaka.log.debug('Choosing new streams after key status changed');
+        this.chooseVariantAndSwitch_();
+      } else {
+        this.updateAbrManagerVariants_();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #9430 

Fix might not be clearly visible, but the problem lies in `updateAbrManagerVariants_()` call. On key status handler it was called twice, firstly when we notice tracks has changed, and second time when trying to switch to new variant. Unfortunately, when this method returns `false`, player will not choose new variant, because it thinks nothing has changed.

Logic has been adjusted to always call this method once in a key status flow.