### PR TITLE
chore(HLS): Only return true on hasEnoughInfoToFinalizeStreams_ when there are variants

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3152,7 +3152,7 @@ shaka.hls.HlsParser = class {
    * @private
    */
   hasEnoughInfoToFinalizeStreams_() {
-    if (!this.manifest_) {
+    if (!this.manifest_ || !this.manifest_.variants.length) {
       return false;
     }
     const videos = [];


### PR DESCRIPTION
This method can be called with an image stream, and in these cases it cannot be terminated yet.