### PR TITLE
fix: Set IntersectionObserver root to null (document not supported in Chrome 63)

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -157,7 +157,7 @@ shaka.text.UITextDisplayer = class {
     this.visibilityObserver_ = null;
     if ('IntersectionObserver' in window) {
       const options = {
-        root: document,
+        root: null,
         threshold: [0.01],
       };
       this.visibilityObserver_ = new IntersectionObserver((entries) => {


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/9781