### PR TITLE
feat: Update catalog format to MSF/CMSF v0 and standardize MOQ terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ For details on the HLS format and these tags' meanings, see https://datatracker.
 
 Features supported:
  - Media over QUIC Transport [draft-14](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/14/)
- - MOQT Streaming Format [draft-01](https://datatracker.ietf.org/doc/draft-ietf-moq-warp/01/)
+ - MOQT Streaming Format [draft-0](https://datatracker.ietf.org/doc/draft-ietf-moq-msf/00/) and CMSF [draft-0](https://datatracker.ietf.org/doc/draft-ietf-moq-cmsf/00/)
  - Audio, Video and Text
  - ABR (only navigator.connection change event)
  - Encrypted content with PSSH in the initData

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -34,7 +34,8 @@ goog.require('shaka.util.Uint8ArrayUtils');
  * MOQT Streaming Format.
  *
  * @see https://datatracker.ietf.org/doc/draft-ietf-moq-transport/
- * @see https://datatracker.ietf.org/doc/draft-ietf-moq-warp/
+ * @see https://datatracker.ietf.org/doc/draft-ietf-moq-msf/
+ * @see https://datatracker.ietf.org/doc/draft-ietf-moq-cmsf/
  *
  * @implements {shaka.extern.ManifestParser}
  * @export

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -170,7 +170,7 @@ shaka.msf.TracksManager = class {
       shaka.log.debug(`Publisher Priority: ${publisherPriority}`);
 
       // Buffer for objects while waiting for track registration
-      /** @type {!Array<!shaka.msf.Utils.MoQObject>} */
+      /** @type {!Array<!shaka.msf.Utils.MOQObject>} */
       const bufferedObjects = [];
       const retryInterval = 0.1;
       const maxRetries = 5;
@@ -227,7 +227,7 @@ shaka.msf.TracksManager = class {
           shaka.log.debug(`Read ${data.byteLength} bytes of object data`);
         }
 
-        /** @type {shaka.msf.Utils.MoQObject} */
+        /** @type {shaka.msf.Utils.MOQObject} */
         const obj = {
           trackAlias,
           location: {
@@ -342,7 +342,7 @@ shaka.msf.TracksManager = class {
    * Notify all callbacks registered for a track
    *
    * @param {number} trackAlias
-   * @param {shaka.msf.Utils.MoQObject} obj
+   * @param {shaka.msf.Utils.MOQObject} obj
    * @private
    */
   notifyCallbacks_(trackAlias, obj) {
@@ -505,7 +505,7 @@ shaka.msf.TracksManager = class {
 
     const trackDescription = `${trackInfo.namespace}:${trackInfo.trackName}`;
 
-    // According to MoQ Transport draft-14, the unsubscribe message must use the
+    // According to MOQT draft-14, the unsubscribe message must use the
     // same request ID that was used in the original subscribe message
     const requestId = trackInfo.requestId;
 
@@ -520,7 +520,7 @@ shaka.msf.TracksManager = class {
 
     try {
       // Create a Promise that will be resolved after a short delay
-      // Note: The MoQ spec doesn't require an acknowledgment for unsubscribe
+      // Note: The MOQ spec doesn't require an acknowledgment for unsubscribe
       // messages, so we'll just wait a short time to allow the message to be
       // sent
       const unsubscribePromise = new Promise((resolve) => {

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -20,7 +20,7 @@ goog.require('shaka.util.IReleasable');
 
 
 /**
- * MoQT (Media over QUIC Transport).
+ * MOQT (Media over QUIC Transport).
  *
  * @implements {shaka.util.IReleasable}
  * @export
@@ -139,7 +139,7 @@ shaka.msf.MSFTransport = class {
 
   /**
    * Get the next available request ID and increment for future use.
-   * According to the MoQ Transport spec, client request IDs are even numbers
+   * According to the MOQ Transport spec, client request IDs are even numbers
    * starting at 0 and increment by 2 for each new request.
    *
    * @return {number}

--- a/lib/msf/msf_utils.js
+++ b/lib/msf/msf_utils.js
@@ -291,11 +291,11 @@ shaka.msf.Utils.MessageHandler;
  *   status: ?(number|undefined)
  * }}
  */
-shaka.msf.Utils.MoQObject;
+shaka.msf.Utils.MOQObject;
 
 
 /**
- * @typedef {function(shaka.msf.Utils.MoQObject)}
+ * @typedef {function(shaka.msf.Utils.MOQObject)}
  */
 shaka.msf.Utils.ObjectCallback;
 
@@ -338,8 +338,10 @@ shaka.msf.Utils.TrackInfo;
  *   displayWidth: (number|undefined),
  *   displayHeight: (number|undefined),
  *   lang: (string|undefined),
+ *   targetLatency: (number|undefined),
+ *   trackDuration: (number|undefined),
+ *   eventType: (string|undefined),
  *   parentName: (string|undefined),
- *   trackDuration: (number|undefined)
  * }}
  */
 shaka.msf.Utils.MSFTrack;
@@ -348,11 +350,12 @@ shaka.msf.Utils.MSFTrack;
 /**
  * @typedef {{
  *   version: number,
+ *   generatedAt: (number|undefined),
+ *   isComplete: (boolean|undefined),
  *   deltaUpdate: (boolean|undefined),
  *   addTracks: (Array<!shaka.msf.Utils.MSFTrack>|undefined),
  *   removeTracks: (Array<!shaka.msf.Utils.MSFTrack>|undefined),
  *   cloneTracks: (Array<!shaka.msf.Utils.MSFTrack>|undefined),
- *   generatedAt: (number|undefined),
  *   tracks: !Array<!shaka.msf.Utils.MSFTrack>
  * }}
  */


### PR DESCRIPTION
Implemented MSF/CMSF v0 specifications
- Catalog structure now follows draft-ietf-moq-msf-00
- CMAF packaging follows draft-ietf-moq-cmsf-00

MOQ naming consistency
- Changed "MoQ" → "MOQ"
- Renamed MoQObject interface to MOQObject