### PR TITLE
perf: Remove redundant base64/xml conversions in PlayReady

### DIFF
--- a/lib/drm/playready.js
+++ b/lib/drm/playready.js
@@ -6,7 +6,6 @@
 
 goog.provide('shaka.drm.PlayReady');
 
-goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Pssh');
@@ -123,19 +122,17 @@ shaka.drm.PlayReady = class {
   /**
    * Gets a PlayReady Header Object
    *
-   * @param {!shaka.extern.xml.Node} element
+   * @param {!Uint8Array} proBytes
    * @return {?shaka.extern.xml.Node}
    * @private
    */
-  static getPlayReadyHeaderObject_(element) {
+  static getPlayReadyHeaderObject_(proBytes) {
     const PLAYREADY_RECORD_TYPES = shaka.drm.PlayReady.PLAYREADY_RECORD_TYPES;
 
-    const bytes = shaka.util.Uint8ArrayUtils.fromBase64(
-        /** @type {string} */ (shaka.util.TXml.getTextContents(element)));
-    const records = shaka.drm.PlayReady.parseMsPro_(bytes);
-    const record = records.filter((record) => {
+    const records = shaka.drm.PlayReady.parseMsPro_(proBytes);
+    const record = records.find((record) => {
       return record.type === PLAYREADY_RECORD_TYPES.RIGHTS_MANAGEMENT;
-    })[0];
+    });
 
     if (!record) {
       return null;
@@ -156,17 +153,9 @@ shaka.drm.PlayReady = class {
    * @return {string}
    */
   static getLicenseUrl(element) {
-    try {
-      const headerObject =
-          shaka.drm.PlayReady.getPlayReadyHeaderObject_(element);
-      if (!headerObject) {
-        return '';
-      }
-
-      return shaka.drm.PlayReady.getLaurl_(headerObject);
-    } catch (e) {
-      return '';
-    }
+    const bytes = shaka.util.Uint8ArrayUtils.fromBase64(
+        /** @type {string} */ (shaka.util.TXml.getTextContents(element)));
+    return shaka.drm.PlayReady.getLicenseFromHeader_(bytes);
   }
 
   /**
@@ -177,11 +166,28 @@ shaka.drm.PlayReady = class {
    */
   static getLicenseUrlFromPssh(data) {
     const proData = shaka.util.Pssh.getPsshData(data);
-    const proString = shaka.util.Uint8ArrayUtils.toStandardBase64(proData);
-    const reBuildProNode =
-        shaka.util.TXml.parseXmlString('<pro>' + proString + '</pro>');
-    goog.asserts.assert(reBuildProNode, 'Must have pro node');
-    return shaka.drm.PlayReady.getLicenseUrl(reBuildProNode);
+    return shaka.drm.PlayReady.getLicenseFromHeader_(proData);
+  }
+
+  /**
+   * Gets a PlayReady license URL from PlayReady Header Object bytes.
+   *
+   * @param {!Uint8Array} bytes
+   * @return {string}
+   * @private
+   */
+  static getLicenseFromHeader_(bytes) {
+    try {
+      const headerObject =
+          shaka.drm.PlayReady.getPlayReadyHeaderObject_(bytes);
+      if (!headerObject) {
+        return '';
+      }
+
+      return shaka.drm.PlayReady.getLaurl_(headerObject);
+    } catch (e) {
+      return '';
+    }
   }
 };
 


### PR DESCRIPTION
Refactors PlayReady license URL extraction to operate directly on PRO bytes instead of performing a base64/XML roundtrip.

Previously, getLicenseUrlFromPssh converted PRO bytes to base64, wrapped them in a synthetic XML node, parsed them, and then decoded them back to bytes before processing. This change removes the redundant conversions and makes the flow bytes-first.

Both getLicenseUrl() and getLicenseUrlFromPssh() now delegate to a shared internal method that extracts the WRMHEADER directly from PRO bytes.