### PR TITLE
fix: don't clear text displayer cache for vtt if we're clearing cea cache

### DIFF
--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -244,6 +244,11 @@ shaka.text.TextEngine = class {
     }
     if (removeClosedCaptions) {
       this.removeClosedCaptions_(startTime, endTime);
+      // if we are not displaying closed captions and are clearing data for
+      // closed captions, we shouldn't clear the displayer.
+      if (this.selectedClosedCaptionId_ === '') {
+        return;
+      }
     }
     if (this.displayer_ && this.displayer_.remove(startTime, endTime)) {
       if (this.bufferStart_ == null) {

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -261,6 +261,20 @@ describe('TextEngine', () => {
       expect(mockDisplayer.removeSpy).toHaveBeenCalledWith(0, 1);
     });
 
+    it('calls displayer.remove() if displaying CC and removing CC',
+        async () => {
+          textEngine.setSelectedClosedCaptionId('CC1', 1);
+          await textEngine.remove(0, 1, /* removeCC= */ true);
+          expect(mockDisplayer.removeSpy).toHaveBeenCalledWith(0, 1);
+        });
+
+    it('does not call displayer.remove() if not displaying CC and removing CC',
+        async () => {
+          textEngine.setSelectedClosedCaptionId('', 0);
+          await textEngine.remove(0, 1, /* removeCC= */ true);
+          expect(mockDisplayer.removeSpy).not.toHaveBeenCalled();
+        });
+
     it('does not throw if called right before destroy', async () => {
       const p = textEngine.remove(0, 1);
       textEngine.destroy();


### PR DESCRIPTION
an issue we found as part of making the fix for #9470 and also separately.