### PR TITLE
fix(UI): Prevent hidden seek button from interfering with double-tap

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -883,8 +883,8 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
    */
   setLastTouchEventTime(time, container) {
     shaka.Deprecate.deprecateFeature(6,
-          'setLastTouchEventTime',
-          'This method is no longer used.');
+        'setLastTouchEventTime',
+        'This method is no longer used.');
   }
 
   /**

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -11,6 +11,7 @@ goog.provide('shaka.ui.ControlsPanel');
 goog.require('goog.asserts');
 goog.require('shaka.ads.Utils');
 goog.require('shaka.cast.CastProxy');
+goog.require('shaka.Deprecate');
 goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.device.IDevice');
 goog.require('shaka.log');
@@ -873,6 +874,17 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
    */
   getDisplayTime() {
     return this.seekBar_ ? this.seekBar_.getValue() : this.video_.currentTime;
+  }
+
+  /**
+   * @param {?number} time
+   * @param {boolean} container
+   * @export
+   */
+  setLastTouchEventTime(time, container) {
+    shaka.Deprecate.deprecateFeature(6,
+          'setLastTouchEventTime',
+          'This method is no longer used.');
   }
 
   /**

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -876,18 +876,6 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
   }
 
   /**
-   * @param {?number} time
-   * @param {boolean} container
-   * @export
-   */
-  setLastTouchEventTime(time, container) {
-    this.lastTouchEventTime_ = time;
-    if (container) {
-      this.lastContainerTouchEventTime_ = time;
-    }
-  }
-
-  /**
    * @return {boolean}
    * @export
    */

--- a/ui/hidden_seek_button.js
+++ b/ui/hidden_seek_button.js
@@ -93,7 +93,6 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     this.eventManager.listen(this.seekContainer, 'touchend', (e) => {
       const event = /** @type {!TouchEvent} */(e);
       this.onTouchEnd_(event);
-      this.controls.setLastTouchEventTime(Date.now(), /* container= */ true);
     });
   }
 
@@ -139,6 +138,14 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
    * @private
    */
   onTouchEnd_(event) {
+    // Ignore this event if the controls are transparent.
+    // Double-tapping the hidden seek button when the controls are hidden
+    // should cause the player to go fullscreen, not cause it to
+    // rewind/fast-forward.
+    if (!this.controls.isOpaque()) {
+      return;
+    }
+
     // If user scrolled, don't handle as a tap.
     if (this.hasMoved_) {
       return;
@@ -147,7 +154,6 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     // If any settings menus are open, this tap closes them instead of toggling
     // play/seek.
     if (this.controls.anySettingsMenusAreOpen()) {
-      event.preventDefault();
       this.controls.hideSettingsMenus();
       return;
     }
@@ -155,7 +161,6 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     // Normal tap logic (single vs double tap).
     if (this.controls.getConfig().tapSeekDistance > 0 &&
         (!this.ad || !this.ad.isLinear())) {
-      event.preventDefault();
       this.onSeekButtonClick_();
     }
   }

--- a/ui/hidden_seek_button.js
+++ b/ui/hidden_seek_button.js
@@ -154,6 +154,7 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     // If any settings menus are open, this tap closes them instead of toggling
     // play/seek.
     if (this.controls.anySettingsMenusAreOpen()) {
+      event.preventDefault();
       this.controls.hideSettingsMenus();
       return;
     }
@@ -161,6 +162,7 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     // Normal tap logic (single vs double tap).
     if (this.controls.getConfig().tapSeekDistance > 0 &&
         (!this.ad || !this.ad.isLinear())) {
+      event.preventDefault();
       this.onSeekButtonClick_();
     }
   }

--- a/ui/hidden_seek_button.js
+++ b/ui/hidden_seek_button.js
@@ -155,6 +155,7 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     // play/seek.
     if (this.controls.anySettingsMenusAreOpen()) {
       event.preventDefault();
+      event.stopPropagation();
       this.controls.hideSettingsMenus();
       return;
     }
@@ -163,6 +164,7 @@ shaka.ui.HiddenSeekButton = class extends shaka.ui.Element {
     if (this.controls.getConfig().tapSeekDistance > 0 &&
         (!this.ad || !this.ad.isLinear())) {
       event.preventDefault();
+      event.stopPropagation();
       this.onSeekButtonClick_();
     }
   }

--- a/ui/overflow_menu.js
+++ b/ui/overflow_menu.js
@@ -75,13 +75,6 @@ shaka.ui.OverflowMenu = class extends shaka.ui.Element {
           shaka.ui.Utils.setDisplay(this.overflowMenuButton_, true);
         });
 
-    this.eventManager.listen(
-        this.overflowMenu_, 'touchstart', (event) => {
-          this.controls.setLastTouchEventTime(
-              Date.now(), /* container= */ false);
-          event.stopPropagation();
-        });
-
     this.eventManager.listen(this.overflowMenuButton_, 'click', () => {
       if (!this.controls.isOpaque()) {
         return;


### PR DESCRIPTION
The hidden seek button has custom behavior that causes it to attempt to "delay" touch events on it, to wait to see
if they are a double-tap or not.
This interacted with the double click to fullscreen behavior unfortunately; a single touch was registered, then it was
registered again 500ms later, causing it to be detected as a double-tap by the controls container.

This PR changes the hidden seek button to ignore `touchend` events that happen while the controls are transparent, and changes the initial `touchend` event on the hidden seek button to not propagate down, thus preventing the doubling behavior without introducing any lag on the controls appearing.

Fixes #9705