### PR TITLE
build: Support ES5/ES2021 dual builds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -165,7 +165,7 @@ jobs:
 
       - name: Build Player
         timeout-minutes: 20
-        run: python3 build/all.py
+        run: python3 build/all.py --only-es5
 
       - name: Test Player
         timeout-minutes: 15

--- a/build/all.py
+++ b/build/all.py
@@ -76,6 +76,12 @@ def main(args):
            'release version.',
       action='store_true')
 
+  parser.add_argument(
+     '--only-es5',
+      help='If set, only compile ECMASCRIPT5 builds.',
+      action='store_true',
+      default=False)
+
   parsed_args = parser.parse_args(args)
 
   # Make the dist/ folder, ignore errors.
@@ -159,13 +165,31 @@ def main(args):
     build_args_only_hls_without_ui,
   ]
 
+  if parsed_args.only_es5:
+    language_variants = [
+      ('ECMASCRIPT5', ''),
+    ]
+  else:
+    language_variants = [
+      ('ECMASCRIPT5', ''),
+      ('ECMASCRIPT_2021', 'es2021'),
+    ]
+
   for mode in modes:
     # Complete build includes the UI library, but it is optional and player lib
     # should build and work without it as well.
     # First, build the full build (UI included) and then build excluding UI.
-    for build_args in builds:
-      if build.main(build_args + ['--mode', mode]) != 0:
-        return 1
+    for lang_out, suffix in language_variants:
+      for build_args in builds:
+        args = list(build_args)
+        if '--name' in args and suffix:
+          idx = args.index('--name')
+          original_name = args[idx + 1]
+          args[idx + 1] = f"{original_name}-{suffix}"
+        args += ['--langout', lang_out]
+        args += ['--mode', mode]
+        if build.main(args) != 0:
+          return 1
 
     is_debug = mode == 'debug'
     if not apps.build_all(parsed_args.force, is_debug):

--- a/build/all.py
+++ b/build/all.py
@@ -78,7 +78,11 @@ def run_task(task):
 
   # Stream stderr
   for line in proc.stderr:
-      print(f"{prefix} [ERR] {line}", end='')
+      # Do not mark INFO lines as errors
+      if line.startswith("[INFO]"):
+          print(f"{prefix} {line}", end='')
+      else:
+          print(f"{prefix} [ERR] {line}", end='')
 
   proc.wait()
   return proc.returncode, cmd, "", ""
@@ -245,7 +249,7 @@ def main(args):
         tasks.append((cmd, env))
 
     failures = []
-    with concurrent.futures.ProcessPoolExecutor(max_workers=max(1, parsed_args.jobs)) as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, parsed_args.jobs)) as executor:
       for rc, cmd, out, err in executor.map(run_task, tasks):
         if rc != 0:
           failures.append((rc, cmd, out, err))

--- a/build/all.py
+++ b/build/all.py
@@ -45,6 +45,44 @@ def compile_less(path_name, main_file_name, parsed_args):
   less = compiler.Less(main_less_src, all_less_srcs, output)
   return less.compile(parsed_args.force)
 
