### PR TITLE
feat!: Remove codem-isoboxer dependency

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -208,9 +208,6 @@ module.exports = (config) => {
       //   Babel polyfill, required for async/await
       'node_modules/@babel/polyfill/dist/polyfill.js',
 
-      // codem-isoboxer module next
-      'node_modules/codem-isoboxer/dist/iso_boxer.min.js',
-
       // LCEVC decoder libraries (.wasm & .js)
       {
         pattern: 'node_modules/lcevc_dec.js/dist/liblcevc_dpi.wasm',

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "cajon": "^0.4.4",
         "clean-package": "^2.2.0",
         "code-prettify": "^0.1.0",
-        "codem-isoboxer": "^0.3.7",
         "color-themes-for-google-code-prettify": "^2.0.4",
         "core-js": "^3.21.1",
         "cspell": "^8.17.1",
@@ -4002,12 +4001,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/code-prettify/-/code-prettify-0.1.0.tgz",
       "integrity": "sha1-RocMyMGlDQm61TmzOpg9vUqjSx4=",
-      "dev": true
-    },
-    "node_modules/codem-isoboxer": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.7.tgz",
-      "integrity": "sha512-aJh5CAuJX0TUUu1aLCd2DKmYxlebJfr1f4PJc9BCfXFbFclHsKvqrnqTrRV5hWVWtisllm+Q03tCEeirow8XAg==",
       "dev": true
     },
     "node_modules/color-convert": {
@@ -13526,12 +13519,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/code-prettify/-/code-prettify-0.1.0.tgz",
       "integrity": "sha1-RocMyMGlDQm61TmzOpg9vUqjSx4=",
-      "dev": true
-    },
-    "codem-isoboxer": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.7.tgz",
-      "integrity": "sha512-aJh5CAuJX0TUUu1aLCd2DKmYxlebJfr1f4PJc9BCfXFbFclHsKvqrnqTrRV5hWVWtisllm+Q03tCEeirow8XAg==",
       "dev": true
     },
     "color-convert": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "cajon": "^0.4.4",
     "clean-package": "^2.2.0",
     "code-prettify": "^0.1.0",
-    "codem-isoboxer": "^0.3.7",
     "color-themes-for-google-code-prettify": "^2.0.4",
     "core-js": "^3.21.1",
     "cspell": "^8.17.1",
@@ -85,7 +84,6 @@
     "demoDeps": [
       "awesomplete/awesomplete.css",
       "awesomplete/awesomplete.min.js",
-      "codem-isoboxer/dist/iso_boxer.min.js",
       "dialog-polyfill/dialog-polyfill.css",
       "dialog-polyfill/dist/dialog-polyfill.js",
       "es6-promise-polyfill/promise.min.js",


### PR DESCRIPTION
This was only used in MSS, and support for it has been discontinued.