### PR TITLE
fix: Check end time when getting next segment reference

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1792,7 +1792,7 @@ shaka.media.StreamingEngine = class {
         const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
         const lastStartTime = mediaState.lastSegmentReference.startTime;
         const lastEndTime = mediaState.lastSegmentReference.endTime;
-        if (isDiffNegligible(lastStartTime, ref.startTime) && isDiffNegligible(lastEndTime, ref.endTime) {
+        if (isDiffNegligible(lastStartTime, ref.startTime) && isDiffNegligible(lastEndTime, ref.endTime)) {
           ref = mediaState.segmentIterator.next().value;
         }
       }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1792,7 +1792,8 @@ shaka.media.StreamingEngine = class {
         const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
         const lastStartTime = mediaState.lastSegmentReference.startTime;
         const lastEndTime = mediaState.lastSegmentReference.endTime;
-        if (isDiffNegligible(lastStartTime, ref.startTime) && isDiffNegligible(lastEndTime, ref.endTime)) {
+        if (isDiffNegligible(lastStartTime, ref.startTime) &&
+            isDiffNegligible(lastEndTime, ref.endTime)) {
           ref = mediaState.segmentIterator.next().value;
         }
       }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1791,7 +1791,8 @@ shaka.media.StreamingEngine = class {
         // again, tolerating a difference of 1ms.
         const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
         const lastStartTime = mediaState.lastSegmentReference.startTime;
-        if (isDiffNegligible(lastStartTime, ref.startTime)) {
+        const lastEndTime = mediaState.lastSegmentReference.endTime;
+        if (isDiffNegligible(lastStartTime, ref.startTime) && isDiffNegligible(lastEndTime, ref.endTime) {
           ref = mediaState.segmentIterator.next().value;
         }
       }


### PR DESCRIPTION
In specific situations. this check was causing a segment append to get skipped in DASH manifests.
The conditions to trigger this issue are a multi period DASH manifest, where the period boundary splits either a video or audio segment, rather than being aligned on segment boundaries. This can happen in content that has audio and video segments that are not aligned. The resulting behavior is that a gap is introduced into the buffer.

Here is an example manifest that could result in this behavior.
[manifest.xml](https://github.com/user-attachments/files/25494234/manifest.xml)
I am unable to share the source mp4. The content between the two periods is contiguous. However, since the video durations are all over the place and audio is constant 8s durations, there is no point that you could split the content into two periods without splitting either a video or audio segment. Because there can be issues with video segments being dropped when the keyframe is outside the append window, it is better to split the manifest along video boundaries and let audio get split by the period.

When the audio segment is split by the period, it must be referenced in both segment timelines from each period. This way the first say 4s of the audio segment are captured in the first period, and the later half 4s of the segment are captured in the second period. In order to not drop any audio data, the player needs to append the audio segment twice, once when filling the first period, and again when filling the second period. The append window will end up truncating the first/last half of the audio segment depending on which period is getting filled. 

Because of the original check here to prevent the same segment from getting appended twice. this second append was being skipped, leaving a gap for the second half of the segment.

The fix here is to check both the start and end times, and if both match, we can reasonably assume the entire segment was appended, and it is safe to skip.

In my example, the audio segment being appended has a `start=64s, end=72s`.
Because the append window truncated the end of the audio segment during the first append, we actually end up getting
```
lastSegmentReference.startTime = 64s
lastSegmentReference.endTime = 69s
ref.startTime = 64s
ref.endTime = 72s
```
so by checking the end time as well, we can see that the segment was not full appended, allowing shaka to not skip the segment and re-append.

This should still address the HLS issue mentioned by the comment, however I am unsure of the full context for the original check, so I can't say for certainty whether this change will impact that check or not. 

The original pull request is here https://github.com/shaka-project/shaka-player/pull/8084 but there is no description or comments other than the one in code. No test fixtures or anything added, so quite difficult to discern the context.