+def run_task(task):
+  """Run a build subprocess and stream its output live."""
+  cmd, env = task
+
+  proc = subprocess.Popen(
+      cmd,
+      env=env,
+      stdout=subprocess.PIPE,
+      stderr=subprocess.PIPE,
+      text=True
+  )
+
+  # Build a readable prefix for logs
+  try:
+      name_index = cmd.index("--name") + 1
+      name = cmd[name_index]
+  except ValueError:
+      name = "unknown"
+
+  try:
+      mode_index = cmd.index("--mode") + 1
+      mode = cmd[mode_index]
+  except ValueError:
+      mode = "unknown"
+
+  prefix = f"[build:{name}-{mode}]"
+
+  # Stream stdout
+  for line in proc.stdout:
+      print(f"{prefix} {line}", end='')
+
+  # Stream stderr
+  for line in proc.stderr:
+      print(f"{prefix} [ERR] {line}", end='')
+
+  proc.wait()
+  return proc.returncode, cmd, "", ""
+
 def main(args):
   parser = argparse.ArgumentParser(
       description='User facing build script for building the Shaka'
@@ -206,47 +244,8 @@ def main(args):
         cmd = [sys.executable, os.path.join(base, 'build', 'build.py')] + args
         tasks.append((cmd, env))
 
-    def run_task(task):
-      """Run a build subprocess and stream its output live."""
-      cmd, env = task
-
-      proc = subprocess.Popen(
-          cmd,
-          env=env,
-          stdout=subprocess.PIPE,
-          stderr=subprocess.PIPE,
-          text=True
-      )
-
-      # Build a readable prefix for logs
-      try:
-          name_index = cmd.index("--name") + 1
-          name = cmd[name_index]
-      except ValueError:
-          name = "unknown"
-
-      try:
-          mode_index = cmd.index("--mode") + 1
-          mode = cmd[mode_index]
-      except ValueError:
-          mode = "unknown"
-
-      prefix = f"[build:{name}-{mode}]"
-
-      # Stream stdout
-      for line in proc.stdout:
-          print(f"{prefix} {line}", end='')
-
-      # Stream stderr
-      for line in proc.stderr:
-          print(f"{prefix} [ERR] {line}", end='')
-
-      proc.wait()
-      return proc.returncode, cmd, "", ""
-
     failures = []
-    # ThreadPool is fine because each task spawns an external process (no GIL bottleneck).
-    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, parsed_args.jobs)) as executor:
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max(1, parsed_args.jobs)) as executor:
       for rc, cmd, out, err in executor.map(run_task, tasks):
         if rc != 0:
           failures.append((rc, cmd, out, err))

--- a/build/all.py
+++ b/build/all.py
@@ -18,6 +18,8 @@
 
 import argparse
 
+import concurrent.futures
+
 import apps
 import build
 import check
@@ -29,6 +31,8 @@ import shakaBuildHelpers
 
 import os
 import re
+import subprocess
+import sys
 
 def compile_less(path_name, main_file_name, parsed_args):
   match = re.compile(r'.*\.less$')
@@ -81,6 +85,12 @@ def main(args):
       help='If set, only compile ECMASCRIPT5 builds.',
       action='store_true',
       default=False)
+
+  parser.add_argument(
+      '--jobs', '-j',
+      type=int,
+      default=(os.cpu_count() or 1),
+      help='Number of parallel builds (defaults to number of CPUs).')
 
   parsed_args = parser.parse_args(args)
 
@@ -175,22 +185,81 @@ def main(args):
       ('ECMASCRIPT_2021', 'es2021'),
     ]
 
+  # Run library builds in parallel per mode.
   for mode in modes:
-    # Complete build includes the UI library, but it is optional and player lib
-    # should build and work without it as well.
-    # First, build the full build (UI included) and then build excluding UI.
+    tasks = []
+
     for lang_out, suffix in language_variants:
       for build_args in builds:
         args = list(build_args)
+        # If the build has a --name, append a suffix (e.g., -es2021) for clarity.
         if '--name' in args and suffix:
           idx = args.index('--name')
           original_name = args[idx + 1]
           args[idx + 1] = f"{original_name}-{suffix}"
+        # Add language and mode flags.
         args += ['--langout', lang_out]
         args += ['--mode', mode]
-        if build.main(args) != 0:
-          return 1
 
