### PR TITLE
fix: Do not exclude time to first byte from measurements by default

### DIFF
--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2514,7 +2514,7 @@ shaka.extern.AdsConfiguration;
  *   If true, we remove the latency from first packet time. This time is
  *   used to calculate the real bandwidth.
  *   <br>
- *   Defaults to <code>true</code>.
+ *   Defaults to <code>false</code>.
  * @exportDoc
  */
 shaka.extern.AbrConfiguration;

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -336,7 +336,7 @@ shaka.util.PlayerConfiguration = class {
       cacheLoadThreshold: 5,
       minTimeToSwitch: 0,
       preferNetworkInformationBandwidth: false,
-      removeLatencyFromFirstPacketTime: true,
+      removeLatencyFromFirstPacketTime: false,
     };
 
     const cmcd = {


### PR DESCRIPTION
`removeLatencyFromFirstPacketTime: true` causes time to first byte to be excluded from throughput measurements, greatly inflating bandwidth estimates by as much as 2x.  This causes elevated rebuffering rates.

Measurements were taken on various Cast models, as well as Chrome on Linux.  In all cases, bandwidth estimates after 60 seconds of 4K Sintel with the flag set to `true` were about 2x what they would be with the flag set to `false`.

It appears that time to first byte is excluded from all requests, rather than just the first segment as is implied by the config docs.  It's also unclear to me, at least, what this was supposed to accomplish, even if only applied to one segment.  For now I'm neither removing nor attempting to fix the feature, until we can discuss the original thinking behind it.

As an emergency fix, because the default behavior was so problematic, this changes the default to `false`.  Applications that know better than me still have the option to set it explicitly to `true` for now.

See issue #9475, which will stay open until we decide what to do with this flag and its implementation.