### PR TITLE
fix(ABR): Safeguard calls to this.switch_

### DIFF
--- a/lib/abr/simple_abr_manager.js
+++ b/lib/abr/simple_abr_manager.js
@@ -106,7 +106,7 @@ shaka.abr.SimpleAbrManager = class {
       if (this.enabled_ && (this.config_.restrictToElementSize ||
           this.config_.restrictToScreenSize)) {
         const chosenVariant = this.chooseVariant();
-        if (chosenVariant) {
+        if (chosenVariant && this.switch_) {
           this.switch_(chosenVariant, this.config_.clearBufferSwitch,
               this.config_.safeMarginSwitch);
         }
@@ -513,7 +513,7 @@ shaka.abr.SimpleAbrManager = class {
     const bandwidthEstimate = this.getBandwidthEstimate();
     const currentBandwidthKbps = Math.round(bandwidthEstimate / 1000.0);
 
-    if (chosenVariant) {
+    if (chosenVariant && this.switch_) {
       shaka.log.debug(
           'Calling switch_(), bandwidth=' + currentBandwidthKbps + ' kbps');
       // If any of these chosen streams are already chosen, Player will filter


### PR DESCRIPTION
Safeguard calls to this.switch_ in case this.switch_ has not been initialised yet with a call to init() before the event callbacks fire.