+        # Prepare environment and command for a separate process.
+        env = os.environ.copy()
+        cmd = [sys.executable, os.path.join(base, 'build', 'build.py')] + args
+        tasks.append((cmd, env))
+
+    def run_task(task):
+      """Run a build subprocess and stream its output live."""
+      cmd, env = task
+
+      proc = subprocess.Popen(
+          cmd,
+          env=env,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          text=True
+      )
+
+      # Build a readable prefix for logs
+      try:
+          name_index = cmd.index("--name") + 1
+          name = cmd[name_index]
+      except ValueError:
+          name = "unknown"
+
+      try:
+          mode_index = cmd.index("--mode") + 1
+          mode = cmd[mode_index]
+      except ValueError:
+          mode = "unknown"
+
+      prefix = f"[build:{name}-{mode}]"
+
+      # Stream stdout
+      for line in proc.stdout:
+          print(f"{prefix} {line}", end='')
+
+      # Stream stderr
+      for line in proc.stderr:
+          print(f"{prefix} [ERR] {line}", end='')
+
+      proc.wait()
+      return proc.returncode, cmd, "", ""
+
+    failures = []
+    # ThreadPool is fine because each task spawns an external process (no GIL bottleneck).
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, parsed_args.jobs)) as executor:
+      for rc, cmd, out, err in executor.map(run_task, tasks):
+        if rc != 0:
+          failures.append((rc, cmd, out, err))
+
+    if failures:
+      # Print the first failure for quick diagnosis and abort.
+      rc, cmd, out, err = failures[0]
+      print("ERROR running build:", cmd)
+      print("STDOUT:\n", out)
+      print("STDERR:\n", err, file=sys.stderr)
+      return 1
+
+    # Build the demo/apps once per mode, after all library builds succeed.
     is_debug = mode == 'debug'
     if not apps.build_all(parsed_args.force, is_debug):
       return 1

--- a/build/build.py
+++ b/build/build.py
@@ -418,6 +418,7 @@ def main(args):
       'mode': mode,
       'locales': locales,
       'skip_ts': skip_ts,
+      'langout': parsed_args.langout,
     }
     state_json = json.dumps(state, sort_keys=True)
     return hashlib.sha256(state_json.encode('utf-8')).hexdigest()

--- a/build/build.py
+++ b/build/build.py
@@ -48,6 +48,9 @@ import logging
 import os
 import re
 import shutil
+import sys
+
+from contextlib import contextmanager
 
 import compiler
 import generateLocalizations
@@ -408,6 +411,7 @@ def main(args):
   if not custom_build.parse_build(commands, os.getcwd()):
     return 1
 
+  # Global shared state file; parallel processes will serialize access via locks.
   hash_file_path = os.path.join(dist_path, 'build_state.json')
 
   def compute_build_hash(include, exclude, commands, mode, locales, skip_ts):
@@ -436,15 +440,60 @@ def main(args):
 
   force = parsed_args.force
 
-  if os.path.isfile(hash_file_path):
-    with open(hash_file_path, 'r') as f:
-      previous_state = json.load(f)
-    previous_hash = previous_state.get(build_key)
-    if previous_hash != current_hash:
-      logging.info('Build parameters changed for "%s"; forcing rebuild.', parsed_args.name)
-      force = True
+  # --- Cross‑platform file lock helpers (defined inline to keep changes local) ---
+  if os.name == "posix":
+    import fcntl
+
+    @contextmanager
+    def locked_file_rw(path, create=False):
+      """Open file for read/write and acquire an exclusive advisory lock (POSIX)."""
+      mode = 'r+' if os.path.isfile(path) or not create else 'w+'
+      with open(path, mode) as f:
+        # Acquire exclusive lock on the entire file.
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+          yield f
+        finally:
+          fcntl.flock(f.fileno(), fcntl.LOCK_UN)
   else:
-    previous_state = {}
+    import msvcrt
+
+    @contextmanager
+    def locked_file_rw(path, create=False):
+      """Open file for read/write and acquire an exclusive lock (Windows).
+      This uses msvcrt.locking over the first byte as a process‑wide mutex.
+      """
+      mode = 'r+' if os.path.isfile(path) or not create else 'w+'
+      with open(path, mode) as f:
+        # Always lock the first byte as a mutex region.
+        f.seek(0, os.SEEK_SET)
+        msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+        try:
+          yield f
+        finally:
+          f.seek(0, os.SEEK_SET)
+          msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+
+  # --- Safe read of the global state under lock (if the file exists) ---
+  previous_state = {}
+  if os.path.isfile(hash_file_path):
+    try:
+      with locked_file_rw(hash_file_path):
+        # Re-opened with lock: parse safely
+        with open(hash_file_path, 'r') as f:
+          try:
+            previous_state = json.load(f)
+          except json.JSONDecodeError:
+            logging.warning("Detected a corrupted build_state.json; continuing with empty state.")
+            previous_state = {}
+    except OSError as e:
+      logging.warning("Could not lock/read build_state.json (%s); proceeding with empty state.", e)
+      previous_state = {}
+
+  previous_hash = previous_state.get(build_key)
+  if previous_hash != current_hash:
+    logging.info('Build parameters changed for "%s"; forcing rebuild.', parsed_args.name)
+    force = True
 
   name = parsed_args.name
   langout = parsed_args.langout
