### PR TITLE
chore: Remove unused getPlayReadyKID

### DIFF
--- a/lib/drm/playready.js
+++ b/lib/drm/playready.js
@@ -183,44 +183,6 @@ shaka.drm.PlayReady = class {
     goog.asserts.assert(reBuildProNode, 'Must have pro node');
     return shaka.drm.PlayReady.getLicenseUrl(reBuildProNode);
   }
-
-  /**
-   * Gets a PlayReady KID from a protection element containing a
-   * PlayReady Header Object
-   *
-   * @param {!shaka.extern.xml.Node} element
-   * @return {?string}
-   */
-  static getPlayReadyKID(element) {
-    const rootElement = shaka.drm.PlayReady.getPlayReadyHeaderObject_(element);
-    if (!rootElement) {
-      return null;
-    }
-
-    const TXml = shaka.util.TXml;
-    // KID element is optional and no more than one is
-    // allowed inside the DATA element.
-    for (const elem of TXml.getElementsByTagName(rootElement, 'DATA')) {
-      const kid = TXml.findChild(elem, 'KID');
-      if (kid) {
-        // GUID: [DWORD, WORD, WORD, 8-BYTE]
-        const guidBytes =
-            shaka.util.Uint8ArrayUtils.fromBase64(
-                /** @type {string} */ (shaka.util.TXml.getTextContents(kid)));
-        // Reverse byte order from little-endian to big-endian
-        const kidBytes = new Uint8Array([
-          guidBytes[3], guidBytes[2], guidBytes[1], guidBytes[0],
-          guidBytes[5], guidBytes[4],
-          guidBytes[7], guidBytes[6],
-          ...guidBytes.slice(8),
-        ]);
-        return shaka.util.Uint8ArrayUtils.toHex(kidBytes);
-      }
-    }
-
-    // Not found
-    return null;
-  }
 };
 
 /**


### PR DESCRIPTION
Note: This was used in MSS, but we no longer support it.