### PR TITLE
refactor(net): Improve DataUriPlugin parsing logic

### DIFF
--- a/lib/net/data_uri_plugin.js
+++ b/lib/net/data_uri_plugin.js
@@ -60,8 +60,7 @@ shaka.net.DataUriPlugin = class {
    */
   static parseRaw(uri) {
     // Extract the scheme.
-    const parts = uri.split(':');
-    if (parts.length < 2 || parts[0] != 'data') {
+    if (!uri.startsWith('data:')) {
       shaka.log.error('Bad data URI, failed to parse scheme');
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -69,11 +68,11 @@ shaka.net.DataUriPlugin = class {
           shaka.util.Error.Code.MALFORMED_DATA_URI,
           uri);
     }
-    const path = parts.slice(1).join(':');
+    const path = uri.substring(5);
 
     // Extract the encoding and MIME type (required but can be empty).
-    const infoAndData = path.split(',');
-    if (infoAndData.length < 2) {
+    const commaIndex = path.indexOf(',');
+    if (commaIndex < 0) {
       shaka.log.error('Bad data URI, failed to extract encoding and MIME type');
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -81,8 +80,9 @@ shaka.net.DataUriPlugin = class {
           shaka.util.Error.Code.MALFORMED_DATA_URI,
           uri);
     }
-    const info = infoAndData[0];
-    const dataStr = window.decodeURIComponent(infoAndData.slice(1).join(','));
+    const info = path.substring(0, commaIndex);
+    const dataPart = path.substring(commaIndex + 1);
+    const dataStr = decodeURIComponent(dataPart);
 
     // The MIME type is always the first thing in the semicolon-separated list
     // of type parameters.  It may be blank.
@@ -93,7 +93,7 @@ shaka.net.DataUriPlugin = class {
     // semicolon-separated list if present.
     let base64Encoded = false;
     if (typeInfoList.length > 1 &&
-        typeInfoList[typeInfoList.length - 1] == 'base64') {
+        typeInfoList[typeInfoList.length - 1].toLowerCase() == 'base64') {
       base64Encoded = true;
       typeInfoList.pop();
     }


### PR DESCRIPTION
- Replace split(':') with startsWith('data:') for scheme validation
- Use indexOf(',') instead of split(',') to avoid unnecessary allocations
- Remove window dependency from decodeURIComponent
- Normalize base64 detection using toLowerCase()