### PR TITLE
ci: Fix shaka-bot issue comments

### DIFF
--- a/.github/workflows/shaka-bot-commands/lib.sh
+++ b/.github/workflows/shaka-bot-commands/lib.sh
@@ -30,13 +30,13 @@ function check_required_variable() {
 # Leaving a comment requires a token with "repo" scope.
 function reply() {
   echo "@$COMMENTER: $@" | \
-      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -f -
+      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -F -
 }
 
 # Leaving a comment requires a token with "repo" scope.
 function reply_from_pipe() {
   (echo -n "@$COMMENTER: "; cat /dev/stdin) | \
-      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -f -
+      gh issue comment "$PR_NUMBER" -R "$THIS_REPO" -F -
 }
 
 # Checking permissions requires a token with "repo" and "org:read" scopes, and


### PR DESCRIPTION
Leaving issue comments was broken in #9482, which changed gh api's -F to -f for security reasons.  However, gh issue comment doesn't have -f, only -F, and this is distinct from gh api's problematic -F.

This reverts back to -F for gh issue comment.