### PR TITLE
fix: FairPlay polyfill bugs in PatchedMediaKeysApple

### DIFF
--- a/lib/polyfill/patchedmediakeys_apple.js
+++ b/lib/polyfill/patchedmediakeys_apple.js
@@ -14,7 +14,6 @@ goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.EventManager');
 goog.require('shaka.util.FakeEvent');
 goog.require('shaka.util.FakeEventTarget');
-goog.require('shaka.util.MediaReadyState');
 goog.require('shaka.util.PublicPromise');
 goog.require('shaka.util.StreamUtils');
 goog.require('shaka.util.StringUtils');
@@ -423,8 +422,14 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeys = class {
   constructor(keySystem) {
     shaka.log.debug('PatchedMediaKeysApple.MediaKeys');
 
+    // Safari's WebKitMediaKeys requires 'com.apple.fps.1_0' for FairPlay HLS
+    // decryption. Shaka uses 'com.apple.fps' as the standard key system ID.
+    // Remap to the versioned string that WebKitMediaKeys expects.
+    const nativeKeySystem = keySystem === 'com.apple.fps' ?
+        'com.apple.fps.1_0' : keySystem;
+
     /** @private {!WebKitMediaKeys} */
-    this.nativeMediaKeys_ = new WebKitMediaKeys(keySystem);
+    this.nativeMediaKeys_ = new WebKitMediaKeys(nativeKeySystem);
 
     /** @private {!shaka.util.EventManager} */
     this.eventManager_ = new shaka.util.EventManager();
@@ -479,14 +484,11 @@ shaka.polyfill.PatchedMediaKeysApple.MediaKeys = class {
 
     // Wrap native HTMLMediaElement.webkitSetMediaKeys with a Promise.
     try {
-      // Some browsers require that readyState >=1 before mediaKeys can be
-      // set, so check this and wait for loadedmetadata if we are not in the
-      // correct state
-      shaka.util.MediaReadyState.waitForReadyState(media,
-          HTMLMediaElement.HAVE_METADATA,
-          this.eventManager_, () => {
-            media.webkitSetMediaKeys(this.nativeMediaKeys_);
-          });
+      // Attach WebKitMediaKeys immediately. For FairPlay HLS in src= mode,
+      // Safari requires WebKitMediaKeys attached before video.src is set.
+      // Deferring until HAVE_METADATA creates a deadlock: the video never
+      // reaches that readyState because it errors without keys attached.
+      media.webkitSetMediaKeys(this.nativeMediaKeys_);
 
       return Promise.resolve();
     } catch (exception) {


### PR DESCRIPTION
## Summary

Two bugs in `patchedmediakeys_apple.js` prevent FairPlay DRM from working in src= mode on Safari when using the Apple EME polyfill (`PatchedMediaKeysApple.install()`).

Fixes #9794

## Changes

### 1. `com.apple.fps` → `com.apple.fps.1_0` remapping

Shaka configures FairPlay as `com.apple.fps`, but Safari's `WebKitMediaKeys` constructor requires the versioned string `com.apple.fps.1_0`. The polyfill now remaps in the `MediaKeys` constructor.

### 2. Remove `waitForReadyState(HAVE_METADATA)` deadlock

The polyfill deferred `webkitSetMediaKeys()` until `readyState >= HAVE_METADATA`. In src= mode, this creates a deadlock: Safari encounters encrypted content and errors before reaching `HAVE_METADATA` because no keys are attached. The fix calls `webkitSetMediaKeys()` immediately.

## What was removed (vs v1)

The previous version of this PR included changes to `drm_engine.js` and `abstract_device.js` that forced early MediaKeys attachment and encrypted event listening in src= mode. Testing by @matvp91 found these changes broke the native `com.apple.fps` path (without the polyfill). My own testing on Safari 26.3 confirmed the regression. Since the polyfill-only fixes are sufficient, the `drm_engine.js` and `abstract_device.js` changes have been dropped entirely.

## Test matrix (Safari 26.3, Shaka 5.0.4, src= mode)

| Shaka | Polyfill | Result |
|-------|----------|--------|
| unpatched | `PatchedMediaKeysApple` | Works |
| unpatched | none (`com.apple.fps` native) | Stalled |
| **this PR** | **`PatchedMediaKeysApple`** | **Works** |
| this PR | none (`com.apple.fps` native) | Stalled (same as unpatched — no regression) |