### PR TITLE
chore: Reduce the internal complexity of the chapters

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -1683,7 +1683,7 @@ shaka.hls.HlsParser = class {
         const reference = new shaka.media.SegmentReference(
             chapter.startTime,
             chapter.endTime,
-            () => [chapter.title],
+            () => [],
             /* startByte= */ 0,
             /* endByte= */ null,
             /* initSegmentReference= */ null,
@@ -1691,6 +1691,11 @@ shaka.hls.HlsParser = class {
             /* appendWindowStart= */ 0,
             /* appendWindowEnd= */ Infinity,
         );
+        /** @type {shaka.media.SegmentReference.Metadata} */
+        const metadata = {
+          title: chapter.title,
+        };
+        reference.setMetadata(metadata);
         references.push(reference);
       }
 

--- a/lib/media/segment_reference.js
+++ b/lib/media/segment_reference.js
@@ -345,6 +345,9 @@ shaka.media.SegmentReference = class {
 
     /** @type {boolean} */
     this.removeSegmentDataOnGet = false;
+
+    /** @type {?shaka.media.SegmentReference.Metadata} */
+    this.metadata_ = null;
   }
 
   /**
@@ -680,6 +683,26 @@ shaka.media.SegmentReference = class {
       partialReference.updateInitSegmentReference(initSegmentReference);
     }
   }
+
+  /**
+   * Set the segment's metadata.
+   *
+   * @param {shaka.media.SegmentReference.Metadata} metadata
+   * @export
+   */
+  setMetadata(metadata) {
+    this.metadata_ = metadata;
+  }
+
+  /**
+   * Returns the segment's metadata.
+   *
+   * @return {?shaka.media.SegmentReference.Metadata}
+   * @export
+   */
+  getMetadata() {
+    return this.metadata_;
+  }
 };
 
 
@@ -724,3 +747,12 @@ shaka.media.AnySegmentReference;
  * @export
  */
 shaka.media.SegmentReference.ThumbnailSprite;
+
+
+/**
+ * @typedef {{
+ *   title: string,
+ * }}
+ * @export
+ */
+shaka.media.SegmentReference.Metadata;

--- a/lib/offline/manifest_converter.js
+++ b/lib/offline/manifest_converter.js
@@ -244,7 +244,7 @@ shaka.offline.ManifestConverter = class {
    */
   fromSegmentDB_(index, segmentDB, streamDB) {
     /** @type {!(shaka.offline.OfflineUri|string)} */
-    const uri = segmentDB.chapterTitle ? segmentDB.chapterTitle :
+    const uri = this.isChapter_(streamDB) ? '' :
         shaka.offline.OfflineUri.segment(
             this.mechanism_, this.cell_, segmentDB.dataKey);
 
@@ -267,6 +267,13 @@ shaka.offline.ManifestConverter = class {
     ref.codecs = segmentDB.codecs || streamDB.codecs || '';
     if (segmentDB.thumbnailSprite) {
       ref.setThumbnailSprite(segmentDB.thumbnailSprite);
+    }
+    if (segmentDB.chapterTitle) {
+      /** @type {shaka.media.SegmentReference.Metadata} */
+      const metadata = {
+        title: segmentDB.chapterTitle,
+      };
+      ref.setMetadata(metadata);
     }
     return ref;
   }

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1726,7 +1726,10 @@ shaka.offline.Storage = class {
 
       let chapterTitle = null;
       if (stream.type == shaka.util.ManifestParserUtils.ContentType.CHAPTER) {
-        chapterTitle = segment.getUris()[0];
+        const metadata = segment.getMetadata();
+        if (metadata) {
+          chapterTitle = metadata.title;
+        }
       }
 
       // Set up the download for the segment, which will be downloaded later,

--- a/lib/player.js
+++ b/lib/player.js
@@ -6243,7 +6243,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             timeline.getPresentationStartTime());
       }
       stream.segmentIndex.forEachTopLevelReference((ref) => {
-        const title = ref.getUris()[0];
+        const metadata = ref.getMetadata();
+        if (!metadata) {
+          return;
+        }
+        const title = metadata.title;
         const id = ref.startTime + '-' + ref.endTime + '-' + title;
         // This occurs when the chapter timings are aligned to the start of the
         // presentation in the client and not to the PDT.
@@ -7067,7 +7071,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const reference = new shaka.media.SegmentReference(
           cue.startTime,
           cue.endTime,
-          () => [cue.payload],
+          () => [],
           /* startByte= */ 0,
           /* endByte= */ null,
           /* initSegmentReference= */ null,
@@ -7075,6 +7079,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           /* appendWindowStart= */ 0,
           /* appendWindowEnd= */ Infinity,
       );
+      /** @type {shaka.media.SegmentReference.Metadata} */
+      const metadata = {
+        title: cue.payload,
+      };
+      reference.setMetadata(metadata);
       references.push(reference);
     }
 

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -1622,17 +1622,18 @@ describe('HlsParser live', () => {
     expect(chapters).toBeDefined();
 
     await chapters.createSegmentIndex();
-    expect(chapters.segmentIndex.getNumReferences()).toBe(1);
-    expect(chapters.segmentIndex.get(0).getUris()[0]).toBe('Intro');
+    const segmentIndex = chapters.segmentIndex;
+    expect(segmentIndex.getNumReferences()).toBe(1);
+    expect(segmentIndex.get(0).getMetadata().title).toBe('Intro');
 
     fakeNetEngine.setResponseText('test:/video', videoLive2);
     fakeNetEngine.setResponseText('test:/chapters.json', chaptersJson2);
 
     await parser.update();
 
-    expect(chapters.segmentIndex.getNumReferences()).toBe(2);
-    expect(chapters.segmentIndex.get(0).getUris()[0]).toBe('Intro');
-    expect(chapters.segmentIndex.get(1).getUris()[0]).toBe('Live Part 1');
+    expect(segmentIndex.getNumReferences()).toBe(2);
+    expect(segmentIndex.get(0).getMetadata().title).toBe('Intro');
+    expect(segmentIndex.get(1).getMetadata().title).toBe('Live Part 1');
   });
 
   it('Live updates: adds new chapter streams', async () => {
@@ -1742,8 +1743,9 @@ describe('HlsParser live', () => {
     expect(chapters).toBeDefined();
 
     await chapters.createSegmentIndex();
-    expect(chapters.segmentIndex.getNumReferences()).toBe(1);
-    expect(chapters.segmentIndex.get(0).getUris()[0]).toBe('Intro');
+    const segmentIndex = chapters.segmentIndex;
+    expect(segmentIndex.getNumReferences()).toBe(1);
+    expect(segmentIndex.get(0).getMetadata().title).toBe('Intro');
   });
 
   /**

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -3023,10 +3023,14 @@ describe('HlsParser', () => {
     expect(firstChapterReference).not.toBe(null);
     expect(secondChapterReference).not.toBe(null);
     if (firstChapterReference) {
-      expect(firstChapterReference.getUris()[0]).toBe('One');
+      const metadata = firstChapterReference.getMetadata();
+      expect(metadata).not.toBe(null);
+      expect(metadata.title).toBe('One');
     }
     if (secondChapterReference) {
-      expect(secondChapterReference.getUris()[0]).toBe('Two');
+      const metadata = secondChapterReference.getMetadata();
+      expect(metadata).not.toBe(null);
+      expect(metadata.title).toBe('Two');
     }
   });
 


### PR DESCRIPTION
Instead of saving chapter titles as a URL, they are now saved as a metadata section that can be expanded in the future.