### PR TITLE
fix: add guards to prevent errors removing already detached media sources

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -265,10 +265,10 @@ shaka.media.MediaSourceEngine = class {
     this.url_ = shaka.media.MediaSourceEngine.createObjectURL(mediaSource);
     if (this.config_.useSourceElements) {
       this.video_.removeAttribute('src');
-      if (this.source_) {
+      if (this.source_?.parentElement === this.video_) {
         this.video_.removeChild(this.source_);
       }
-      if (this.secondarySource_) {
+      if (this.secondarySource_?.parentElement === this.video_) {
         this.video_.removeChild(this.secondarySource_);
       }
       this.source_ = shaka.util.Dom.createSourceElement(this.url_);
@@ -297,7 +297,7 @@ shaka.media.MediaSourceEngine = class {
     if (!this.config_.useSourceElements) {
       return;
     }
-    if (this.secondarySource_) {
+    if (this.secondarySource_?.parentElement === this.video_) {
       this.video_.removeChild(this.secondarySource_);
     }
     this.secondarySource_ = shaka.util.Dom.createSourceElement(uri, mimeType);
@@ -453,10 +453,10 @@ shaka.media.MediaSourceEngine = class {
       this.eventManager_ = null;
     }
 
-    if (this.video_ && this.secondarySource_) {
+    if (this.video_ && this.secondarySource_?.parentElement === this.video_) {
       this.video_.removeChild(this.secondarySource_);
     }
-    if (this.video_ && this.source_) {
+    if (this.video_ && this.source_?.parentElement === this.video_) {
       // "unload" the video element.
       this.video_.removeChild(this.source_);
       this.video_.load();


### PR DESCRIPTION
Media source engine internally handles `source_` and `secondarySource_` safely by resetting or recreating them after they are removed from the dom. But I have still been getting errors from shaka about this.

Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
at removeChild (../lib/media/media_source_engine.js:267:20)
at createMediaSource (../lib/media/media_source_engine.js:530:31)
at [unknown] (src/com/google/javascript/jscomp/js/es6/generator_engine.js:795:37)
at [unknown] (src/com/google/javascript/jscomp/js/es6/generator_engine.js:699:14)
at [unknown] (src/com/google/javascript/jscomp/js/es6/execute_async_generator.js:52:21)

(the error stack was deminified with https://github.com/mifi/stacktracify)

This was reproduced on a cast receiver app with Shaka 4.16.9 (I didn't see any changes related to this logic added since).

CAF framework PlayerManager reuses the same video element when you make a new load request, which could cause this.

I also noticed the sources can be removed from the player:
https://github.com/shaka-project/shaka-player/blob/main/lib/player.js#L2661-L2663

Although MediaSourceEngine shouldn't exist at this point, if something else like an error or state change could triggers a reload it could this could cause trouble also, so I think having these guards is better than not.

These fixes could probably just check if parentElement exists, but if they were somehow moved to a different parent the removeChild call would still fail, so I checked that too.