### PR TITLE
fix(ContentWorkarounds): Insert PSSH boxes for fake init encryption

### DIFF
--- a/lib/media/content_workarounds.js
+++ b/lib/media/content_workarounds.js
@@ -229,6 +229,10 @@ shaka.media.ContentWorkarounds = class {
           workItem.newType);
     }
 
+    // Insert PSSH boxes as some platforms require it, i.e. NOS STBs.
+    modifiedInitSegment = ContentWorkarounds.insertPsshBoxes_(stream,
+        modifiedInitSegment);
+
     // Edge Windows needs the unmodified init segment to be appended after the
     // patched one, otherwise video element throws following error:
     // CHUNK_DEMUXER_ERROR_APPEND_FAILED: Sample encryption info is not
@@ -461,6 +465,46 @@ shaka.media.ContentWorkarounds = class {
         metadataBoxArray, /* boxStart= */ 0, metadataBoxArray.byteLength);
 
     return metadataBoxArray;
+  }
+
+  /**
+   * @param {!shaka.extern.Stream} stream
+   * @param {!Uint8Array} initSegment
+   * @return {!Uint8Array}
+   * @private
+   */
+  static insertPsshBoxes_(stream, initSegment) {
+    const psshs = new shaka.util.Mp4Generator().psshs(stream);
+    if (psshs.byteLength === 0) {
+      return initSegment;
+    }
+
+    let moovBoxStart = 0;
+    let moovBoxSize = 0;
+    new shaka.util.Mp4Parser()
+        .box('moov', (box) => {
+          moovBoxStart = box.start;
+          moovBoxSize = box.size;
+          box.parser.stop();
+        })
+        .parse(initSegment);
+
+    const updatedMoovBoxSize = moovBoxSize + psshs.byteLength;
+    const cutPoint = moovBoxStart + moovBoxSize;
+
+    shaka.media.ContentWorkarounds.updateBoxSize_(
+        initSegment, moovBoxStart, updatedMoovBoxSize);
+
+    const newInitSegment = new Uint8Array(initSegment.byteLength +
+      psshs.byteLength);
+    const beforeData = initSegment.subarray(0, cutPoint);
+    const afterData = initSegment.subarray(cutPoint);
+
+    newInitSegment.set(beforeData);
+    newInitSegment.set(psshs, cutPoint);
+    newInitSegment.set(afterData, cutPoint + psshs.byteLength);
+
+    return newInitSegment;
   }
 
   /**

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -59,7 +59,7 @@ shaka.util.Mp4Generator = class {
         this.mvhd_(firstStreamInfo),
         traks,
         this.mvex_(),
-        this.pssh_(firstStreamInfo));
+        this.psshs(firstStreamInfo.stream));
   }
 
   /**
@@ -790,17 +790,16 @@ shaka.util.Mp4Generator = class {
   /**
    * Generate a PSSH box
    *
-   * @param {shaka.util.Mp4Generator.StreamInfo} streamInfo
+   * @param {!shaka.extern.Stream} stream
    * @return {!Uint8Array}
-   * @private
    */
-  pssh_(streamInfo) {
+  psshs(stream) {
     const initDatas = [];
-    if (!shaka.util.Mp4Generator.isStreamEncrypted_(streamInfo.stream)) {
+    if (!shaka.util.Mp4Generator.isStreamEncrypted_(stream)) {
       return new Uint8Array([]);
     }
 
-    for (const drmInfo of streamInfo.stream.drmInfos) {
+    for (const drmInfo of stream.drmInfos) {
       if (!drmInfo.initData) {
         continue;
       }


### PR DESCRIPTION
Related to #8048

Some platforms (i.e. NOS STB) are not able to play encrypted content without PSSH boxes in init segments. This PR addresses it by adding PSSH boxes with actual data if we have it.