### PR TITLE
fix(HLS): Fix timing of EMSG boxes when using HLS

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -33,6 +33,7 @@ goog.require('shaka.util.MediaElementEvent');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
+goog.require('shaka.util.NumberUtils');
 goog.require('shaka.util.PublicPromise');
 goog.require('shaka.util.StreamUtils');
 goog.require('shaka.util.TimeUtils');
@@ -1070,7 +1071,10 @@ shaka.media.MediaSourceEngine = class {
    * @private
    */
   dispatchEmsg_(emsg, reference, timestamp) {
-    if (timestamp && this.manifestType_ == shaka.media.ManifestParser.HLS) {
+    const isVersion0 = shaka.util.NumberUtils.isFloatEqual(emsg.startTime,
+        reference.startTime + (emsg.presentationTimeDelta / emsg.timescale));
+    if (timestamp && this.manifestType_ == shaka.media.ManifestParser.HLS &&
+        !isVersion0) {
       const diff = -timestamp + reference.startTime;
       emsg.startTime = emsg.startTime + diff;
       emsg.endTime = emsg.endTime + diff;

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -904,9 +904,14 @@ shaka.media.MediaSourceEngine = class {
       const hasEmsg = ((stream.emsgSchemeIdUris != null &&
           stream.emsgSchemeIdUris.length > 0) ||
           this.config_.dispatchAllEmsgBoxes);
+      const emsgEvents = [];
       if (hasEmsg) {
-        parser.fullBox('emsg', (box) =>
-          this.parseEMSG_(reference, stream.emsgSchemeIdUris, box));
+        parser.fullBox('emsg', (box) => {
+          const emsg = this.parseEMSG_(reference, stream.emsgSchemeIdUris, box);
+          if (emsg) {
+            emsgEvents.push(emsg);
+          }
+        });
       }
       const timescale = reference.initSegmentReference.timescale;
       const hasTimescale = timescale && !isNaN(timescale);
@@ -944,6 +949,9 @@ shaka.media.MediaSourceEngine = class {
       if (parsedMedia && reference.timestampOffset == 0) {
         timestamp = startTime;
       }
+      for (const emsg of emsgEvents) {
+        this.dispatchEmsg_(emsg, reference, timestamp);
+      }
     } else if (!mimeType.includes('/mp4') && !mimeType.includes('/webm') &&
         shaka.util.TsParser.probe(uint8ArrayData)) {
       const tsParser = this.tsParsers_.getOrInsertComputed(
@@ -968,6 +976,7 @@ shaka.media.MediaSourceEngine = class {
    * @param {?Array<string>} emsgSchemeIdUris Array of emsg
    *     scheme_id_uri for which emsg boxes should be parsed.
    * @param {!shaka.extern.ParsedBox} box
+   * @return {?shaka.extern.EmsgInfo}
    * @private
    * https://dashif-documents.azurewebsites.net/Events/master/event.html#emsg-format
    * aligned(8) class DASHEventMessageBox
@@ -1048,28 +1057,47 @@ shaka.media.MediaSourceEngine = class {
           messageData: messageData,
         };
 
-        this.playerInterface_.onEmsg(emsg);
+        return emsg;
+      }
+    }
+    return null;
+  }
 
-        // Additionally, ID3 events generate a 'metadata' event.  This is a
-        // pre-parsed version of the metadata blob already dispatched in the
-        // 'emsg' event.
-        if (schemeId == 'https://aomedia.org/emsg/ID3' ||
-            schemeId == 'https://developer.apple.com/streaming/emsg-id3') {
-          // See https://aomediacodec.github.io/id3-emsg/
-          const frames = shaka.util.Id3Utils.getID3Frames(messageData);
-          if (frames.length) {
-            /** @private {shaka.extern.ID3Metadata} */
-            const metadata = {
-              cueTime: startTime,
-              data: messageData,
-              frames: frames,
-              dts: startTime,
-              pts: startTime,
-            };
-            this.playerInterface_.onMetadata(
-                [metadata], /* offset= */ 0, endTime);
-          }
-        }
+  /**
+   * @param {shaka.extern.EmsgInfo} emsg
+   * @param {!shaka.media.SegmentReference} reference
+   * @param {?number} timestamp
+   * @private
+   */
+  dispatchEmsg_(emsg, reference, timestamp) {
+    if (timestamp && this.manifestType_ == shaka.media.ManifestParser.HLS) {
+      const diff = -timestamp + reference.startTime;
+      emsg.startTime = emsg.startTime + diff;
+      emsg.endTime = emsg.endTime + diff;
+    }
+
+    this.playerInterface_.onEmsg(emsg);
+
+    // Additionally, ID3 events generate a 'metadata' event.  This is a
+    // pre-parsed version of the metadata blob already dispatched in the
+    // 'emsg' event.
+    if (emsg.messageData &&
+        (emsg.schemeIdUri == 'https://aomedia.org/emsg/ID3' ||
+        emsg.schemeIdUri == 'https://developer.apple.com/streaming/emsg-id3')) {
+      // See https://aomediacodec.github.io/id3-emsg/
+      const frames = shaka.util.Id3Utils.getID3Frames(emsg.messageData);
+      if (frames.length) {
+        const startTime = emsg.startTime;
+        /** @private {shaka.extern.ID3Metadata} */
+        const metadata = {
+          cueTime: startTime,
+          data: emsg.messageData,
+          frames: frames,
+          dts: startTime,
+          pts: startTime,
+        };
+        this.playerInterface_.onMetadata(
+            [metadata], /* offset= */ 0, emsg.endTime);
       }
     }
   }

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -856,6 +856,17 @@ describe('MediaSourceEngine', () => {
         /* appendWindowStart= */ 0,
         /* appendWindowEnd= */ Infinity);
 
+    const hlsReference = new shaka.media.SegmentReference(
+        /* startTime= */ 2,
+        /* endTime= */ 3,
+        /* uris= */ () => [],
+        /* startByte= */ 0,
+        /* endByte= */ null,
+        initSegmentReference,
+        /* timestampOffset= */ 0,
+        /* appendWindowStart= */ 0,
+        /* appendWindowEnd= */ Infinity);
+
     it('raises an event for registered embedded emsg boxes', () => {
       const videoStream =
           shaka.test.StreamingEngineUtil.createMockVideoStream(1);
@@ -896,17 +907,6 @@ describe('MediaSourceEngine', () => {
       const videoStream =
           shaka.test.StreamingEngineUtil.createMockVideoStream(1);
       videoStream.emsgSchemeIdUris = [emsgObjWithOffsetHls.schemeIdUri];
-
-      const hlsReference = new shaka.media.SegmentReference(
-          /* startTime= */ 2,
-          /* endTime= */ 3,
-          /* uris= */ () => [],
-          /* startByte= */ 0,
-          /* endByte= */ null,
-          initSegmentReference,
-          /* timestampOffset= */ 0,
-          /* appendWindowStart= */ 0,
-          /* appendWindowEnd= */ Infinity);
 
       await mediaSourceEngine.init(new Map(), /* sequenceMode= */ true,
           shaka.media.ManifestParser.HLS);

--- a/test/media/media_source_engine_integration.js
+++ b/test/media/media_source_engine_integration.js
@@ -827,6 +827,18 @@ describe('MediaSourceEngine', () => {
       messageData: new Uint8Array([0x74, 0x65, 0x73, 0x74]),
     };
 
+    const emsgObjWithOffsetHls = {
+      startTime: 8,
+      endTime: 0xffff + 8,
+      schemeIdUri: 'foo:bar:customdatascheme',
+      value: '1',
+      timescale: 1,
+      presentationTimeDelta: 6,
+      eventDuration: 0xffff,
+      id: 1,
+      messageData: new Uint8Array([0x74, 0x65, 0x73, 0x74]),
+    };
+
     const initSegmentReference = new shaka.media.InitSegmentReference(
         /* uris= */ () => [],
         /* startByte= */ 0,
@@ -878,6 +890,38 @@ describe('MediaSourceEngine', () => {
 
       const emsgInfo = onEmsg.calls.argsFor(0)[0];
       expect(emsgInfo).toEqual(emsgObjWithOffset);
+    });
+
+    it('uses segment reference times for embedded emsg in HLS', async () => {
+      const videoStream =
+          shaka.test.StreamingEngineUtil.createMockVideoStream(1);
+      videoStream.emsgSchemeIdUris = [emsgObjWithOffsetHls.schemeIdUri];
+
+      const hlsReference = new shaka.media.SegmentReference(
+          /* startTime= */ 2,
+          /* endTime= */ 3,
+          /* uris= */ () => [],
+          /* startByte= */ 0,
+          /* endByte= */ null,
+          initSegmentReference,
+          /* timestampOffset= */ 0,
+          /* appendWindowStart= */ 0,
+          /* appendWindowEnd= */ Infinity);
+
+      await mediaSourceEngine.init(new Map(), /* sequenceMode= */ true,
+          shaka.media.ManifestParser.HLS);
+
+      mediaSourceEngine.getTimestampAndDispatchMetadata(
+          ContentType.VIDEO,
+          emsgSegmentV1,
+          hlsReference,
+          videoStream,
+          /* mimeType= */ 'video/mp4');
+
+      expect(onEmsg).toHaveBeenCalledTimes(1);
+
+      const emsgInfo = onEmsg.calls.argsFor(0)[0];
+      expect(emsgInfo).toEqual(emsgObjWithOffsetHls);
     });
 
     it('raises multiple events', () => {


### PR DESCRIPTION
Shaka Player was interpreting EMSG timestamps using the wall-clock reference of the playlist's initial load, which caused EMSG events to fire at incorrect times. In HLS, however, the `emsg` timing fields (`presentation_time` / `presentation_time_delta`) are defined relative to the segment’s local timescale.

This change normalizes EMSG timestamps using the segment’s `startTime`, aligning them with Shaka’s internal timeline. As a result, EMSG events are now triggered at the correct playback time regardless of when the playlist was first loaded.