### PR TITLE
fix(MSF): Add support for moqtail relay

### DIFF
--- a/lib/msf/msf_classes.js
+++ b/lib/msf/msf_classes.js
@@ -244,10 +244,12 @@ shaka.msf.Reader = class {
       const slice = this.slice_(8);
       const view = shaka.util.BufferUtils.toDataView(slice);
       value = BigInt(view.getBigUint64(0)) & BigInt('0x3fffffffffffffff');
-      if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
-        throw new Error('Number bigger than 53-bits');
+      if (value <= BigInt(Number.MAX_SAFE_INTEGER)) {
+        value = Number(value);
+      } else {
+        // eslint-disable-next-line no-self-assign
+        value = /** @type {number} */ (/** @type {*} */ (value));
       }
-      value = Number(value);
     } else {
       throw new Error(`invalid size: ${size}`);
     }

--- a/lib/msf/msf_classes.js
+++ b/lib/msf/msf_classes.js
@@ -211,7 +211,6 @@ shaka.msf.Reader = class {
 
   /**
    * Returns a number and tracks the number of bytes read
-   * If the number is greater than 53 bits, it throws an error.
    *
    * @return {!Promise<{value: number, bytesRead: number}>}
    */

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -488,7 +488,11 @@ shaka.msf.MSFParser = class {
 
     /** @type {?shaka.media.SegmentUtils.BasicInfo} */
     let basicInfo = null;
-    if (track.packaging === 'cmaf') {
+    const validPackagings = [
+      'cmaf',
+      'chunk-per-object',
+    ];
+    if (validPackagings.includes(track.packaging)) {
       basicInfo = shaka.media.SegmentUtils.getBasicInfoFromMp4(
           initData, initData, /* disableText= */ false);
     }

--- a/lib/msf/msf_receiver.js
+++ b/lib/msf/msf_receiver.js
@@ -57,9 +57,11 @@ shaka.msf.Receiver = class {
     // Log each parameter in detail
     if (params && params.length > 0) {
       for (const param of params) {
-        if (typeof param.value === 'number') {
+        if (typeof param.value === 'number' ||
+            typeof param.value === 'bigint') {
+          const typeOf = typeof param.value;
           shaka.log.v1(
-              `Parameter ID: ${param.type}, value: ${param.value} (number)`);
+              `Parameter ID: ${param.type}, value: ${param.value} (${typeOf})`);
         } else {
           shaka.log.v1(`Parameter ID: ${param.type}, length:
               ${param.value.byteLength} bytes, value:


### PR DESCRIPTION
A workaround is added to support bigint.
And support chunk-per-object packaging.