### PR TITLE
feat: Only disallow SourceBuffer.changeType on PlayReady when using Edge browser

### DIFF
--- a/externs/shaka/adaptation_set_criteria.js
+++ b/externs/shaka/adaptation_set_criteria.js
@@ -77,6 +77,7 @@ shaka.extern.AdaptationSetCriteria.Factory;
  *   activeAudioChannelCount: number,
  *   preferredAudioCodecs: !Array<string>,
  *   preferredAudioChannelCount: number,
+ *   keySystem: string,
  * }}
  *
  * @property {string} language
@@ -109,6 +110,8 @@ shaka.extern.AdaptationSetCriteria.Factory;
  *   The ordered list of audio codecs to filter variants.
  * @property {number} preferredAudioChannelCount
  *   The preferred audio channel count to filter variants.
+ * @property {number} keySystem
+ *   Current used key system or empty if not used.
  * @exportDoc
  */
 shaka.extern.AdaptationSetCriteria.Configuration;

--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -203,7 +203,7 @@ shaka.device.AbstractDevice = class {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
+  supportsSmoothCodecSwitching(keySystem) {
     const sourceBuffer = window.ManagedSourceBuffer || window.SourceBuffer;
     return !!sourceBuffer &&
         // eslint-disable-next-line no-restricted-syntax

--- a/lib/device/chromecast.js
+++ b/lib/device/chromecast.js
@@ -88,8 +88,8 @@ shaka.device.Chromecast = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
-    return super.supportsSmoothCodecSwitching() &&
+  supportsSmoothCodecSwitching(keySystem) {
+    return super.supportsSmoothCodecSwitching(keySystem) &&
       this.osType_.value() !== shaka.device.Chromecast.OsType_.LINUX;
   }
 

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -60,17 +60,6 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
     });
 
     /** @private {!shaka.util.Lazy<boolean>} */
