### PR TITLE
fix(ci): Update release for trusted publishing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,6 +13,13 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       patch: ${{ steps.release.outputs.patch }}
+
+    permissions:
+      # Write to "contents" is needed to create a release
+      contents: write
+      # Write to pull-requests is needed to create and update the release PR
+      pull-requests: write
+
     steps:
       # Create/update release PR
       - uses: googleapis/release-please-action@v4
@@ -58,6 +65,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     if: needs.release.outputs.release_created
+
+    permissions:
+      # Required for OIDC ("trusted publishing")
+      id-token: write
+      # Write to "contents" is needed to attach files to the release
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -65,15 +79,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          registry-url: 'https://registry.npmjs.org'
-
       - uses: actions/setup-java@v4
         with:
           distribution: zulu
           java-version: 21
+
+      - uses: actions/setup-node@v4
+        with:
+          # NOTE: OIDC fails with node less than 24.
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      # NOTE: OIDC fails with npm less than 11.5.1.
+      - name: Update npm
+        run: sudo npm install -g npm@11.7
 
       - name: Compute NPM tags
         run: |
@@ -87,8 +106,6 @@ jobs:
           # the branch was v4.4.x, and the explicit NPM tag should be
           # v4.4-latest.
           GIT_TAG_NAME=${{ needs.release.outputs.tag_name }}
-          NPM_TAG=$(echo "$GIT_TAG_NAME" | cut -f 1-2 -d .)-latest
-          echo "NPM_TAG=$NPM_TAG" >> $GITHUB_ENV
 
           # We only tag the NPM package as "latest" if this release is the
           # highest version to date.
@@ -105,32 +122,43 @@ jobs:
           # Debug the decisions made here.
           echo "Latest release: $LATEST_RELEASE"
           echo "This release: $GIT_TAG_NAME"
-          echo "NPM tag: $NPM_TAG"
           echo "NPM latest: $NPM_LATEST"
 
       - run: npm ci
-      - name: Publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        run: |
-          # Publish with an explicit tag.
-          npm publish --tag "$NPM_TAG"
 
-          # Add the "latest" tag if needed.
+      # NOTE: OIDC fails if the repository URL doesn't match package.json, but
+      # Shaka Player's prepublish checks will reject any local changes beyond
+      # the tag.  So if you fork this package, update repository.url in
+      # package.json to match.
+      - name: Publish
+        run: |
+          set -x
+
+          # Publish with an explicit tag.
+          # NOTE: --access public is required for scoped forks.
           if [[ "$NPM_LATEST" == "true" ]]; then
-            NPM_VERSION=$(npm version --json | jq -r '."shaka-player"')
-            npm dist-tag add "shaka-player@$NPM_VERSION" latest
+            # The "latest" tag is implied and automatic.
+            npm publish --access public
+          else
+            # You can't **not** have a tag.  So if we don't want to overwrite
+            # "latest" (implied default), we have to overwrite something else.
+            # Even with NPM 11, if you don't do this, instead of overwriting
+            # "latest", it will detect that it's inappropriate, and **fail**.
+            # See https://github.com/npm/npm/issues/10625
+            # and https://github.com/npm/cli/issues/7553
+            # See also https://github.com/npm/cli/issues/8547, which killed our
+            # system of branch-specific tags.
+            npm publish --access public --tag tag-required-see-npm-bug-10625
           fi
 
-      - run: npm pack
+      # Stores the file name into the file "tarball" (unpredictable for forks).
+      - run: npm pack --ignore-scripts > tarball
 
       - name: Attach to release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: |
-          gh release upload \
-              ${{ needs.release.outputs.tag_name }} shaka-player-*.tgz \
-              --clobber
+        # Reads the file name from the file "tarball".
+        run: gh release upload --clobber "${{ needs.release.outputs.tag_name }}" "$(cat tarball)"
 
   appspot:
     runs-on: ubuntu-latest

--- a/build/shakaBuildHelpers.py
+++ b/build/shakaBuildHelpers.py
@@ -228,7 +228,7 @@ def npm_version(is_dirty=False):
     text = execute_get_output(cmd_line).decode('utf8')
   except subprocess.CalledProcessError as e:
     text = e.output.decode('utf8')
-  match = re.search(r'shaka-player@(.*) ', text)
+  match = re.search(r'shaka-player.*@(.*) ', text)
   if match:
     return match.group(1) + ('-npm-dirty' if is_dirty else '')
   raise RuntimeError('Unable to determine library version!')


### PR DESCRIPTION
This handles trusted publishing for Shaka Player.

In addition, it makes a check in shakaBuildHelpers a little broader to accommodate forked package names (like @joeyparrish/shaka-player-staging that I have been using to test the workflow updates from my fork).

Issue #9132