### PR TITLE
chore(MSF): Change the catalog log from debug to info

### DIFF
--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -453,7 +453,7 @@ shaka.msf.MSFParser = class {
    * @private
    */
   processCatalog_(catalog) {
-    shaka.log.debug('MSF Catalog:', catalog);
+    shaka.log.info('MSF Catalog:', catalog);
     const promises = [];
     let isLive = true;
     let duration = Infinity;


### PR DESCRIPTION
Debugging WebTransport connections is not easy; this helps to visualize the MSF catalog more easily.