### PR TITLE
build: print stderr if closure compiler errors

### DIFF
--- a/build/compiler.py
+++ b/build/compiler.py
@@ -226,9 +226,13 @@ class ClosureCompiler(object):
     proc = shakaBuildHelpers.execute_subprocess(
         cmd_line, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
-    stripped_wrapper_code = proc.communicate(wrapper_code.encode('utf8'))[0]
+    stripped_wrapper_code, stderr = proc.communicate(wrapper_code.encode('utf8'))
 
     if proc.returncode != 0:
+      # Print stderr to help diagnose the failure (e.g., Java version errors)
+      if stderr:
+        stderr_text = stderr.decode('utf-8', errors='replace')
+        logging.error('Closure Compiler failed with stderr:\n%s', stderr_text)
       raise RuntimeError('Failed to strip whitespace from wrapper!')
 
     with shakaBuildHelpers.open_file(wrapper_output_path, 'w') as f:


### PR DESCRIPTION
Prevents swallowing the error details (mainly happens if you use an old java version).

Before:
<img width="1592" height="948" alt="image" src="https://github.com/user-attachments/assets/c899a7b0-15ca-4952-84af-a9612941c357" />


After:
<img width="2458" height="1176" alt="image" src="https://github.com/user-attachments/assets/38eeb459-c37d-4f17-9563-666cc32a8e70" />

`execute_get_output` and `execute_get_code` in shakaBuildHelpers.py has the same problem with swallowing the error, but they are used for other commands and I didn't replicate any issues with them.