-    this.supportsSmoothCodecSwitching_ = new shaka.util.Lazy(() => {
-      if (!super.supportsSmoothCodecSwitching()) {
-        return false;
-      }
-      if (!navigator.userAgent.match(/Edge?\//)) {
-        return true;
-      }
-      return !this.isWindows_.value();
-    });
-
-    /** @private {!shaka.util.Lazy<boolean>} */
     this.isSonyTV_ = new shaka.util.Lazy(() => {
       return navigator.userAgent.includes('sony.hbbtv.tv');
     });
@@ -127,8 +116,12 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
-    return this.supportsSmoothCodecSwitching_.value();
+  supportsSmoothCodecSwitching(keySystem) {
+    if (this.deviceName_.value() === 'Edge' && this.isWindows_.value() &&
+        shaka.drm.DrmUtils.isPlayReadyKeySystem(keySystem)) {
+      return false;
+    }
+    return super.supportsSmoothCodecSwitching(keySystem);
   }
 
   /**
@@ -210,7 +203,7 @@ shaka.device.DefaultBrowser = class extends shaka.device.AbstractDevice {
    */
   needWaitForEncryptedEvent(keySystem) {
     if (this.getBrowserEngine() === shaka.device.IDevice.BrowserEngine.GECKO) {
-      return keySystem.startsWith('com.microsoft.playready.recommendation');
+      return shaka.drm.DrmUtils.isPlayReadyKeySystem(keySystem);
     }
     return super.needWaitForEncryptedEvent(keySystem);
   }

--- a/lib/device/i_device.js
+++ b/lib/device/i_device.js
@@ -131,9 +131,10 @@ shaka.device.IDevice = class {
    * reports that it supports <code<changeType</code> but supports it unreliably
    * it should be disallowed in this method.
    *
+   * @param {string} keySystem
    * @return {boolean}
    */
-  supportsSmoothCodecSwitching() {}
+  supportsSmoothCodecSwitching(keySystem) {}
 
   /**
    * On some platforms, the act of seeking can take a significant amount

--- a/lib/device/playstation.js
+++ b/lib/device/playstation.js
@@ -75,7 +75,7 @@ shaka.device.PlayStation = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
+  supportsSmoothCodecSwitching(keySystem) {
     return false;
   }
 

--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -89,7 +89,7 @@ shaka.device.Tizen = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
+  supportsSmoothCodecSwitching(keySystem) {
     return false;
   }
 

--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -98,7 +98,7 @@ shaka.device.WebOS = class extends shaka.device.AbstractDevice {
   /**
    * @override
    */
-  supportsSmoothCodecSwitching() {
+  supportsSmoothCodecSwitching(keySystem) {
     return false;
   }
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -2260,7 +2260,8 @@ shaka.media.MediaSourceEngine = class {
     shaka.log.debug(
         `Change Type: ${sourceBuffer} -> ${mimeType}`);
     const device = shaka.device.DeviceFactory.getDevice();
-    if (device.supportsSmoothCodecSwitching()) {
+    const keySystem = this.playerInterface_.getKeySystem();
+    if (device.supportsSmoothCodecSwitching(keySystem)) {
       if (this.transmuxers_.has(contentType)) {
         this.transmuxers_.get(contentType).destroy();
         this.transmuxers_.delete(contentType);
@@ -2575,9 +2576,10 @@ shaka.media.MediaSourceEngine = class {
     }
 
     const device = shaka.device.DeviceFactory.getDevice();
+    const keySystem = this.playerInterface_.getKeySystem();
     if (allowChangeType && this.config_.codecSwitchingStrategy ===
         shaka.config.CodecSwitchingStrategy.SMOOTH &&
-          device.supportsSmoothCodecSwitching()) {
+          device.supportsSmoothCodecSwitching(keySystem)) {
       return {
         type: shaka.media.MediaSourceEngine.ResetMode_.CHANGE_TYPE,
         newMimeType,
@@ -2740,7 +2742,7 @@ shaka.media.MediaSourceEngine.ResetMode_ = {
 
 /**
  * @typedef {{
- *   getKeySystem: function():?string,
+ *   getKeySystem: function():string,
  *   onMetadata: function(!Array<shaka.extern.ID3Metadata>, number, ?number),
  *   onEmsg: function(!shaka.extern.EmsgInfo),
  *   onEvent: function(!Event),
@@ -2748,8 +2750,8 @@ shaka.media.MediaSourceEngine.ResetMode_ = {
  * }}
  *
  * @summary Player interface
- * @property {function():?string} getKeySystem
- *   Gets currently used key system or null if not used.
+ * @property {function():string} getKeySystem
+ *   Gets currently used key system or empty if not used.
  * @property {function(
  *     !Array<shaka.extern.ID3Metadata>, number, ?number)} onMetadata
  *   Callback to use when metadata arrives.

--- a/lib/media/preference_based_criteria.js
+++ b/lib/media/preference_based_criteria.js
@@ -186,10 +186,11 @@ shaka.media.PreferenceBasedCriteria = class {
     }
 
     const device = shaka.device.DeviceFactory.getDevice();
+    const keySystem = this.config_.keySystem;
     const supportsSmoothCodecTransitions =
       this.config_.codecSwitchingStrategy ==
       shaka.config.CodecSwitchingStrategy.SMOOTH &&
-        device.supportsSmoothCodecSwitching();
+        device.supportsSmoothCodecSwitching(keySystem);
 
     this.lastAdaptationSet_ = new shaka.media.AdaptationSet(current[0], current,
         !supportsSmoothCodecTransitions);

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -604,6 +604,13 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
       this.throwIfDestroyed_();
     }
 
+    if (this.currentAdaptationSetCriteria_) {
+      const config =
+          this.currentAdaptationSetCriteria_.getConfiguration();
+      config.keySystem = this.keySystem_();
+      this.currentAdaptationSetCriteria_.configure(config);
+    }
+
     // Now that we have drm information, filter the manifest (again) so that
     // we can ensure we only use variants with the selected key system.
     const tracksChangedAfter = await this.manifestFilterer_.filterManifest(
@@ -674,6 +681,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: this.config_.preferredAudioCodecs,
         preferredAudioChannelCount: this.config_.preferredAudioChannelCount,
+        keySystem: this.keySystem_(),
       });
     }
 
@@ -933,6 +941,7 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
       activeAudioChannelCount: 0,
       preferredAudioCodecs: this.config_.preferredAudioCodecs,
       preferredAudioChannelCount: this.config_.preferredAudioChannelCount,
+      keySystem: this.keySystem_(),
     };
     if (shaka.util.ObjectUtils.alphabeticalKeyOrderStringify(currentConfig) !=
         shaka.util.ObjectUtils.alphabeticalKeyOrderStringify(newConfig)) {
@@ -1066,6 +1075,19 @@ shaka.media.PreloadManager = class extends shaka.util.FakeEventTarget {
   /** @return {boolean} */
   hasBeenAttached() {
     return this.hasBeenAttached_;
+  }
+
+  /**
+   * Get the key system currently used by EME. If EME is not being used, this
+   * will return an empty string. If the player has not loaded content, this
+   * will return an empty string.
+   *
+   * @return {string}
+   * @private
+   */
+  keySystem_() {
+    return shaka.drm.DrmUtils.keySystem(
+        this.drmEngine_ ? this.drmEngine_.getDrmInfo() : null);
   }
 
   /**

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3314,7 +3314,8 @@ shaka.media.StreamingEngine = class {
       return true;
     }
     const device = shaka.device.DeviceFactory.getDevice();
-    if (!device.supportsSmoothCodecSwitching()) {
+    const keySystem = this.playerInterface_.getKeySystem();
+    if (!device.supportsSmoothCodecSwitching(keySystem)) {
       for (const type of this.mediaStates_.keys()) {
         const mediaState = this.mediaStates_.get(type);
         const ContentType = shaka.util.ManifestParserUtils.ContentType;
@@ -3580,6 +3581,7 @@ shaka.media.StreamingEngine = class {
  *   disableStream: function(!shaka.extern.Stream, number):boolean,
  *   shouldPrefetchNextSegment: function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream):boolean,
+ *   getKeySystem: function():string,
  * }}
  *
  * @property {function():number} getPresentationTime
@@ -3615,6 +3617,8 @@ shaka.media.StreamingEngine = class {
  *   containing said stream.
  * @property {function(!shaka.media.SegmentReference,
  *     !shaka.extern.Stream):boolean} shouldPrefetchNextSegment
+ * @property {function():string} getKeySystem
+ *   Gets currently used key system or empty if not used.
  */
 shaka.media.StreamingEngine.PlayerInterface;
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -933,6 +933,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       activeAudioChannelCount: 0,
       preferredAudioCodecs: this.config_.preferredAudioCodecs,
       preferredAudioChannelCount: this.config_.preferredAudioChannelCount,
+      keySystem: this.keySystem(),
     });
 
     /** @private {string} */
@@ -1976,6 +1977,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           await this.drmEngine_.attach(this.video_);
         }, 'drmEngine_.attach');
 
+        if (this.currentAdaptationSetCriteria_) {
+          const config =
+              this.currentAdaptationSetCriteria_.getConfiguration();
+          config.keySystem = this.keySystem();
+          this.currentAdaptationSetCriteria_.configure(config);
+        }
 
         const abrFactory = this.config_.abrFactory;
         if (!this.abrManager_ || this.abrManagerFactory_ != abrFactory) {
@@ -4242,6 +4249,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         }
         return false;
       },
+      getKeySystem: () => this.keySystem(),
     };
 
     return new shaka.media.StreamingEngine(this.manifest_, playerInterface);
@@ -5674,6 +5682,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           active.audio.channelsCount : 0,
         preferredAudioCodecs: this.config_.preferredAudioCodecs,
         preferredAudioChannelCount: this.config_.preferredAudioChannelCount,
+        keySystem: this.keySystem(),
       });
 
       // Update AbrManager variants to match these new settings.

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -101,7 +101,7 @@ shaka.util.PlayerConfiguration = class {
     };
 
     let codecSwitchingStrategy = shaka.config.CodecSwitchingStrategy.RELOAD;
-    if (device.supportsSmoothCodecSwitching()) {
+    if (device.supportsSmoothCodecSwitching('')) {
       codecSwitchingStrategy = shaka.config.CodecSwitchingStrategy.SMOOTH;
     }
 

--- a/test/codec_switching/codec_switching_integration.js
+++ b/test/codec_switching/codec_switching_integration.js
@@ -93,7 +93,7 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!deviceDetected.supportsSmoothCodecSwitching()) {
+      if (!deviceDetected.supportsSmoothCodecSwitching('')) {
         pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/webm; codecs="opus"')) {
@@ -165,7 +165,7 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!deviceDetected.supportsSmoothCodecSwitching()) {
+      if (!deviceDetected.supportsSmoothCodecSwitching('')) {
         pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/webm; codecs="opus"')) {
@@ -237,7 +237,7 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!deviceDetected.supportsSmoothCodecSwitching()) {
+      if (!deviceDetected.supportsSmoothCodecSwitching('')) {
         pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/mp4; codecs="ec-3"')) {
@@ -310,7 +310,7 @@ describe('Codec Switching', () => {
     });
 
     it('can switch codecs SMOOTH', async () => {
-      if (!deviceDetected.supportsSmoothCodecSwitching()) {
+      if (!deviceDetected.supportsSmoothCodecSwitching('')) {
         pending('SourceBuffer.changeType is not supported');
       }
       if (!await Util.isTypeSupported('audio/mp4; codecs="ec-3"')) {

--- a/test/media/adaptation_set_criteria_unit.js
+++ b/test/media/adaptation_set_criteria_unit.js
@@ -36,6 +36,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -79,6 +80,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -147,6 +149,7 @@ describe('AdaptationSetCriteria', () => {
           activeAudioChannelCount: 0,
           preferredAudioCodecs: [],
           preferredAudioChannelCount: 0,
+          keySystem: '',
         });
 
         expect(builder.getLastAdaptationSet()).toBeNull();
@@ -208,6 +211,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -258,6 +262,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -302,6 +307,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -373,6 +379,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -453,6 +460,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -511,6 +519,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -589,6 +598,7 @@ describe('AdaptationSetCriteria', () => {
             activeAudioChannelCount: 0,
             preferredAudioCodecs: [],
             preferredAudioChannelCount: 0,
+            keySystem: '',
           });
 
           expect(builder.getLastAdaptationSet()).toBeNull();
@@ -668,6 +678,7 @@ describe('AdaptationSetCriteria', () => {
             activeAudioChannelCount: 0,
             preferredAudioCodecs: [],
             preferredAudioChannelCount: 0,
+            keySystem: '',
           });
 
           expect(builder.getLastAdaptationSet()).toBeNull();
@@ -718,6 +729,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -768,6 +780,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -818,6 +831,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -867,6 +881,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -923,6 +938,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -974,6 +990,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1025,6 +1042,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 2,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1076,6 +1094,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 2,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1126,6 +1145,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 2,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1175,6 +1195,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1220,6 +1241,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1264,6 +1286,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1326,6 +1349,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1376,6 +1400,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1432,6 +1457,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1477,6 +1503,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1521,6 +1548,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1565,6 +1593,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: ['mp4a.40.2'],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1610,6 +1639,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: ['mp4a.40.2'],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1655,6 +1685,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: ['ec-3', 'mp4a.40.2'],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1700,6 +1731,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: [],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();
@@ -1745,6 +1777,7 @@ describe('AdaptationSetCriteria', () => {
         activeAudioChannelCount: 0,
         preferredAudioCodecs: ['ec-3'],
         preferredAudioChannelCount: 0,
+        keySystem: '',
       });
 
       expect(builder.getLastAdaptationSet()).toBeNull();

--- a/test/media/streaming_engine_integration.js
+++ b/test/media/streaming_engine_integration.js
@@ -275,6 +275,7 @@ describe('StreamingEngine', () => {
       beforeAppendSegment: () => Promise.resolve(),
       disableStream: (stream, time) => false,
       shouldPrefetchNextSegment: () => true,
+      getKeySystem: () => '',
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -483,6 +483,7 @@ describe('StreamingEngine', () => {
       beforeAppendSegment: Util.spyFunc(beforeAppendSegment),
       disableStream: Util.spyFunc(disableStream),
       shouldPrefetchNextSegment: () => true,
+      getKeySystem: () => '',
     };
     streamingEngine = new shaka.media.StreamingEngine(
         /** @type {shaka.extern.Manifest} */(manifest), playerInterface);


### PR DESCRIPTION
More info in https://chromium-review.googlesource.com/c/chromium/src/+/4577759 and https://issues.chromium.org/issues/40261162

According to the source code and empirical testing, SMOOTH is supported with clear content and Widevine, but not with PlayReady.