### PR TITLE
fix: delay appending vtt subtitles depending on presence of discontinuity sequence and timestamp offset

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1154,7 +1154,7 @@ shaka.media.MediaSourceEngine = class {
           reference ? reference.startTime : null,
           reference ? reference.endTime : null,
           reference ? reference.getUris()[0] : null,
-          reference ? reference.discontinuitySequence : 0);
+          reference ? reference.discontinuitySequence : -1);
       return;
     }
 

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -687,7 +687,8 @@ shaka.media.MediaSourceEngine = class {
    */
   reinitText(mimeType, external) {
     if (!this.textEngine_) {
-      this.textEngine_ = new shaka.text.TextEngine(this.textDisplayer_);
+      this.textEngine_ = new shaka.text.TextEngine(
+          this.textDisplayer_, this.manifestType_);
       if (this.textEngine_) {
         this.textEngine_.setModifyCueCallback(this.config_.modifyCueCallback);
       }

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -166,9 +166,6 @@ shaka.media.MediaSourceEngine = class {
     /** @private {boolean} */
     this.attemptTimestampOffsetCalculation_ = false;
 
-    /** @private {!shaka.util.PublicPromise<number>} */
-    this.textSequenceModeOffset_ = new shaka.util.PublicPromise();
-
     /** @private {boolean} */
     this.needSplitMuxedContent_ = false;
 
@@ -1152,16 +1149,12 @@ shaka.media.MediaSourceEngine = class {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
 
     if (contentType == ContentType.TEXT) {
-      if (this.manifestType_ == shaka.media.ManifestParser.HLS) {
-        // This won't be known until the first video segment is appended.
-        const offset = await this.textSequenceModeOffset_;
-        this.textEngine_.setTimestampOffset(offset);
-      }
       await this.textEngine_.appendBuffer(
           data,
           reference ? reference.startTime : null,
           reference ? reference.endTime : null,
-          reference ? reference.getUris()[0] : null);
+          reference ? reference.getUris()[0] : null,
+          reference ? reference.discontinuitySequence : 0);
       return;
     }
 
@@ -1255,8 +1248,9 @@ shaka.media.MediaSourceEngine = class {
         const isBestSourceBufferForTimestamps =
             contentType == ContentType.VIDEO ||
             !(this.sourceBuffers_.has(ContentType.VIDEO));
-        if (isBestSourceBufferForTimestamps) {
-          this.textSequenceModeOffset_.resolve(timestampOffset);
+        if (isBestSourceBufferForTimestamps && this.textEngine_) {
+          this.textEngine_.setTimestampOffset(
+              timestampOffset, reference.discontinuitySequence);
         }
       }
       if (metadata.length) {
@@ -1606,11 +1600,6 @@ shaka.media.MediaSourceEngine = class {
       return;
     }
 
-    // Reset the promise in case the timestamp offset changed during
-    // a period/discontinuity transition.
-    if (contentType == ContentType.VIDEO) {
-      this.textSequenceModeOffset_ = new shaka.util.PublicPromise();
-    }
 
     if (!this.sequenceMode_) {
       return;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -694,7 +694,7 @@ shaka.media.MediaSourceEngine = class {
       }
     }
     this.textEngine_.initParser(mimeType, external,
-        this.segmentRelativeVttTiming_, this.manifestType_);
+        this.segmentRelativeVttTiming_);
   }
 
   /**

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -26,7 +26,7 @@ shaka.text.TextEngine = class {
    * @param {shaka.extern.TextDisplayer} displayer
    * @param {string=} manifestType
    */
-  constructor(displayer, manifestType = shaka.media.ManifestParser.DASH) {
+  constructor(displayer, manifestType = shaka.media.ManifestParser.UNKNOWN) {
     /** @private {?shaka.extern.TextParser} */
     this.parser_ = null;
 
@@ -149,9 +149,8 @@ shaka.text.TextEngine = class {
    * @param {string} mimeType
    * @param {boolean} external
    * @param {boolean} segmentRelativeVttTiming
-   * @param {string} manifestType
    */
-  initParser(mimeType, external, segmentRelativeVttTiming, manifestType) {
+  initParser(mimeType, external, segmentRelativeVttTiming) {
     // No parser for CEA, which is extracted from video and side-loaded
     // into TextEngine and TextDisplayer.
     if (mimeType == shaka.util.MimeUtils.CEA608_CLOSED_CAPTION_MIMETYPE ||
@@ -164,7 +163,7 @@ shaka.text.TextEngine = class {
     goog.asserts.assert(
         factory, 'Text type negotiation should have happened already');
     this.parser_ = factory();
-    this.parser_.setManifestType(manifestType);
+    this.parser_.setManifestType(this.manifestType_);
     this.segmentRelativeVttTiming_ = segmentRelativeVttTiming;
     this.external_ = external;
   }

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -8,10 +8,10 @@ goog.provide('shaka.text.TextEngine');
 
 goog.require('goog.asserts');
 goog.require('shaka.media.ClosedCaptionParser');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.text.Cue');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.IDestroyable');
-goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.MimeUtils');
 
 
@@ -44,6 +44,7 @@ shaka.text.TextEngine = class {
 
     /** @private {Map<number, number>} */
     this.timestampOffsetMap_ = new Map();
+
     /** @private {Map<number, Array<shaka.text.TextEngine.DeferredAppend>>} */
     this.deferredAppends_ = new Map();
 

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -274,10 +274,6 @@ shaka.text.TextEngine = class {
       return inside;
     };
 
-    if (!this.deferredAppends_) {
-      return;
-    }
-
     for (const key of this.deferredAppends_.keys()) {
       const deferred = this.deferredAppends_.get(key);
       /** @type {Array<shaka.text.TextEngine.DeferredAppend>} */

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -44,8 +44,6 @@ shaka.text.TextEngine = class {
 
     /** @private {Map<number, number>} */
     this.timestampOffsetMap_ = new Map();
-    // default timestamp offset for no discontinuities to 0
-    this.timestampOffsetMap_.set(-1, 0);
     /** @private {Map<number, Array<shaka.text.TextEngine.DeferredAppend>>} */
     this.deferredAppends_ = new Map();
 

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -11,6 +11,7 @@ goog.require('shaka.media.ClosedCaptionParser');
 goog.require('shaka.text.Cue');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.IDestroyable');
+goog.require('shaka.media.ManifestParser');
 goog.require('shaka.util.MimeUtils');
 
 
@@ -21,13 +22,19 @@ goog.require('shaka.util.MimeUtils');
  * @export
  */
 shaka.text.TextEngine = class {
-  /** @param {shaka.extern.TextDisplayer} displayer */
-  constructor(displayer) {
+  /**
+   * @param {shaka.extern.TextDisplayer} displayer
+   * @param {string=} manifestType
+   */
+  constructor(displayer, manifestType = shaka.media.ManifestParser.DASH) {
     /** @private {?shaka.extern.TextParser} */
     this.parser_ = null;
 
     /** @private {shaka.extern.TextDisplayer} */
     this.displayer_ = displayer;
+
+    /** @private {string} */
+    this.manifestType_ = manifestType;
 
     /** @private {boolean} */
     this.segmentRelativeVttTiming_ = false;
@@ -329,7 +336,20 @@ shaka.text.TextEngine = class {
    *
    */
   setTimestampOffset(timestampOffset, discontinuity = -1) {
-    this.timestampOffsetMap_.set(discontinuity, timestampOffset);
+    // we should update the timestamp offset:
+    // - if we don't already have a value set for the given discontinuity
+    // - if we aren't playing HLS
+    // - if we are playing HLS and the discontinuity is the default and it
+    //     hasn't been updated from the default value yet
+    const canUpdate =
+      !this.timestampOffsetMap_.has(discontinuity) ||
+      this.manifestType_ !== shaka.media.ManifestParser.HLS || (
+        this.manifestType_ === shaka.media.ManifestParser.HLS &&
+        discontinuity === -1 &&
+        this.timestampOffsetMap_.get(discontinuity) === 0);
+    if (canUpdate) {
+      this.timestampOffsetMap_.set(discontinuity, timestampOffset);
+    }
     /** @type {Array<shaka.text.TextEngine.DeferredAppend>} */
     const deferredAppends = this.deferredAppends_.get(discontinuity) || [];
     for (let i = 0; i < deferredAppends.length; i++) {

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -35,8 +35,13 @@ shaka.text.TextEngine = class {
     /** @private {boolean} */
     this.external_ = false;
 
-    /** @private {number} */
-    this.timestampOffset_ = 0;
+    /** @private {Map.<number, number>} */
+    this.timestampOffsetMap_ = new Map();
+    // default timestamp offset for no discontinuities to 0
+    this.timestampOffsetMap_.set(0, 0);
+    // eslint-disable-next-line max-len
+    /** @private {Map.<number, Array.<shaka.text.TextEngine.DeferredAppend>>} */
+    this.deferredAppends_ = new Map();
 
     /** @private {number} */
     this.appendWindowStart_ = 0;
@@ -117,6 +122,8 @@ shaka.text.TextEngine = class {
   destroy() {
     this.parser_ = null;
     this.displayer_ = null;
+    this.timestampOffsetMap_.clear();
+    this.deferredAppends_.clear();
     this.closedCaptionsMap_.clear();
 
     return Promise.resolve();
@@ -166,11 +173,22 @@ shaka.text.TextEngine = class {
    * @param {?number} startTime relative to the start of the presentation
    * @param {?number} endTime relative to the start of the presentation
    * @param {?string=} uri
+   * @param {number=} disco the associated discontinuity sequence
    * @return {!Promise}
    */
-  async appendBuffer(buffer, startTime, endTime, uri) {
+  async appendBuffer(buffer, startTime, endTime, uri, disco = 0) {
     goog.asserts.assert(
         this.parser_, 'The parser should already be initialized');
+
+    // if we're trying to append content associated with a particular
+    // discontinuity sequence delay that append until after we have received
+    // its associated timestamp offset
+    if (!this.timestampOffsetMap_.has(disco)) {
+      const deferredAppends = this.deferredAppends_.get(disco) || [];
+      deferredAppends.push({buffer, startTime, endTime, uri, disco});
+      this.deferredAppends_.set(disco, deferredAppends);
+      return;
+    }
 
     // Start the operation asynchronously to avoid blocking the caller.
     await Promise.resolve();
@@ -185,9 +203,9 @@ shaka.text.TextEngine = class {
       return;
     }
 
-    const periodStart = this.external_ ? 0 : this.timestampOffset_;
+    const periodStart = this.external_ ? 0 : this.timestampOffsetMap_.get(disco);
     const vttOffset = (this.segmentRelativeVttTiming_ || this.external_) ?
-        startTime : this.timestampOffset_;
+        startTime : this.timestampOffsetMap_.get(disco);
 
     /** @type {shaka.extern.TextParser.TimeContext} **/
     const time = {
@@ -250,6 +268,30 @@ shaka.text.TextEngine = class {
         return;
       }
     }
+
+    const removeInRange = (cue) => {
+      const inside = cue.startTime < endTime && cue.endTime > startTime;
+      return inside;
+    };
+
+    if (!this.deferredAppends_) {
+      return;
+    }
+
+    for (const key of this.deferredAppends_.keys()) {
+      const deferred = this.deferredAppends_.get(key);
+      /** @type {Array.<shaka.text.TextEngine.DeferredAppend>} */
+      const newDeferreds = [];
+
+      for (let i = 0; i < deferred.length; i++) {
+        const cue = deferred[i];
+        if (!removeInRange(cue)) {
+          newDeferreds.push(cue);
+        }
+      }
+      this.deferredAppends_.set(key, newDeferreds);
+    }
+
     if (this.displayer_ && this.displayer_.remove(startTime, endTime)) {
       if (this.bufferStart_ == null) {
         goog.asserts.assert(
@@ -285,9 +327,20 @@ shaka.text.TextEngine = class {
     }
   }
 
-  /** @param {number} timestampOffset */
-  setTimestampOffset(timestampOffset) {
-    this.timestampOffset_ = timestampOffset;
+  /**
+   * @param {number} timestampOffset
+   * @param {number=} discontinuity defaults to 0, meaning no discontinuities
+   *
+   */
+  setTimestampOffset(timestampOffset, discontinuity = 0) {
+    this.timestampOffsetMap_.set(discontinuity, timestampOffset);
+    /** @type {Array.<shaka.text.TextEngine.DeferredAppend>} */
+    const deferredAppends = this.deferredAppends_.get(discontinuity) || [];
+    for (let i = 0; i < deferredAppends.length; i++) {
+      const {buffer, startTime, endTime, uri, disco} = deferredAppends[i];
+      this.appendBuffer(buffer, startTime, endTime, uri, disco);
+    }
+    this.deferredAppends_.set(discontinuity, []);
   }
 
   /**
@@ -490,3 +543,20 @@ shaka.text.TextEngine = class {
 
 /** @private {!Map<string, !shaka.extern.TextParserPlugin>} */
 shaka.text.TextEngine.parserMap_ = new Map();
+
+/**
+ * @typedef {{
+ *    buffer: BufferSource,
+ *    startTime: ?number,
+ *    endTime: ?number,
+ *    uri: (?string|undefined),
+ *    disco: (number|undefined)
+ * }}
+ *
+ * @property {BufferSource} buffer
+ * @property {?number} startTime
+ * @property {?number} endTime
+ * @property {?string=} uri
+ * @property {number=} disco
+ */
+shaka.text.TextEngine.DeferredAppend;

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -35,12 +35,11 @@ shaka.text.TextEngine = class {
     /** @private {boolean} */
     this.external_ = false;
 
-    /** @private {Map.<number, number>} */
+    /** @private {Map<number, number>} */
     this.timestampOffsetMap_ = new Map();
     // default timestamp offset for no discontinuities to 0
-    this.timestampOffsetMap_.set(0, 0);
-    // eslint-disable-next-line max-len
-    /** @private {Map.<number, Array.<shaka.text.TextEngine.DeferredAppend>>} */
+    this.timestampOffsetMap_.set(-1, 0);
+    /** @private {Map<number, Array<shaka.text.TextEngine.DeferredAppend>>} */
     this.deferredAppends_ = new Map();
 
     /** @private {number} */
@@ -176,7 +175,7 @@ shaka.text.TextEngine = class {
    * @param {number=} disco the associated discontinuity sequence
    * @return {!Promise}
    */
-  async appendBuffer(buffer, startTime, endTime, uri, disco = 0) {
+  async appendBuffer(buffer, startTime, endTime, uri, disco = -1) {
     goog.asserts.assert(
         this.parser_, 'The parser should already be initialized');
 
@@ -203,7 +202,8 @@ shaka.text.TextEngine = class {
       return;
     }
 
-    const periodStart = this.external_ ? 0 : this.timestampOffsetMap_.get(disco);
+    const periodStart = this.external_ ?
+        0 : this.timestampOffsetMap_.get(disco);
     const vttOffset = (this.segmentRelativeVttTiming_ || this.external_) ?
         startTime : this.timestampOffsetMap_.get(disco);
 
@@ -280,7 +280,7 @@ shaka.text.TextEngine = class {
 
     for (const key of this.deferredAppends_.keys()) {
       const deferred = this.deferredAppends_.get(key);
-      /** @type {Array.<shaka.text.TextEngine.DeferredAppend>} */
+      /** @type {Array<shaka.text.TextEngine.DeferredAppend>} */
       const newDeferreds = [];
 
       for (let i = 0; i < deferred.length; i++) {
@@ -329,12 +329,12 @@ shaka.text.TextEngine = class {
 
   /**
    * @param {number} timestampOffset
-   * @param {number=} discontinuity defaults to 0, meaning no discontinuities
+   * @param {number=} discontinuity defaults to -1, meaning no discontinuities
    *
    */
-  setTimestampOffset(timestampOffset, discontinuity = 0) {
+  setTimestampOffset(timestampOffset, discontinuity = -1) {
     this.timestampOffsetMap_.set(discontinuity, timestampOffset);
-    /** @type {Array.<shaka.text.TextEngine.DeferredAppend>} */
+    /** @type {Array<shaka.text.TextEngine.DeferredAppend>} */
     const deferredAppends = this.deferredAppends_.get(discontinuity) || [];
     for (let i = 0; i < deferredAppends.length; i++) {
       const {buffer, startTime, endTime, uri, disco} = deferredAppends[i];

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -187,7 +187,9 @@ shaka.text.TextEngine = class {
     // if we're trying to append content associated with a particular
     // discontinuity sequence delay that append until after we have received
     // its associated timestamp offset
-    if (!this.timestampOffsetMap_.has(disco)) {
+    // skip for segment relative timing and external tracks
+    if (!(this.external_) &&
+      !this.timestampOffsetMap_.has(disco)) {
       const deferredAppends = this.deferredAppends_.get(disco) || [];
       deferredAppends.push({buffer, startTime, endTime, uri, disco});
       this.deferredAppends_.set(disco, deferredAppends);

--- a/project-words.txt
+++ b/project-words.txt
@@ -20,6 +20,7 @@ configurationchanged
 currentitemchanged
 customwarning
 defaultselected
+deferreds
 describedby
 disableonfail
 downloadcompleted

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -788,7 +788,7 @@ describe('MediaSourceEngine', () => {
           ContentType.TEXT, data, reference, fakeStream,
           /* hasClosedCaptions= */ false);
       expect(mockTextEngine.appendBuffer).toHaveBeenCalledWith(
-          data, 0, 10, 'foo://bar', 0);
+          data, 0, 10, 'foo://bar', -1);
     });
 
     it('forwards to TextEngine HLS discontinuity sequence', async () => {

--- a/test/media/media_source_engine_unit.js
+++ b/test/media/media_source_engine_unit.js
@@ -788,7 +788,19 @@ describe('MediaSourceEngine', () => {
           ContentType.TEXT, data, reference, fakeStream,
           /* hasClosedCaptions= */ false);
       expect(mockTextEngine.appendBuffer).toHaveBeenCalledWith(
-          data, 0, 10, 'foo://bar');
+          data, 0, 10, 'foo://bar', 0);
+    });
+
+    it('forwards to TextEngine HLS discontinuity sequence', async () => {
+      const data = new ArrayBuffer(0);
+      expect(mockTextEngine.appendBuffer).not.toHaveBeenCalled();
+      const reference = dummyReference(0, 10);
+      reference.discontinuitySequence = 1;
+      await mediaSourceEngine.appendBuffer(
+          ContentType.TEXT, data, reference, fakeStream,
+          /* hasClosedCaptions= */ false);
+      expect(mockTextEngine.appendBuffer).toHaveBeenCalledWith(
+          data, 0, 10, 'foo://bar', 1);
     });
 
     it('appends transmuxed data', async () => {

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -151,6 +151,72 @@ describe('TextEngine', () => {
       expect(modifyCueCallback).toHaveBeenCalledWith(
           cue2, 'uri', jasmine.objectContaining({periodStart: 0}));
     });
+
+    it('defers append to displayer if no timestamp offset for disco',
+        async () => {
+          const cue1 = createFakeCue(1, 2);
+          const cue2 = createFakeCue(2, 3);
+          const cue3 = createFakeCue(3, 4);
+          const cue4 = createFakeCue(4, 5);
+          const cue5 = createFakeCue(5, 6);
+          const cue6 = createFakeCue(6, 7);
+          mockParseMedia.and.returnValue([cue1, cue2]);
+
+          await textEngine.appendBuffer(dummyData, 0, 3, 'subs.vtt', 1);
+          expect(mockParseMedia).not.toHaveBeenCalled();
+          expect(mockDisplayer.appendSpy).not.toHaveBeenCalled();
+
+          textEngine.setTimestampOffset(0, 1);
+          // re-adding deferred appeds is async
+          await shaka.test.Util.shortDelay();
+
+          expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+            dummyData,
+            {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+            'subs.vtt',
+          ]);
+
+          expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+            [cue1, cue2],
+          ]);
+
+          expect(mockDisplayer.removeSpy).not.toHaveBeenCalled();
+
+          mockParseMedia.and.returnValue([cue3, cue4]);
+
+          await textEngine.appendBuffer(dummyData, 3, 5, 'subs2.vtt', 2);
+          expect(mockParseMedia).not.toHaveBeenCalled();
+          expect(mockDisplayer.appendSpy).not.toHaveBeenCalled();
+
+          textEngine.setTimestampOffset(0, 2);
+          // re-adding deferred appeds is async
+          await shaka.test.Util.shortDelay();
+
+          expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+            dummyData,
+            {periodStart: 0, segmentStart: 3, segmentEnd: 5, vttOffset: 0},
+            'subs2.vtt',
+          ]);
+
+          expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+            [cue3, cue4],
+          ]);
+
+          mockParseMedia.and.returnValue([cue5, cue6]);
+
+          // this append wouldn't get deferred
+          await textEngine.appendBuffer(dummyData, 5, 7, 'subs3.vtt', 2);
+
+          expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+            dummyData,
+            {periodStart: 0, segmentStart: 5, segmentEnd: 7, vttOffset: 0},
+            'subs3.vtt',
+          ]);
+
+          expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+            [cue5, cue6],
+          ]);
+        });
   });
 
   describe('storeAndAppendClosedCaptions', () => {
@@ -316,6 +382,47 @@ describe('TextEngine', () => {
         {periodStart: 4, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
         undefined,
         [],
+      ]);
+      expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+        [
+          createFakeCue(4, 5),
+          createFakeCue(6, 7),
+        ],
+      ]);
+    });
+
+    it('respects discontinuity sequence', async () => {
+      mockParseMedia.and.callFake((data, time) => {
+        return [
+          createFakeCue(time.periodStart + 0,
+              time.periodStart + 1),
+          createFakeCue(time.periodStart + 2,
+              time.periodStart + 3),
+        ];
+      });
+
+      textEngine.setTimestampOffset(0, 1);
+      textEngine.setTimestampOffset(4, 2);
+      await textEngine.appendBuffer(dummyData, 0, 3, 'subs.vtt', 0);
+
+      expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+        dummyData,
+        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        'subs.vtt',
+      ]);
+      expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+        [
+          createFakeCue(0, 1),
+          createFakeCue(2, 3),
+        ],
+      ]);
+
+      await textEngine.appendBuffer(dummyData, 4, 7, 'subs2.vtt', 2);
+
+      expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+        dummyData,
+        {periodStart: 4, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
+        'subs2.vtt',
       ]);
       expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
         [

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -46,6 +46,7 @@ describe('TextEngine', () => {
 
     TextEngine.registerParser(dummyMimeType, mockParserPlugIn);
     textEngine = new TextEngine(mockDisplayer);
+    textEngine.setTimestampOffset(0);
     textEngine.initParser(
         dummyMimeType,
         /* external= */ false,
@@ -149,6 +150,36 @@ describe('TextEngine', () => {
           cue1, 'uri', jasmine.objectContaining({periodStart: 0}));
       expect(modifyCueCallback).toHaveBeenCalledWith(
           cue2, 'uri', jasmine.objectContaining({periodStart: 0}));
+    });
+
+    it('delays appending til after a timestamp offset is set', async () => {
+      textEngine = new TextEngine(mockDisplayer);
+      textEngine.initParser(
+          dummyMimeType,
+          /* external= */ false,
+          /* segmentRelativeVttTiming= */ false);
+      const cue1 = createFakeCue(1, 2);
+
+      mockParseMedia.and.returnValue([cue1]);
+      await textEngine.appendBuffer(dummyData, 0, 3, 'subs.vtt');
+
+      expect(mockParseMedia).not.toHaveBeenCalled();
+      expect(mockDisplayer.appendSpy).not.toHaveBeenCalled();
+
+      textEngine.setTimestampOffset(0);
+      // re-adding deferred appends is async
+      await shaka.test.Util.shortDelay();
+
+      expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
+        dummyData,
+        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        'subs.vtt',
+        [],
+      ]);
+
+      expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
+        [cue1],
+      ]);
     });
 
     it('defers append to displayer if no timestamp offset for disco',

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -167,13 +167,14 @@ describe('TextEngine', () => {
           expect(mockDisplayer.appendSpy).not.toHaveBeenCalled();
 
           textEngine.setTimestampOffset(0, 1);
-          // re-adding deferred appeds is async
+          // re-adding deferred appends is async
           await shaka.test.Util.shortDelay();
 
           expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
             dummyData,
             {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
             'subs.vtt',
+            [],
           ]);
 
           expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
@@ -189,13 +190,14 @@ describe('TextEngine', () => {
           expect(mockDisplayer.appendSpy).not.toHaveBeenCalled();
 
           textEngine.setTimestampOffset(0, 2);
-          // re-adding deferred appeds is async
+          // re-adding deferred appends is async
           await shaka.test.Util.shortDelay();
 
           expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
             dummyData,
             {periodStart: 0, segmentStart: 3, segmentEnd: 5, vttOffset: 0},
             'subs2.vtt',
+            [],
           ]);
 
           expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
@@ -211,6 +213,7 @@ describe('TextEngine', () => {
             dummyData,
             {periodStart: 0, segmentStart: 5, segmentEnd: 7, vttOffset: 0},
             'subs3.vtt',
+            [],
           ]);
 
           expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
@@ -401,6 +404,7 @@ describe('TextEngine', () => {
         ];
       });
 
+      textEngine.setTimestampOffset(0, 0);
       textEngine.setTimestampOffset(0, 1);
       textEngine.setTimestampOffset(4, 2);
       await textEngine.appendBuffer(dummyData, 0, 3, 'subs.vtt', 0);
@@ -409,6 +413,7 @@ describe('TextEngine', () => {
         dummyData,
         {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
         'subs.vtt',
+        [],
       ]);
       expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
         [
@@ -423,6 +428,7 @@ describe('TextEngine', () => {
         dummyData,
         {periodStart: 4, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
         'subs2.vtt',
+        [],
       ]);
       expect(mockDisplayer.appendSpy).toHaveBeenCalledOnceMoreWith([
         [

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -49,8 +49,7 @@ describe('TextEngine', () => {
     textEngine.initParser(
         dummyMimeType,
         /* external= */ false,
-        /* segmentRelativeVttTiming= */ false,
-        shaka.media.ManifestParser.UNKNOWN);
+        /* segmentRelativeVttTiming= */ false);
   });
 
   afterEach(() => {
@@ -442,8 +441,7 @@ describe('TextEngine', () => {
       textEngine.initParser(
           dummyMimeType,
           /* external= */ false,
-          /* segmentRelativeVttTiming= */ true,
-          shaka.media.ManifestParser.UNKNOWN);
+          /* segmentRelativeVttTiming= */ true);
 
       mockParseMedia.and.callFake((data, time) => {
         return [
@@ -479,8 +477,7 @@ describe('TextEngine', () => {
       textEngine.initParser(
           dummyMimeType,
           /* external= */ true,
-          /* segmentRelativeVttTiming= */ false,
-          shaka.media.ManifestParser.UNKNOWN);
+          /* segmentRelativeVttTiming= */ false);
 
       mockParseMedia.and.callFake((data, time) => {
         return [


### PR DESCRIPTION
This PR changes the way that timestamp offsets are stored in the media source engine. Instead of a single value, it now has a map of values. For DASH, it should contain a single value, which is the last timestamp offset available. For HLS, it'll keep track of the timestamp offsets per discontinuity sequence. If content is appended and we don't yet have a timestamp offset for that discontinuity sequence number, it'll defer creating the cues until the timestamp offset is set, otherwise, the times for the cues may not be correct.

Fixes #9470
