### PR TITLE
build: generate localizations before gendeps

### DIFF
--- a/build/gendeps.py
+++ b/build/gendeps.py
@@ -21,6 +21,7 @@ import os
 import subprocess
 import sys
 
+import compiler
 import shakaBuildHelpers
 
 
@@ -39,6 +40,10 @@ def main(_):
   except OSError:
     pass
   os.chdir(base)
+
+  localizations = compiler.GenerateLocalizations(None)
+  if not localizations.generate():
+    return 1
 
   make_deps = shakaBuildHelpers.get_node_binary(
       'google-closure-deps', 'closure-make-deps')


### PR DESCRIPTION
`gendeps.py` is documented in build/readme.md as "required to use the uncompiled library", which to me sounds like it should work standalone if you just want to build and test the demo? https://github.com/shaka-project/shaka-player/blob/main/build/README.md?plain=1#L12

If you check out the repo fresh or remove dist and run `./build/gendeps.py` it will fail because it depends on locales.js to be built.

(also, trying to run `./build/generateLocalizations.py` before `./build/gendeps.py` will fail too if you don't `mkdir -p dist` first.

I might need some guidance here about whether to add a locales CLI argument. "build/check.py" already runs without this and will generate locales.js with the default locales, which seems reasonable for this command.

But it seems error prone to me to both be able to specify locales and to use date based conditional checks if locales should be rebuilt, because locales.js can be more recent but generated with different locales.