### PR TITLE
chore: Clean up and comment stream filtering

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -31,7 +31,9 @@ shaka.util.StreamUtils = class {
   /**
    * In case of multiple usable codecs, choose one based on lowest average
    * bandwidth and filter out the rest.
+   *
    * Also filters out variants that have too many audio channels.
+   *
    * @param {!shaka.extern.Manifest} manifest
    * @param {!Array<string>} preferredVideoCodecs
    * @param {!Array<string>} preferredAudioCodecs
@@ -45,6 +47,7 @@ shaka.util.StreamUtils = class {
 
     if (preferredTextFormats.length) {
       let subset = manifest.textStreams;
+
       for (const textFormat of preferredTextFormats) {
         const filtered = subset.filter((textStream) => {
           if (textStream.codecs.startsWith(textFormat) ||
@@ -53,11 +56,14 @@ shaka.util.StreamUtils = class {
           }
           return false;
         });
+
+        // If we found a match for this format, stop here.
         if (filtered.length) {
           subset = filtered;
           break;
         }
       }
+
       manifest.textStreams = subset;
     }
 
@@ -67,6 +73,9 @@ shaka.util.StreamUtils = class {
       variants = StreamUtils.choosePreferredCodecs(variants,
           preferredVideoCodecs, preferredAudioCodecs);
     }
+
+    // Now we have filtered variants and text tracks down by user preferences
+    // for formats and codecs.
 
     if (preferredDecodingAttributes.length) {
       // group variants by resolution and choose preferred variants only
@@ -96,6 +105,9 @@ shaka.util.StreamUtils = class {
       variants = bestVariants;
     }
 
+    // Now we have filtered variants and text tracks down by user preferences
+    // for formats, codecs, and decoding attributes (smooth, efficient, etc).
+
     const audioStreamsSet = new Set();
     const videoStreamsSet = new Set();
     for (const variant of variants) {
@@ -107,23 +119,46 @@ shaka.util.StreamUtils = class {
       }
     }
 
+    // Audio streams sorted by bandwidth, lowest to highest.
     const audioStreams = Array.from(audioStreamsSet).sort((v1, v2) => {
       return v1.bandwidth - v2.bandwidth;
     });
+
+    // Maps that are used to choose codecs when there are no preferences in
+    // effect above.
     const validAudioIds = [];
     const validAudioStreamsMap = new Map();
-    const getAudioId = (stream) => {
-      let id = stream.language + (stream.channelsCount || 0) +
-        (stream.audioSamplingRate || 0) + stream.roles.join(',') +
-        stream.label + stream.groupId + stream.fastSwitching;
+
+    // A group ID composed of attributes like language, channels, role, etc to
+    // find redundant audio streams that only differ in terms of things like
+    // codec, format, and bitrate.
+    const getAudioGroupId = (stream) => {
+      const idParts = [
+        stream.language,
+        (stream.channelsCount || 0),
+        (stream.audioSamplingRate || 0),
+        stream.roles.join(','),
+        stream.label,
+        stream.groupId,
+        stream.fastSwitching,
+      ];
       if (stream.dependencyStream) {
-        id += stream.dependencyStream.baseOriginalId || '';
+        idParts.push(stream.dependencyStream.baseOriginalId || '');
       }
-      return id;
+      return idParts.join(';');
     };
+
+    // For the first audio stream in a group (lowest bandwidth by sorting
+    // above), add it to the map.  For subsequent audio streams in a group,
+    // only add it to the map if the codec matches.  This could make a bad
+    // decision if not every audio codec is used on every quality level in the
+    // audio ladder.  In scenarios like this, use preferredAudioCodecs.  If
+    // preferredAudioCodecs is used, there should only be one codec left when
+    // we get to this stage.
     for (const stream of audioStreams) {
-      const groupId = getAudioId(stream);
+      const groupId = getAudioGroupId(stream);
       const validAudioStreams = validAudioStreamsMap.get(groupId) || [];
+
       if (!validAudioStreams.length) {
         validAudioStreams.push(stream);
         validAudioIds.push(stream.id);
@@ -134,13 +169,11 @@ shaka.util.StreamUtils = class {
         const currentCodec =
           MimeUtils.getNormalizedCodec(stream.codecs);
         if (previousCodec == currentCodec) {
-          if (!stream.bandwidth || !previousStream.bandwidth ||
-              stream.bandwidth > previousStream.bandwidth) {
-            validAudioStreams.push(stream);
-            validAudioIds.push(stream.id);
-          }
+          validAudioStreams.push(stream);
+          validAudioIds.push(stream.id);
         }
       }
+
       validAudioStreamsMap.set(groupId, validAudioStreams);
     }
 
@@ -159,75 +192,84 @@ shaka.util.StreamUtils = class {
       'vvc': 0.6,
     };
 
+    // Sort video streams by: bandwidth, then width (resolution), then assumed
+    // codec efficiency based on the above map.  This last check is only used
+    // if there are no preferredVideoCodecs set by the application (or if none
+    // of the preferred codecs match the content).
     const videoStreams = Array.from(videoStreamsSet)
         .sort((v1, v2) => {
-          if (!v1.bandwidth || !v2.bandwidth || v1.bandwidth == v2.bandwidth) {
-            if (v1.codecs && v2.codecs && v1.codecs != v2.codecs &&
-                v1.width == v2.width) {
-              const v1Codecs = MimeUtils.getNormalizedCodec(v1.codecs);
-              const v2Codecs = MimeUtils.getNormalizedCodec(v2.codecs);
-              if (v1Codecs != v2Codecs) {
-                const indexV1 = videoCodecPreference[v1Codecs] || 1;
-                const indexV2 = videoCodecPreference[v2Codecs] || 1;
-                return indexV1 - indexV2;
-              }
-            }
+          if (v1.bandwidth && v2.bandwidth && v1.bandwidth != v2.bandwidth) {
+            return v1.bandwidth - v2.bandwidth;
+          }
+          if (v1.width != v2.width) {
             return v1.width - v2.width;
           }
-          return v1.bandwidth - v2.bandwidth;
+          if (v1.codecs && v2.codecs) {
+            const v1Codecs = MimeUtils.getNormalizedCodec(v1.codecs);
+            const v2Codecs = MimeUtils.getNormalizedCodec(v2.codecs);
+            const indexV1 = videoCodecPreference[v1Codecs] || 1;
+            const indexV2 = videoCodecPreference[v2Codecs] || 1;
+            return indexV1 - indexV2;
+          }
+          return 0;
         });
 
-    const device = shaka.device.DeviceFactory.getDevice();
-    const supportsSmoothSwitch = device.supportsSmoothCodecSwitching();
-
+    // Maps that are used to choose codecs when there are no preferences in
+    // effect above.
     const validVideoIds = [];
     const validVideoStreamsMap = new Map();
+
+    // A group ID composed of attributes like resolution, frame rate, etc to
+    // find redundant video streams that only differ in terms of things like
+    // codec, format, and bitrate.
     const getVideoGroupId = (stream) => {
-      let id = String(stream.width || '') + String(stream.height || '') +
-          String(Math.round(stream.frameRate || 0)) + (stream.hdr || '') +
-          stream.fastSwitching;
+      const idParts = [
+        String(stream.width || ''),
+        String(stream.height || ''),
+        String(Math.round(stream.frameRate || 0)),
+        (stream.hdr || ''),
+        stream.fastSwitching,
+      ];
       if (stream.dependencyStream) {
-        id += stream.dependencyStream.baseOriginalId || '';
+        idParts.push(stream.dependencyStream.baseOriginalId || '');
       }
       if (stream.roles) {
-        id += stream.roles.sort().join('_');
+        idParts.push(stream.roles.sort().join('_'));
       }
-      return id;
+      return idParts.join(';');
     };
+
+    // For the first video stream in a group (lowest bandwidth / lowest res /
+    // highest efficiency codec by sorting above), add it to the map.  For
+    // subsequent video streams in a group (same resolution, frame rate, HDR,
+    // roles), only add it to the map if the codec matches.  Two items could be
+    // in the same group and codec if they have different URLs (failover,
+    // multi-CDN, etc) but probably not otherwise.
     for (const stream of videoStreams) {
       const groupId = getVideoGroupId(stream);
+
       const validVideoStreams = validVideoStreamsMap.get(groupId) || [];
       if (!validVideoStreams.length) {
         validVideoStreams.push(stream);
         validVideoIds.push(stream.id);
       } else {
         const previousStream = validVideoStreams[validVideoStreams.length - 1];
-        if (!supportsSmoothSwitch) {
-          const previousCodec =
-            MimeUtils.getNormalizedCodec(previousStream.codecs);
-          const currentCodec =
-            MimeUtils.getNormalizedCodec(stream.codecs);
-          if (previousCodec !== currentCodec) {
-            continue;
-          }
-        }
         const previousCodec =
           MimeUtils.getNormalizedCodec(previousStream.codecs);
         const currentCodec =
           MimeUtils.getNormalizedCodec(stream.codecs);
         if (previousCodec == currentCodec) {
-          if (!stream.bandwidth || !previousStream.bandwidth ||
-              stream.bandwidth > previousStream.bandwidth) {
-            validVideoStreams.push(stream);
-            validVideoIds.push(stream.id);
-          }
+          validVideoStreams.push(stream);
+          validVideoIds.push(stream.id);
         }
       }
+
       validVideoStreamsMap.set(groupId, validVideoStreams);
     }
 
     // Filter out any variants that don't match, forcing AbrManager to choose
-    // from a single video codec and a single audio codec possible.
+    // from a single video codec and a single audio codec **per stream group**
+    // (resolution, etc).
     manifest.variants = manifest.variants.filter((variant) => {
       const audio = variant.audio;
       const video = variant.video;


### PR DESCRIPTION
In chooseCodecsAndFilterManifest, there was a real lack of comments.  So first and foremost, this adds comments.

Second, group IDs for audio & video streams were made by concatenating various properties, but without delimiters, so there may have been a possibility for collisions.  This adds delimiters in the group ID construction.

Third, streams are already sorted by bandwidth before we start grouping them, so the grouping code for audio & video doesn't need to check `stream.bandwidth < previousStream.bandwidth`.  This should always be true.

Fourth, the video stream sorting conditions were too nested and hard to read.  This flattens those out in a way that makes them easier to understand.

Finally, because we're always only allowing one codec per group, skipping a stream due to `!supportsSmoothSwitch` makes no sense.  We're only ever adding streams to our filter list when their codecs match what's already in the group.  So the check on `supportsSmoothSwitch` is removed.