### PR TITLE
fix(LCEVC): Return early if playerInterface object is destroyed

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2192,12 +2192,12 @@ shaka.media.StreamingEngine = class {
             otherState = this.mediaStates_.get(ContentType.VIDEO);
           }
           if (otherState && otherState.type == ContentType.AUDIO) {
-            this.playerInterface_?.onSegmentAppended(
+            this.playerInterface_.onSegmentAppended(
                 reference, mediaState.stream,
                 otherState.stream.isAudioMuxedInVideo,
                 /* isDependency= */ true);
           } else {
-            this.playerInterface_?.onSegmentAppended(
+            this.playerInterface_.onSegmentAppended(
                 reference, mediaState.stream,
                 mediaState.stream.codecs.includes(','),
                 /* isDependency= */ true);


### PR DESCRIPTION
In LCEVC scalable delivery (dual-track) mode, return early if the `playerInterface` object is destroyed. This is useful in case `playerInterface` is destroyed during the `await` call.