### PR TITLE
fix: Fix usage of mediaElement in shaka.Player constructor

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -1078,6 +1078,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     /** @private {?shaka.text.SpeechToText} */
     this.speechToText_ = null;
+
+    // Even though |attach| will start in later interpreter cycles, it should be
+    // the LAST thing we do in the constructor because conceptually it relies on
+    // player having been initialized.
+    if (mediaElement) {
+      shaka.log.alwaysWarn('Please migrate from initializing Player with a ' +
+          'mediaElement; use the attach method instead.');
+      this.attach(mediaElement, /* initializeMediaSource= */ true);
+    }
   }
 
   /**


### PR DESCRIPTION
This should have been removed in version 5, but we did it wrong, so we have to add it back.

I'm removing the deprecated log and throwing an `alwaysWarn` because this change could break many more applications than we want, given that the second parameter is `videoContainer` and we could do something wrong.