### PR TITLE
fix: Fix alignItems usage on old devices

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -845,11 +845,11 @@ shaka.text.UITextDisplayer = class {
       if (cue.textAlign == Cue.textAlign.LEFT ||
           cue.textAlign == Cue.textAlign.START) {
         style.width = '100%';
-        style.alignItems = 'self-start';
+        style.alignItems = 'flex-start';
       } else if (cue.textAlign == Cue.textAlign.RIGHT ||
           cue.textAlign == Cue.textAlign.END) {
         style.width = '100%';
-        style.alignItems = 'self-end';
+        style.alignItems = 'flex-end';
       }
 
       if (cue.displayAlign == Cue.displayAlign.BEFORE) {

--- a/test/text/ui_text_displayer_unit.js
+++ b/test/text/ui_text_displayer_unit.js
@@ -673,8 +673,8 @@ describe('UITextDisplayer', () => {
     expect(cueCss).toEqual(jasmine.objectContaining({
       'display': 'flex',
       'flex-direction': 'column',
-      // textAlign LEFT => alignItems 'self-start' and width 100%
-      'align-items': 'self-start',
+      // textAlign LEFT => alignItems 'flex-start' and width 100%
+      'align-items': 'flex-start',
       'width': '100%',
       // displayAlign BEFORE => justifyContent 'flex-start'
       'justify-content': 'flex-start',


### PR DESCRIPTION
start/end are supported from Chromium 93+ (see: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/align-items).