### PR TITLE
chore: Use only raw fields in gh api calls

### DIFF
--- a/.github/workflows/report-incremental-coverage.yaml
+++ b/.github/workflows/report-incremental-coverage.yaml
@@ -52,11 +52,11 @@ jobs:
             gh api \
               --method POST \
               /repos/${{ github.repository }}/issues/$PR_NUMBER/comments \
-              -F "body=$MESSAGE"
+              -f "body=$MESSAGE"
           else
             # Update an old comment
             gh api \
               --method PATCH \
               /repos/${{ github.repository }}/issues/comments/$(cat old-comment-id) \
-              -F "body=$MESSAGE"
+              -f "body=$MESSAGE"
           fi

--- a/.github/workflows/shaka-bot-commands/lib.sh
+++ b/.github/workflows/shaka-bot-commands/lib.sh
@@ -30,13 +30,13 @@ function check_required_variable() {
 # Leaving a comment requires a token with "repo" scope.
 function reply() {
   echo "@$COMMENTER: $@" | \
-      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -F -
+      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -f -
 }
 
 # Leaving a comment requires a token with "repo" scope.
 function reply_from_pipe() {
   (echo -n "@$COMMENTER: "; cat /dev/stdin) | \
-      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -F -
+      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -f -
 }
 
 # Checking permissions requires a token with "repo" and "org:read" scopes, and


### PR DESCRIPTION
Workflows using gh api should always use -f (raw field) instead of -F (field including special characters) because a crafted message could be used to read files from the host, which could lead to things like leaked keys or other private information.

There is no known exploit, because these messages were not yet controllable by an attacker as far as we know, but better safe than sorry.

Discovered during a careful review of #9422, which adds new usage of gh api.