### PR TITLE
fix: Setup correct video codecs on MSE

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -584,6 +584,11 @@ shaka.media.MediaSourceEngine = class {
           codecs, stream.mimeType);
     }
 
+    if (contentType == ContentType.VIDEO && codecs &&
+        stream.mimeType == 'video/mp4') {
+      codecs = shaka.util.StreamUtils.getCorrectVideoCodecs(codecs);
+    }
+
     let mimeType = shaka.util.MimeUtils.getFullType(
         stream.mimeType, codecs);
     if (contentType == ContentType.TEXT) {


### PR DESCRIPTION
Convert avc1 codec string from RFC-4281 to RFC-6381 
Example, convert avc1.66.30 to avc1.42001e