### PR TITLE
fix(TTML): Update position alignment map

### DIFF
--- a/lib/text/ttml_text_parser.js
+++ b/lib/text/ttml_text_parser.js
@@ -1402,7 +1402,9 @@ shaka.text.TtmlTextParser.textAlignToLineAlign_ = new Map()
 shaka.text.TtmlTextParser.textAlignToPositionAlign_ = new Map()
     .set('left', shaka.text.Cue.positionAlign.LEFT)
     .set('center', shaka.text.Cue.positionAlign.CENTER)
-    .set('right', shaka.text.Cue.positionAlign.RIGHT);
+    .set('right', shaka.text.Cue.positionAlign.RIGHT)
+    .set('start', shaka.text.Cue.positionAlign.LEFT)
+    .set('end', shaka.text.Cue.positionAlign.RIGHT);
 
 /**
  * The namespace URL for TTML parameters.  Can be assigned any name in the TTML


### PR DESCRIPTION
Map 'start' to 'LEFT' and 'end' to 'RIGHT'
This mapping needs to be reversed for RTL languages.