### PR TITLE
feat(DASH): Enable automatic XLink processing with fast detection and performance improvements

### DIFF
--- a/demo/common/assets.js
+++ b/demo/common/assets.js
@@ -634,14 +634,7 @@ shakaAssets.testAssets = [
       .addFeature(shakaAssets.Feature.MP4)
       .addFeature(shakaAssets.Feature.WEBM)
       .addFeature(shakaAssets.Feature.XLINK)
-      .addFeature(shakaAssets.Feature.OFFLINE)
-      .setExtraConfig({
-        manifest: {
-          dash: {
-            disableXlinkProcessing: false,
-          },
-        },
-      }),
+      .addFeature(shakaAssets.Feature.OFFLINE),
   // From: http://dig.ccmixter.org/files/JeffSpeed68/53327
   // Licensed under Creative Commons BY-NC 3.0.
   // Free for non-commercial use with attribution.

--- a/demo/config.js
+++ b/demo/config.js
@@ -248,8 +248,6 @@ shakaDemo.Config = class {
     this.addSection_('DASH Manifest', docLink)
         .addBoolInput_('Auto-Correct DASH Drift',
             'manifest.dash.autoCorrectDrift')
-        .addBoolInput_('Disable Xlink processing',
-            'manifest.dash.disableXlinkProcessing')
         .addBoolInput_('Xlink Should Fail Gracefully',
             'manifest.dash.xlinkFailGracefully')
         .addBoolInput_('Ignore DASH suggestedPresentationDelay',

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1434,7 +1434,6 @@ shaka.extern.xml.Node;
 /**
  * @typedef {{
  *   clockSyncUri: string,
- *   disableXlinkProcessing: boolean,
  *   xlinkFailGracefully: boolean,
  *   ignoreMinBufferTime: boolean,
  *   autoCorrectDrift: boolean,
@@ -1455,10 +1454,6 @@ shaka.extern.xml.Node;
  *   URI will be used to determine the current time.
  *   <br>
  *   Defaults to <code>''</code>.
- * @property {boolean} disableXlinkProcessing
- *   If true, xlink-related processing will be disabled.
- *   <br>
- *   Defaults to <code>true</code>.
  * @property {boolean} xlinkFailGracefully
  *   If true, xlink-related errors will result in a fallback to the tag's
  *   existing contents. If false, xlink-related errors will be propagated

--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -486,8 +486,7 @@ shaka.dash.DashParser = class {
       return this.processPatchManifest_(mpd);
     }
 
-    const disableXlinkProcessing = this.config_.dash.disableXlinkProcessing;
-    if (disableXlinkProcessing) {
+    if (!shaka.dash.MpdUtils.hasXlinks(mpd)) {
       return this.processManifest_(mpd, finalManifestUri);
     }
 

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -516,6 +516,50 @@ shaka.dash.MpdUtils = class {
   }
 
   /**
+   * Fast detection of whether the MPD contains XLinks worth resolving.
+   * The DASH spec only allows XLink on the following elements:
+   *   - Period
+   *   - AdaptationSet
+   *   - SegmentList
+   * We also avoid descending into SegmentTimeline for performance and
+   * because XLink is not valid there.
+   *
+   * @param {!shaka.extern.xml.Node} root
+   * @return {boolean}
+   */
+  static hasXlinks(root) {
+    const TXml = shaka.util.TXml;
+    const NS = shaka.dash.MpdUtils.XlinkNamespaceUri_;
+    // Elements where XLink is valid per spec.
+    const xlinkElements = new Set(['Period', 'AdaptationSet', 'SegmentList']);
+    // Containers that are worthwhile to traverse to reach the allowed elements.
+    const containers = new Set([
+      'MPD', 'Period', 'AdaptationSet', 'Representation', 'SegmentList',
+    ]);
+    /** @type {!Array<!shaka.extern.xml.Node>} */
+    const stack = [root];
+    while (stack.length) {
+      const node = stack.pop();
+      if (xlinkElements.has(node.tagName)) {
+        if (TXml.getAttributeNS(node, NS, 'href')) {
+          // Early return on first XLink occurrence.
+          return true;
+        }
+      }
+      if (node.tagName == 'SegmentTimeline') {
+        // Never descend into SegmentTimeline (invalid for XLink and expensive).
+        continue;
+      }
+      for (const child of TXml.getChildNodes(node)) {
+        if (containers.has(child.tagName)) {
+          stack.push(child);
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
    * Follow the xlink link contained in the given element.
    * It also strips the xlink properties off of the element,
    * even if the process fails.
@@ -542,8 +586,7 @@ shaka.dash.MpdUtils = class {
     const xlinkActuate =
         TXml.getAttributeNS(element, NS, 'actuate') || 'onRequest';
 
-    // Remove the xlink properties, so it won't download again
-    // when re-processed.
+    // Strip all xlink attributes to avoid re-fetching on re-processing.
     for (const key of Object.keys(element.attributes)) {
       const segments = key.split(':');
       const namespace = shaka.util.TXml.getKnownNameSpace(NS);
@@ -558,9 +601,12 @@ shaka.dash.MpdUtils = class {
           Error.Code.DASH_XLINK_DEPTH_LIMIT));
     }
 
-    if (xlinkActuate != 'onLoad') {
-      // Only xlink:actuate="onLoad" is supported.
-      // When no value is specified, the assumed value is "onRequest".
+    // DASH/XLink allows both "onLoad" and "onRequest" (default if missing).
+    // Resolve eagerly for both values; this keeps behavior simple and
+    // standard-compliant.
+    // We treat "onLoad" and "onRequest" the same way, that is, they are
+    // resolved immediately.
+    if (xlinkActuate != 'onLoad' && xlinkActuate != 'onRequest') {
       return shaka.util.AbortableOperation.failed(new Error(
           Error.Severity.CRITICAL, Error.Category.MANIFEST,
           Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE));
@@ -569,7 +615,7 @@ shaka.dash.MpdUtils = class {
     // Resolve the xlink href, in case it's a relative URL.
     const uris = ManifestParserUtils.resolveUris([baseUri], [xlinkHref]);
 
-    // Load in the linked elements.
+    // Load the linked element resource.
     const requestType = shaka.net.NetworkingEngine.RequestType.MANIFEST;
     const request =
         shaka.net.NetworkingEngine.makeRequest(uris, retryParameters);
@@ -588,9 +634,8 @@ shaka.dash.MpdUtils = class {
     // Chain onto that operation.
     return networkOperation.chain(
         (response) => {
-          // This only supports the case where the loaded xml has a single
-          // top-level element.  If there are multiple roots, it will be
-          // rejected.
+          // Only support a single top-level element in the fetched XML.
+          // Multiple roots are rejected.
           const rootElem =
               TXml.parseXml(response.data, element.tagName);
           if (!rootElem) {
@@ -600,10 +645,8 @@ shaka.dash.MpdUtils = class {
                 Error.Code.DASH_INVALID_XML, xlinkHref));
           }
 
-          // Now that there is no other possibility of the process erroring,
-          // the element can be changed further.
-
-          // Remove the current contents of the node.
+          // Replace the current element contents with the fetched
+          // children/attributes.
           element.children = [];
 
           // Move the children of the loaded xml into the current element.
@@ -642,6 +685,10 @@ shaka.dash.MpdUtils = class {
     const MpdUtils = shaka.dash.MpdUtils;
     const TXml = shaka.util.TXml;
     const NS = MpdUtils.XlinkNamespaceUri_;
+    // Descend only through containers that can lead to valid XLink locations.
+    const containers = new Set([
+      'MPD', 'Period', 'AdaptationSet', 'Representation', 'SegmentList',
+    ]);
 
     if (TXml.getAttributeNS(element, NS, 'href')) {
       let handled = MpdUtils.handleXlinkInElement_(
@@ -665,16 +712,12 @@ shaka.dash.MpdUtils = class {
     for (const child of shaka.util.TXml.getChildNodes(element)) {
       const resolveToZeroString = 'urn:mpeg:dash:resolve-to-zero:2013';
       if (TXml.getAttributeNS(child, NS, 'href') == resolveToZeroString) {
-        // This is a 'resolve to zero' code; it means the element should
-        // be removed, as specified by the mpeg-dash rules for xlink.
+        // 'resolve-to-zero': remove the element per DASH XLink rules.
         element.children = element.children.filter(
             (elem) => elem !== child);
-      } else if (child.tagName != 'SegmentTimeline') {
-        // Don't recurse into a SegmentTimeline since xlink attributes
-        // aren't valid in there and looking at each segment can take a long
-        // time with larger manifests.
-
-        // Replace the child with its processed form.
+      } else if (child.tagName != 'SegmentTimeline' &&
+        containers.has(child.tagName)) {
+        // Recurse only into relevant containers; never into SegmentTimeline.
         childOperations.push(shaka.dash.MpdUtils.processXlinks(
             /** @type {!shaka.extern.xml.Node} */ (child),
             retryParameters, failGracefully,

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -594,7 +594,8 @@ shaka.dash.MpdUtils = class {
     const xlinkActuate =
         TXml.getAttributeNS(element, NS, 'actuate') || 'onRequest';
 
-    // Strip all xlink attributes to avoid re-fetching on re-processing.
+    // Remove the xlink properties, so it won't download again
+    // when re-processed.
     for (const key of Object.keys(element.attributes)) {
       const segments = key.split(':');
       const namespace = shaka.util.TXml.getKnownNameSpace(NS);
@@ -609,7 +610,7 @@ shaka.dash.MpdUtils = class {
           Error.Code.DASH_XLINK_DEPTH_LIMIT));
     }
 
-     if (xlinkActuate != 'onLoad') {
+    if (xlinkActuate != 'onLoad') {
       // Only xlink:actuate="onLoad" is supported.
       // When no value is specified, the assumed value is "onRequest".
       return shaka.util.AbortableOperation.failed(new Error(
@@ -620,7 +621,7 @@ shaka.dash.MpdUtils = class {
     // Resolve the xlink href, in case it's a relative URL.
     const uris = ManifestParserUtils.resolveUris([baseUri], [xlinkHref]);
 
-    // Load the linked element resource.
+    // Load in the linked elements.
     const requestType = shaka.net.NetworkingEngine.RequestType.MANIFEST;
     const request =
         shaka.net.NetworkingEngine.makeRequest(uris, retryParameters);
@@ -639,8 +640,9 @@ shaka.dash.MpdUtils = class {
     // Chain onto that operation.
     return networkOperation.chain(
         (response) => {
-          // Only support a single top-level element in the fetched XML.
-          // Multiple roots are rejected.
+          // This only supports the case where the loaded xml has a single
+          // top-level element.  If there are multiple roots, it will be
+          // rejected.
           const rootElem =
               TXml.parseXml(response.data, element.tagName);
           if (!rootElem) {
@@ -650,8 +652,10 @@ shaka.dash.MpdUtils = class {
                 Error.Code.DASH_INVALID_XML, xlinkHref));
           }
 
-          // Replace the current element contents with the fetched
-          // children/attributes.
+          // Now that there is no other possibility of the process erroring,
+          // the element can be changed further.
+
+          // Remove the current contents of the node.
           element.children = [];
 
           // Move the children of the loaded xml into the current element.
@@ -717,12 +721,12 @@ shaka.dash.MpdUtils = class {
     for (const child of shaka.util.TXml.getChildNodes(element)) {
       const resolveToZeroString = 'urn:mpeg:dash:resolve-to-zero:2013';
       if (TXml.getAttributeNS(child, NS, 'href') == resolveToZeroString) {
-        // 'resolve-to-zero': remove the element per DASH XLink rules.
+        // This is a 'resolve to zero' code; it means the element should
+        // be removed, as specified by the mpeg-dash rules for xlink.
         element.children = element.children.filter(
             (elem) => elem !== child);
-      } else if (child.tagName != 'SegmentTimeline' &&
-        containers.has(child.tagName)) {
-        // Recurse only into relevant containers; never into SegmentTimeline.
+      } else if (containers.has(child.tagName)) {
+        // Recurse only into relevant containers.
         childOperations.push(shaka.dash.MpdUtils.processXlinks(
             /** @type {!shaka.extern.xml.Node} */ (child),
             retryParameters, failGracefully,

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -530,6 +530,14 @@ shaka.dash.MpdUtils = class {
   static hasXlinks(root) {
     const TXml = shaka.util.TXml;
     const NS = shaka.dash.MpdUtils.XlinkNamespaceUri_;
+
+    // If the MPD root does not declare the XLink namespace, we can skip
+    // scanning in the common case where the namespace is always declared at
+    // the root.
+    if (root.attributes['xmlns:xlink'] !== NS) {
+      return false;
+    }
+
     // Elements where XLink is valid per spec.
     const xlinkElements = new Set(['Period', 'AdaptationSet', 'SegmentList']);
     // Containers that are worthwhile to traverse to reach the allowed elements.

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -554,10 +554,6 @@ shaka.dash.MpdUtils = class {
           return true;
         }
       }
-      if (node.tagName == 'SegmentTimeline') {
-        // Never descend into SegmentTimeline (invalid for XLink and expensive).
-        continue;
-      }
       for (const child of TXml.getChildNodes(node)) {
         if (containers.has(child.tagName)) {
           stack.push(child);

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -609,12 +609,9 @@ shaka.dash.MpdUtils = class {
           Error.Code.DASH_XLINK_DEPTH_LIMIT));
     }
 
-    // DASH/XLink allows both "onLoad" and "onRequest" (default if missing).
-    // Resolve eagerly for both values; this keeps behavior simple and
-    // standard-compliant.
-    // We treat "onLoad" and "onRequest" the same way, that is, they are
-    // resolved immediately.
-    if (xlinkActuate != 'onLoad' && xlinkActuate != 'onRequest') {
+     if (xlinkActuate != 'onLoad') {
+      // Only xlink:actuate="onLoad" is supported.
+      // When no value is specified, the assumed value is "onRequest".
       return shaka.util.AbortableOperation.failed(new Error(
           Error.Severity.CRITICAL, Error.Category.MANIFEST,
           Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE));

--- a/lib/player.js
+++ b/lib/player.js
@@ -4383,6 +4383,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
     goog.asserts.assert(typeof(config) == 'object', 'Should be an object!');
 
+    // Deprecate 'manifest.dash.disableXlinkProcessing' configuration.
+    if (config['manifest'] && config['manifest']['dash'] &&
+        'disableXlinkProcessing' in config['manifest']['dash']) {
+      shaka.Deprecate.deprecateFeature(6,
+          'manifest.dash.disableXlinkProcessing configuration',
+          'It is now automatically detected if the manifest has Xlink.');
+      delete config['manifest']['dash']['disableXlinkProcessing'];
+    }
+
     // Backward compatibility for old individual preference fields.
     // These were replaced by structured preference arrays in v5.1.
     shaka.Player.convertLegacyPreferences_(config);

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -130,7 +130,6 @@ shaka.util.PlayerConfiguration = class {
       enableAudioGroups: true,
       dash: {
         clockSyncUri: '',
-        disableXlinkProcessing: true,
         xlinkFailGracefully: false,
         ignoreMinBufferTime: false,
         autoCorrectDrift: true,

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -932,7 +932,6 @@ describe('DashParser Manifest', () => {
           shaka.util.Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE);
 
       const config = shaka.util.PlayerConfiguration.createDefault().manifest;
-      config.dash.disableXlinkProcessing = false;
 
       await Dash.testFails(source, error, config);
     });

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -928,9 +928,7 @@ describe('DashParser Manifest', () => {
           shaka.util.Error.Category.MANIFEST,
           shaka.util.Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE);
 
-      const config = shaka.util.PlayerConfiguration.createDefault().manifest;
-
-      await Dash.testFails(source, error, config);
+      await Dash.testFails(source, error);
     });
 
     it('failed network requests', async () => {

--- a/test/dash/dash_parser_manifest_unit.js
+++ b/test/dash/dash_parser_manifest_unit.js
@@ -915,13 +915,10 @@ describe('DashParser Manifest', () => {
     it('xlink problems when xlinkFailGracefully is false', async () => {
       const source = [
         '<MPD minBufferTime="PT75S" xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
-            'xmlns:xlink="http://www.w3.org/1999/xlink">',
+        '  xmlns:xlink="http://www.w3.org/1999/xlink">',
         '  <Period id="1" duration="PT30S">',
-        '    <AdaptationSet mimeType="video/mp4">',
-        '      <Representation bandwidth="1" xlink:href="https://xlink1" ' +
-            'xlink:actuate="onInvalid">', // Incorrect actuate
-        '        <SegmentBase indexRange="100-200" />',
-        '      </Representation>',
+        '    <AdaptationSet mimeType="video/mp4" xlink:href="https://xlink1" ' +
+        '      xlink:actuate="onInvalid">', // Incorrect actuate
         '    </AdaptationSet>',
         '  </Period>',
         '</MPD>',

--- a/test/dash/mpd_utils_unit.js
+++ b/test/dash/mpd_utils_unit.js
@@ -468,7 +468,6 @@ describe('MpdUtils', () => {
   });
 
   describe('hasXlinks', () => {
-
     function parse(xmlString) {
       return /** @type {shaka.extern.xml.Node} */ (
         shaka.util.TXml.parseXmlString(xmlString));
@@ -507,7 +506,7 @@ describe('MpdUtils', () => {
               '<SegmentList xlink:href="https://deep" ' +
               'xlink:actuate="onLoad" />' +
             '</Representation>' +
-          '</AdaptationSet>'
+          '</AdaptationSet>',
       ));
 
       expect(MpdUtils.hasXlinks(xml)).toBe(true);
@@ -518,7 +517,7 @@ describe('MpdUtils', () => {
           '<SegmentTimeline>' +
             '<S xlink:href="https://shouldIgnore" ' +
             'xlink:actuate="onLoad" />' +
-          '</SegmentTimeline>'
+          '</SegmentTimeline>',
       ));
 
       expect(MpdUtils.hasXlinks(xml)).toBe(false);
@@ -530,7 +529,7 @@ describe('MpdUtils', () => {
             '<Representation />' +
           '</AdaptationSet>' +
           '<AdaptationSet xlink:href="https://branch" ' +
-          'xlink:actuate="onLoad" />'
+          'xlink:actuate="onLoad" />',
       ));
 
       expect(MpdUtils.hasXlinks(xml)).toBe(true);
@@ -586,7 +585,8 @@ describe('MpdUtils', () => {
       const xlinkXMLString =
           '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<AdaptationSet otherVariable="q" variable="1"><Contents /></AdaptationSet>');
+          '<AdaptationSet otherVariable="q" variable="1"><Contents />' +
+          '</AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -648,7 +648,8 @@ describe('MpdUtils', () => {
       const baseXMLString = inBaseContainer(
           '<AdaptationSet xlink:href="https://xlink1?parameter" ' +
           'xlink:actuate="onLoad" />');
-      const xlinkXMLString = '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
           '<AdaptationSet variable="1"><Contents /></AdaptationSet>');
 
@@ -661,7 +662,8 @@ describe('MpdUtils', () => {
       const baseXMLString = inBaseContainer(
           '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad">' +
           '<Unwanted /></AdaptationSet>');
-      const xlinkXMLString = '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
           '<AdaptationSet variable="1"><Contents /></AdaptationSet>');
 

--- a/test/dash/mpd_utils_unit.js
+++ b/test/dash/mpd_utils_unit.js
@@ -485,10 +485,11 @@ describe('MpdUtils', () => {
 
     it('will replace elements and children', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad" />');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad" />');
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace variable="1"><Contents /></ToReplace>');
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -496,11 +497,12 @@ describe('MpdUtils', () => {
 
     it('preserves non-xlink attributes', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace otherVariable="q" xlink:href="https://xlink1" ' +
+          '<AdaptationSet otherVariable="q" xlink:href="https://xlink1" ' +
           'xlink:actuate="onLoad" />');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace otherVariable="q" variable="1"><Contents /></ToReplace>');
+          '<AdaptationSet otherVariable="q" variable="1"><Contents /></AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -508,11 +510,11 @@ describe('MpdUtils', () => {
 
     it('preserves text', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad" />');
       const xlinkXMLString =
-          '<ToReplace variable="1">TEXT CONTAINED WITHIN</ToReplace>';
+          '<AdaptationSet variable="1">TEXT CONTAINED WITHIN</AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace variable="1">TEXT CONTAINED WITHIN</ToReplace>');
+          '<AdaptationSet variable="1">TEXT CONTAINED WITHIN</AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -520,17 +522,17 @@ describe('MpdUtils', () => {
 
     it('supports multiple replacements', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad" />',
-          '<ToReplace xlink:href="https://xlink2" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad" />',
+          '<AdaptationSet xlink:href="https://xlink2" xlink:actuate="onLoad" />');
       const xlinkXMLString1 = makeRecursiveXMLString(1, 'https://xlink3');
       const xlinkXMLString2 =
-          '<ToReplace variable="2"><Contents /></ToReplace>';
-      const xlinkXMLString3 = '<ToReplace otherVariable="blue" />';
+          '<AdaptationSet variable="2"><Contents /></AdaptationSet>';
+      const xlinkXMLString3 = '<AdaptationSet otherVariable="blue" />';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
+          '<AdaptationSet xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
           'xmlns:xlink="http://www.w3.org/1999/xlink" variable="1">' +
-          '<ToReplace otherVariable="blue" /></ToReplace>',
-          '<ToReplace variable="2"><Contents /></ToReplace>');
+          '<AdaptationSet otherVariable="blue" /></AdaptationSet>',
+          '<AdaptationSet variable="2"><Contents /></AdaptationSet>');
 
       fakeNetEngine
           .setResponseText('https://xlink1', xlinkXMLString1)
@@ -542,7 +544,7 @@ describe('MpdUtils', () => {
 
     it('fails if it recurses too many times', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink0" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="https://xlink0" xlink:actuate="onLoad" />');
       // Create a large but finite number of links, so this won't
       // infinitely recurse if there isn't a depth limit.
       for (let i = 0; i < 20; i++) {
@@ -560,11 +562,11 @@ describe('MpdUtils', () => {
 
     it('preserves url parameters', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1?parameter" ' +
+          '<AdaptationSet xlink:href="https://xlink1?parameter" ' +
           'xlink:actuate="onLoad" />');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+      const xlinkXMLString = '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace variable="1"><Contents /></ToReplace>');
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>');
 
       fakeNetEngine.setResponseText(
           'https://xlink1?parameter', xlinkXMLString);
@@ -573,11 +575,11 @@ describe('MpdUtils', () => {
 
     it('replaces existing contents', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad">' +
-          '<Unwanted /></ToReplace>');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad">' +
+          '<Unwanted /></AdaptationSet>');
+      const xlinkXMLString = '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace variable="1"><Contents /></ToReplace>');
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -585,33 +587,34 @@ describe('MpdUtils', () => {
 
     it('handles relative links', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="xlink1" xlink:actuate="onLoad" />',
-          '<ToReplace xlink:href="xlink2" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="xlink1" xlink:actuate="onLoad" />',
+          '<AdaptationSet xlink:href="xlink2" xlink:actuate="onLoad" />');
       const xlinkXMLString1 = // This is loaded relative to base.
           makeRecursiveXMLString(1, 'xlink3');
       const xlinkXMLString2 = // This is loaded relative to base.
-          '<ToReplace variable="2"><Contents /></ToReplace>';
+          '<AdaptationSet variable="2"><Contents /></AdaptationSet>';
       const xlinkXMLString3 = // This is loaded relative to string1.
-          '<ToReplace variable="3" />';
+          '<AdaptationSet variable="3" />';
       fakeNetEngine
           .setResponseText('https://base/xlink1', xlinkXMLString1)
           .setResponseText('https://base/xlink2', xlinkXMLString2)
           .setResponseText('https://base/xlink3', xlinkXMLString3);
 
       const desiredXMLString = inBaseContainer(
-          '<ToReplace xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
+          '<AdaptationSet xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
           'xmlns:xlink="http://www.w3.org/1999/xlink" variable="1">' +
-          '<ToReplace variable="3" /></ToReplace>',
-          '<ToReplace variable="2"><Contents /></ToReplace>');
+          '<AdaptationSet variable="3" /></AdaptationSet>',
+          '<AdaptationSet variable="2"><Contents /></AdaptationSet>');
 
       await testSucceeds(baseXMLString, desiredXMLString, 3);
     });
 
     it('fails for actuate=onRequest', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" ' +
+          '<AdaptationSet xlink:href="https://xlink1" ' +
           'xlink:actuate="onRequest" />');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const expectedError = new shaka.util.Error(
           Error.Severity.CRITICAL, Error.Category.MANIFEST,
           Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE);
@@ -622,8 +625,9 @@ describe('MpdUtils', () => {
 
     it('fails for no actuate', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" />');
-      const xlinkXMLString = '<ToReplace variable="1"><Contents /></ToReplace>';
+          '<AdaptationSet xlink:href="https://xlink1" />');
+      const xlinkXMLString =
+          '<AdaptationSet variable="1"><Contents /></AdaptationSet>';
       const expectedError = new shaka.util.Error(
           Error.Severity.CRITICAL, Error.Category.MANIFEST,
           Error.Code.DASH_UNSUPPORTED_XLINK_ACTUATE);
@@ -634,7 +638,7 @@ describe('MpdUtils', () => {
 
     it('removes elements with resolve-to-zero', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="urn:mpeg:dash:resolve-to-zero:2013" />');
+          '<AdaptationSet xlink:href="urn:mpeg:dash:resolve-to-zero:2013" />');
       const desiredXMLString = inBaseContainer();
 
       await testSucceeds(baseXMLString, desiredXMLString, 0);
@@ -642,7 +646,7 @@ describe('MpdUtils', () => {
 
     it('needs the top-level to match the link\'s tagName', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad" />');
       const xlinkXMLString = '<BadTagName</BadTagName>';
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
@@ -652,12 +656,12 @@ describe('MpdUtils', () => {
     it('doesn\'t error when set to fail gracefully', async () => {
       failGracefully = true;
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink1" xlink:actuate="onLoad">' +
+          '<AdaptationSet xlink:href="https://xlink1" xlink:actuate="onLoad">' +
           '<DefaultContents />' +
-          '</ToReplace>');
+          '</AdaptationSet>');
       const xlinkXMLString = '<BadTagName</BadTagName>';
       const desiredXMLString = inBaseContainer(
-          '<ToReplace><DefaultContents /></ToReplace>');
+          '<AdaptationSet><DefaultContents /></AdaptationSet>');
 
       fakeNetEngine.setResponseText('https://xlink1', xlinkXMLString);
       await testSucceeds(baseXMLString, desiredXMLString, 1);
@@ -665,7 +669,7 @@ describe('MpdUtils', () => {
 
     it('interrupts requests on abort', async () => {
       const baseXMLString = inBaseContainer(
-          '<ToReplace xlink:href="https://xlink0" xlink:actuate="onLoad" />');
+          '<AdaptationSet xlink:href="https://xlink0" xlink:actuate="onLoad" />');
       // Create a few links.  This is few enough that it would succeed if we
       // didn't abort it.
       for (let i = 0; i < 4; i++) {
@@ -708,7 +712,7 @@ describe('MpdUtils', () => {
     it('ignores SegmentTimeline children', async () => {
       const baseXMLString = inBaseContainer(
           '<SegmentTimeline>' +
-          '  <ToReplace xlink:href="https://xlink1" ' +
+          '  <Ignore xlink:href="https://xlink1" ' +
           '     xlink:actuate="onRequest" />' +
           '</SegmentTimeline>');
       await testSucceeds(baseXMLString, baseXMLString, 0);
@@ -743,10 +747,10 @@ describe('MpdUtils', () => {
      */
     function makeRecursiveXMLString(variable, link) {
       const format =
-          '<ToReplace xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
+          '<AdaptationSet xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
           'xmlns:xlink="http://www.w3.org/1999/xlink" variable="%(let)s">' +
-          '<ToReplace xlink:href="%(link)s" xlink:actuate="onLoad" />' +
-          '</ToReplace>';
+          '<AdaptationSet xlink:href="%(link)s" xlink:actuate="onLoad" />' +
+          '</AdaptationSet>';
       return sprintf(format, {'let': variable, 'link': link});
     }
 
@@ -758,13 +762,15 @@ describe('MpdUtils', () => {
      */
     function inBaseContainer(toReplaceOne = '', toReplaceTwo = '') {
       const format =
-          '<Container xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
+          '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
           'xmlns:xlink="http://www.w3.org/1999/xlink">' +
-          '<Thing>' +
+          '<Period>' +
           '%(toReplaceOne)s' +
-          '</Thing>' +
+          '</Period>' +
+          '<Period>' +
           '%(toReplaceTwo)s' +
-          '</Container>';
+          '</Period>' +
+          '</MPD>';
       return sprintf(format, {
         toReplaceOne: toReplaceOne,
         toReplaceTwo: toReplaceTwo});

--- a/test/dash/mpd_utils_unit.js
+++ b/test/dash/mpd_utils_unit.js
@@ -467,6 +467,90 @@ describe('MpdUtils', () => {
     }
   });
 
+  describe('hasXlinks', () => {
+
+    function parse(xmlString) {
+      return /** @type {shaka.extern.xml.Node} */ (
+        shaka.util.TXml.parseXmlString(xmlString));
+    }
+
+    function wrapInMpd(inner = '') {
+      return (
+        '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" ' +
+        'xmlns:xlink="http://www.w3.org/1999/xlink">' +
+          '<Period>' +
+            inner +
+          '</Period>' +
+        '</MPD>'
+      );
+    }
+
+    it('returns false when no xlink is present', () => {
+      const xml = parse(wrapInMpd(
+          '<AdaptationSet><Representation /></AdaptationSet>'));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(false);
+    });
+
+    it('returns true when child has xlink:href', () => {
+      const xml = parse(wrapInMpd(
+          '<AdaptationSet xlink:href="https://xlink1" ' +
+          'xlink:actuate="onLoad" />'));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(true);
+    });
+
+    it('returns true for deeply nested xlink', () => {
+      const xml = parse(wrapInMpd(
+          '<AdaptationSet>' +
+            '<Representation>' +
+              '<SegmentList xlink:href="https://deep" ' +
+              'xlink:actuate="onLoad" />' +
+            '</Representation>' +
+          '</AdaptationSet>'
+      ));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(true);
+    });
+
+    it('returns false when xlink is inside SegmentTimeline', () => {
+      const xml = parse(wrapInMpd(
+          '<SegmentTimeline>' +
+            '<S xlink:href="https://shouldIgnore" ' +
+            'xlink:actuate="onLoad" />' +
+          '</SegmentTimeline>'
+      ));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(false);
+    });
+
+    it('returns true when one of multiple branches has xlink', () => {
+      const xml = parse(wrapInMpd(
+          '<AdaptationSet>' +
+            '<Representation />' +
+          '</AdaptationSet>' +
+          '<AdaptationSet xlink:href="https://branch" ' +
+          'xlink:actuate="onLoad" />'
+      ));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(true);
+    });
+
+    it('does not require xlink:actuate to detect xlink', () => {
+      const xml = parse(wrapInMpd(
+          '<AdaptationSet xlink:href="https://xlink1" />'));
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(true);
+    });
+
+    it('handles empty document safely', () => {
+      const xml = parse(
+          '<MPD xmlns="urn:mpeg:dash:schema:mpd:2011"></MPD>');
+
+      expect(MpdUtils.hasXlinks(xml)).toBe(false);
+    });
+  });
+
   describe('processXlinks', () => {
     const Error = shaka.util.Error;
 


### PR DESCRIPTION
This PR modernizes and optimizes XLink handling in the DASH parser by removing the legacy flag-based behavior and replacing it with a standards‑aligned, fast, and deterministic workflow. The changes improve performance on large MPDs, simplify configuration, and ensure correct XLink expansion according to DASH/XLink rules.

XLink processing is now automatically enabled only when needed. If the MPD contains no XLinks, the parser skips processXlinks entirely.