### PR TITLE
fix(MSF): fix namespace tuple encoding in SUBSCRIBE message

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Bryan Huh <bhh1988@gmail.com>
 Charter Communications Inc <*@charter.com>
 Code It <*@code-it.fr>
 Cristian Atehortua <cristian25a32@gmail.com>
+Daiki Matsui <mti.daiki@gmail.com>
 Damien Deis <developer.deis@gmail.com>
 Dany L'Hébreux <danylhebreux@gmail.com>
 Dave Nicholas <davenicholasuk@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -45,6 +45,7 @@ Chad Assareh <assareh@google.com>
 Chris Fillmore <fillmore.chris@gmail.com>
 Costel Madalin Grecu <madalin.grecu@adswizz.com>
 Cristian Atehortua <cristian25a32@gmail.com>
+Daiki Matsui <mti.daiki@gmail.com>
 Damien Deis <developer.deis@gmail.com>
 Dany L'Hébreux <danylhebreux@gmail.com>
 Dave Nicholas <davenicholasuk@gmail.com>

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -402,7 +402,7 @@ shaka.msf.TracksManager = class {
     const subscribeMsg = {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
       requestId,
-      namespace: [namespace],
+      namespace: namespace.split('/'),
       name: trackName,
       // Default priority
       subscriberPriority: 0,


### PR DESCRIPTION
## Summary

`subscribeTrack()` in `msf_tracks_manager.js` wraps the namespace string as a 1-element tuple (e.g., `["moq-chat/chat"]`) instead of splitting it back into the original tuple (e.g., `["moq-chat", "chat"]`).

These produce different bytes on the wire, so the relay cannot match the SUBSCRIBE against the publisher's namespace. This affects all SUBSCRIBE messages including catalog, video, and audio tracks.

## Details

Internally, Shaka Player represents the namespace as a `/`-joined string (see `subscribeToCatalog_()` in `msf_parser.js:341`). 

When encoding a SUBSCRIBE message, the string must be split by `/` to reconstruct the original tuple. But the code was using `[namespace]` instead of `namespace.split('/')`.

## Changes

Replace `namespace: [namespace]` with `namespace: namespace.split('/')` in `subscribeTrack()`.

## Testing

Tested manually with a draft-14 publisher ([moqtail](https://github.com/moqtail/moqtail)) and relay ([moq-wasm](https://github.com/nttcom/moq-wasm)).