### PR TITLE
fix(Transmuxer): Keep stream width/height if it already exists

### DIFF
--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -943,8 +943,8 @@ shaka.transmuxer.TsTransmuxer = class {
           shaka.util.Error.Code.TRANSMUXING_FAILED,
           reference ? reference.getUris()[0] : null);
     }
-    stream.height = info.height;
-    stream.width = info.width;
+    stream.height = stream.height || info.height;
+    stream.width = stream.width || info.width;
 
     return {
       id: stream.id,
@@ -1038,8 +1038,8 @@ shaka.transmuxer.TsTransmuxer = class {
           shaka.util.Error.Code.TRANSMUXING_FAILED,
           reference ? reference.getUris()[0] : null);
     }
-    stream.height = info.height;
-    stream.width = info.width;
+    stream.height = stream.height || info.height;
+    stream.width = stream.width || info.width;
 
     return {
       id: stream.id,


### PR DESCRIPTION
Keep stream width/height if it already exists from the manifest, and only overwrite if the values were not available.

This change fixes a bug we were seeing with LCEVC, where the base stream NALUS would report a halved width/height as the base stream is later upscaled by the LCEVC decoder. In this case we would want to keep the original width/height values from the manifest and skip the overwrite.