### PR TITLE
docs: Update agent config WRT attribution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # Shaka Player — AI Agent Instructions
 
+## Attribution
+
+Attribution is important when using agents for coding.  Commits should be authored by the human contributor and co‑signed by the AI agent(s).  Always use a 'Co-Authored-By' trailer in commit messages.
+
+The format generally is: "Co-Authored-By: <Current Model Name and/or Version> <email address>".  Substitute the actual model name/version at runtime.
+
+For GitHub to link these to the correct accounts, these specific email addresses should be used by these common models:
+  - Gemini (including gemini-cli and other Gemini models and agent integrations): gemini-cli@users.noreply.github.com
+  - Claude (including Claude Code and other integrations of Claude): noreply@anthropic.com
+  - Copilot (including Microsoft Copilot, GitHub Copilot, or other variations): 198982749+Copilot@users.noreply.github.com
+  - ChatGPT (including Codex and other integrations): chatgpt-codex-connector[bot]@users.noreply.github.com
+  - Cursor: cursoragent@cursor.com
+  - Warp: agent@warp.dev
+
 ## Project Overview
 
 Shaka Player is an open-source JavaScript library for adaptive media playback

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,28 +62,33 @@ that involved AI assistance must say so clearly.
 The preferred convention is a **git trailer** in the commit message:
 
 ```
-Co-authored-by: Claude Code <noreply@anthropic.com>
+Co-Authored-By: Claude Code <noreply@anthropic.com>
 ```
 
 Git trailers are lines at the end of the commit message body, separated from the
-body by a blank line, in `Key: Value` format.  GitHub renders `Co-authored-by`
+body by a blank line, in `Key: Value` format.  GitHub renders `Co-Authored-By`
 trailers natively, showing the tool as a co-author on the commit and pull
 request.
 
-Other tools have their own canonical addresses — use whatever the tool provides,
-or follow the same pattern:
+Other tools have their own canonical addresses, and AGENTS.md contains a list
+of addresses that map known tools to GitHub user identities.  Ideally, your
+agent has already read the instructions there and could include the correct
+trailer automatically.
+
+If you used multiple tools, add a line for each.  For example:
 
 ```
-Co-authored-by: GitHub Copilot <copilot@github.com>
-Co-authored-by: Cursor <cursor@anysphere.com>
+Co-Authored-By: GitHub Copilot <198982749+Copilot@users.noreply.github.com>
+Co-Authored-By: Cursor <cursoragent@cursor.com>
 ```
 
-If you used multiple tools or a tool doesn't have a canonical address, a
-`Co-authored-by` line with a descriptive name is fine:
+If a tool doesn't have a canonical address, a `Co-Authored-By` line with a
+descriptive name is fine:
 
 ```
-Co-authored-by: Claude Code (claude-sonnet-4-6) <noreply@anthropic.com>
+Co-Authored-By: Some Coding Tool (v5) <noreply@example.com>
 ```
+
 
 **Why this matters:** Attribution helps reviewers calibrate their review effort,
 gives the project an honest record of how the code was produced, and keeps us


### PR DESCRIPTION
It was difficult to find all the addresses for these agents that connect to GitHub bot accounts.  With these addresses, the correct icon and user will show as the co-author.  Even Gemini didn't know the correct address to use for itself, so this is worth documenting and communicating directly to the agents.