@@ -456,9 +505,31 @@ def main(args):
       skip_ts):
     return 1
 
-  previous_state[build_key] = current_hash
-  with open(hash_file_path, 'w') as f:
-    json.dump(previous_state, f, indent=2, sort_keys=True)
+  # Persist (merge) the updated state under lock so we don't clobber parallel updates.
+  # Use create=True so the file is created if it didn't exist.
+  try:
+    with locked_file_rw(hash_file_path, create=True) as f:
+      # Read current on-disk state (may have been updated by other processes)
+      try:
+        f.seek(0, os.SEEK_SET)
+        on_disk = json.load(f)
+      except json.JSONDecodeError:
+        on_disk = {}
+      except Exception:
+        on_disk = {}
+      # Merge and write back atomically under the same lock
+      on_disk[build_key] = current_hash
+      f.seek(0, os.SEEK_SET)
+      f.truncate()
+      json.dump(on_disk, f, indent=2, sort_keys=True)
+      f.flush()
+      try:
+        os.fsync(f.fileno())
+      except Exception:
+        # fsync may be unavailable on some platforms; ignore safely.
+        pass
+  except OSError as e:
+    logging.warning("Failed to persist build_state.json safely: %s", e)
 
   return 0
 

--- a/project-words.txt
+++ b/project-words.txt
@@ -537,6 +537,7 @@ sintel
 stardate
 systeminfo
 templatized
+UNLCK
 vaage
 webapis
 


### PR DESCRIPTION
Results:

| File                           | ES5                    | ES2021                 | Diff                       |
| ------------------------------ | ---------------------- | ---------------------- | -------------------------- |
| Compiled Debug                 | 1502.9 KiB (344.0 KiB) | 1235.9 KiB (302.9 KiB) | **-267.0 KiB (-41.1 KiB)** |
| Compiled                       | 755.8 KiB (244.8 KiB)  | 653.7 KiB (217.4 KiB)  | **-102.1 KiB (-27.4 KiB)** |
| DASH Debug                     | 1101.3 KiB (257.6 KiB) | 906.8 KiB (227.3 KiB)  | **-194.5 KiB (-30.3 KiB)** |
| DASH                           | 521.0 KiB (172.5 KiB)  | 448.8 KiB (152.9 KiB)  | **-72.2 KiB (-19.6 KiB)**  |
| HLS Debug                      | 1137.9 KiB (263.6 KiB) | 938.2 KiB (232.8 KiB)  | **-199.7 KiB (-30.8 KiB)** |
| HLS                            | 559.3 KiB (184.1 KiB)  | 484.1 KiB (163.5 KiB)  | **-75.2 KiB (-20.6 KiB)**  |
| UI Debug                       | 1825.6 KiB (411.9 KiB) | 1527.5 KiB (366.4 KiB) | **-298.1 KiB (-45.5 KiB)** |
| UI                             | 966.8 KiB (302.3 KiB)  | 855.5 KiB (271.9 KiB)  | **-111.3 KiB (-30.4 KiB)** |
| Experimental Debug             | 1886.5 KiB (424.9 KiB) | 1572.3 KiB (377.0 KiB) | **-314.2 KiB (-47.9 KiB)** |
| Experimental                   | 993.1 KiB (310.0 KiB)  | 875.1 KiB (278.0 KiB)  | **-118.0 KiB (-32.0 KiB)** |

Since the number of builds has doubled, the option to compile in parallel has now been added to optimize time.
