### PR TITLE
fix(MSF): Remove "Possible encoding problem detected!"

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1384,7 +1384,8 @@ shaka.media.MediaSourceEngine = class {
       this.append_(contentType, data, timestampOffset, stream, !reference);
     }, reference ? reference.getUris()[0] : null);
 
-    if (goog.DEBUG && reference && !reference.isPreload() && !isChunkedData) {
+    if (goog.DEBUG && reference && !reference.isPreload() && !isChunkedData &&
+        this.manifestType_ !== shaka.media.ManifestParser.MSF) {
       const bufferedAfter = this.getBuffered_(contentType);
       const newBuffered = shaka.media.TimeRangesUtils.computeAddedRange(
           bufferedBefore, bufferedAfter);


### PR DESCRIPTION
For MoQ it is normal to use very small segments (sometimes a single frame), so this log is not useful for this format.