### PR TITLE
fix: Disable smooth codec switching for Hisense VIDAA

### DIFF
--- a/lib/device/hisense.js
+++ b/lib/device/hisense.js
@@ -47,6 +47,13 @@ shaka.device.Hisense = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
+  supportsSmoothCodecSwitching() {
+    return false;
+  }
+
+  /**
+   * @override
+   */
   detectMaxHardwareResolution() {
     const maxResolution = {width: 1920, height: 1080};
     let supports4k = null;


### PR DESCRIPTION
Ran a multi codec test and transitioning from AAC to AC3 fails silently on Hisense VIDAA (there's no audio), despite `changeType` indicating else wise. 

We should disable SMOOTH for this device, similar to Tizen and webOS.