### PR TITLE
fix(MSF): fall back to session namespace for media subscribes

### DIFF
--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -393,11 +393,16 @@ shaka.msf.MSFParser = class {
       // Fall back to the session namespace when the catalog track object
       // does not include an explicit namespace field (the namespace is
       // typically established at the transport level via PUBLISH_NAMESPACE).
-      const namespace = track.namespace ||
-          (this.config_.msf.namespaces.length ?
-            this.config_.msf.namespaces.join('/') :
-            this.publishNamespaces_.length ?
-              this.publishNamespaces_[0].join('/') : '');
+      let namespace = track.namespace;
+      if (!namespace) {
+        if (this.config_.msf.namespaces.length) {
+          namespace = this.config_.msf.namespaces.join('/');
+        } else if (this.publishNamespaces_.length) {
+          namespace = this.publishNamespaces_[0].join('/');
+        } else {
+          namespace = '';
+        }
+      }
       const trackName = track.name;
 
       shaka.log.debug(`Subscribing to track: ${trackKey}`);

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -390,7 +390,14 @@ shaka.msf.MSFParser = class {
    */
   async subscribeToTrack(track, trackKey, callback) {
     try {
-      const namespace = track.namespace || '';
+      // Fall back to the session namespace when the catalog track object
+      // does not include an explicit namespace field (the namespace is
+      // typically established at the transport level via PUBLISH_NAMESPACE).
+      const namespace = track.namespace ||
+          (this.config_.msf.namespaces.length ?
+            this.config_.msf.namespaces.join('/') :
+            this.publishNamespaces_.length ?
+              this.publishNamespaces_[0].join('/') : '');
       const trackName = track.name;
 
       shaka.log.debug(`Subscribing to track: ${trackKey}`);


### PR DESCRIPTION
## Summary

- When MSF catalog track objects don't include an explicit `namespace` field, `subscribeToTrack` falls through to an empty string. This causes SUBSCRIBE messages with an empty namespace that the relay cannot match to any published broadcast.
- The MSF catalog spec does not require per-track namespace fields — the namespace is established at the transport level via PUBLISH_NAMESPACE. Shaka should fall back to the session namespace.
- Fix: fall back to `config.msf.namespaces`, then to `publishNamespaces_` (from PUBLISH_NAMESPACE), before defaulting to empty string.

## Test plan

- [ ] Publish an MSF live stream where the catalog does not include per-track `namespace` fields
- [ ] Verify that media SUBSCRIBE messages use the correct session namespace
- [ ] Verify that audio and video segments are received and played back