### PR TITLE
build: improve no changes detected log

### DIFF
--- a/build/compiler.py
+++ b/build/compiler.py
@@ -27,6 +27,10 @@ import generateLocalizations
 import shakaBuildHelpers
 
 
+_force_hint_shown = False
+_skip_messages_shown = set()
+
+
 def _canonicalize_source_files(source_files):
   """Canonicalize a set or list of source files.
 
@@ -45,6 +49,8 @@ def _get_source_path(path):
 def _must_build(output, source_files):
   """Returns True if any of the |source_files| have changed since |output| was
      built, or if |output| does not exist yet."""
+  global _force_hint_shown, _skip_messages_shown
+
   if not os.path.isfile(output):
     # Nothing built, so we should build the output.
     return True
@@ -64,7 +70,18 @@ def _must_build(output, source_files):
     if path and os.path.exists(path) and os.path.getmtime(path) > build_time:
       return True
 
-  logging.warning('No changes detected, skipping. Use --force to override.')
+  # Inform about the --force flag once (if something is skipped)
+  if not _force_hint_shown:
+    logging.warning('Detected output files that do not need to be rebuilt. Use --force to override.')
+    _force_hint_shown = True
+
+  # Log skip message once per output file
+  output_basename = os.path.basename(output)
+  if output_basename not in _skip_messages_shown:
+    logging.info('Skipping %s (already built)', output_basename)
+    _skip_messages_shown.add(output_basename)
+
+
   return False
 
 def _update_timestamp(path):


### PR DESCRIPTION
The "No changes detected" warning applies per output file, but the file wasn't included in the log, which was confusing to me. In addition to that, many of the builds depends on locales.js, so the log message got duplicated several times because of that when you build `./build/all.py`

This PR adds module level caching for build/compiler to avoid repetition and tries to make the log more informative.

It uses the output file basename, which seems like a safe assumption currently since the dist output structure is flat. But if this is a deal breaker maybe we can print the full path or the relative path from the shaka repo root instead.

This is the log for the most extreme case (`./build/all.py` directly after another build) before the PR:

```
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Generating Closure dependencies...
[INFO] Linting JavaScript...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Linting CSS...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Linting HTML...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Checking that the build files are complete...
[INFO] Checking for spelling mistakes in js files...
CSpell: Files checked: 578, Issues found: 0 in 0 files.
[INFO] Checking for spelling mistakes in md files...
CSpell: Files checked: 49, Issues found: 0 in 0 files.
[INFO] Checking for spelling mistakes in py files...
CSpell: Files checked: 16, Issues found: 0 in 0 files.
[INFO] Checking the tests for type errors...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Building the docs...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (experimental, debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (ui, debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (compiled, debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (dash, debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (hls, debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the demo app (debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the receiver app (debug)...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (experimental, release)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (ui, release)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (compiled, release)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (dash, release)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the library (hls, release)...
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the demo app (release)...
[WARNING] No changes detected, skipping. Use --force to override.
[INFO] Compiling the receiver app (release)...
[WARNING] No changes detected, skipping. Use --force to override.
```

With this PR it will print this instead:

```
[WARNING] Detected output files that do not need to be rebuilt. Use --force to override.
[INFO] Skipping locales.js (already built)
[INFO] Generating Closure dependencies...
[INFO] Linting JavaScript...
[INFO] Skipping .lintstamp (already built)
[INFO] Linting CSS...
[INFO] Skipping .csslintstamp (already built)
[INFO] Linting HTML...
[INFO] Skipping .htmllintstamp (already built)
[INFO] Checking that the build files are complete...
[INFO] Checking for spelling mistakes in js files...
CSpell: Files checked: 578, Issues found: 0 in 0 files.
[INFO] Checking for spelling mistakes in md files...
CSpell: Files checked: 49, Issues found: 0 in 0 files.
[INFO] Checking for spelling mistakes in py files...
CSpell: Files checked: 16, Issues found: 0 in 0 files.
[INFO] Checking the tests for type errors...
[INFO] Skipping .testcheckstamp (already built)
[INFO] Building the docs...
[INFO] Skipping index.html (already built)
[INFO] Skipping controls.css (already built)
[INFO] Skipping demo.css (already built)
[INFO] Compiling the library (experimental, debug)...
[INFO] Skipping shaka-player.experimental.debug.js (already built)
[INFO] Skipping shaka-player.experimental.debug.externs.js (already built)
[INFO] Skipping shaka-player.experimental.debug.d.ts (already built)
[INFO] Compiling the library (ui, debug)...
[INFO] Skipping shaka-player.ui.debug.js (already built)
[INFO] Skipping shaka-player.ui.debug.externs.js (already built)
[INFO] Skipping shaka-player.ui.debug.d.ts (already built)
[INFO] Compiling the library (compiled, debug)...
[INFO] Skipping shaka-player.compiled.debug.js (already built)
[INFO] Skipping shaka-player.compiled.debug.externs.js (already built)
[INFO] Skipping shaka-player.compiled.debug.d.ts (already built)
[INFO] Compiling the library (dash, debug)...
[INFO] Skipping shaka-player.dash.debug.js (already built)
[INFO] Skipping shaka-player.dash.debug.externs.js (already built)
[INFO] Skipping shaka-player.dash.debug.d.ts (already built)
[INFO] Compiling the library (hls, debug)...
[INFO] Skipping shaka-player.hls.debug.js (already built)
[INFO] Skipping shaka-player.hls.debug.externs.js (already built)
[INFO] Skipping shaka-player.hls.debug.d.ts (already built)
[INFO] Compiling the demo app (debug)...
[INFO] Skipping demo.compiled.debug.js (already built)
[INFO] Compiling the receiver app (debug)...
[INFO] Skipping receiver.compiled.debug.js (already built)
[INFO] Compiling the library (experimental, release)...
[INFO] Skipping shaka-player.experimental.js (already built)
[INFO] Skipping shaka-player.experimental.externs.js (already built)
[INFO] Skipping shaka-player.experimental.d.ts (already built)
[INFO] Compiling the library (ui, release)...
[INFO] Skipping shaka-player.ui.js (already built)
[INFO] Skipping shaka-player.ui.externs.js (already built)
[INFO] Skipping shaka-player.ui.d.ts (already built)
[INFO] Compiling the library (compiled, release)...
[INFO] Skipping shaka-player.compiled.js (already built)
[INFO] Skipping shaka-player.compiled.externs.js (already built)
[INFO] Skipping shaka-player.compiled.d.ts (already built)
[INFO] Compiling the library (dash, release)...
[INFO] Skipping shaka-player.dash.js (already built)
[INFO] Skipping shaka-player.dash.externs.js (already built)
[INFO] Skipping shaka-player.dash.d.ts (already built)
[INFO] Compiling the library (hls, release)...
[INFO] Skipping shaka-player.hls.js (already built)
[INFO] Skipping shaka-player.hls.externs.js (already built)
[INFO] Skipping shaka-player.hls.d.ts (already built)
[INFO] Compiling the demo app (release)...
[INFO] Skipping demo.compiled.js (already built)
[INFO] Compiling the receiver app (release)...
[INFO] Skipping receiver.compiled.js (already built)
```