### PR TITLE
fix(MSF): Use bigint natively

### DIFF
--- a/lib/msf/buffer_control_writer.js
+++ b/lib/msf/buffer_control_writer.js
@@ -106,12 +106,12 @@ shaka.msf.BufferControlWriter = class {
     this.writer_.writeVarInt62(pair.type);
 
     // Handle the value based on whether the key is odd or even
-    if (pair.type % 2 === 0) {
+    if (pair.type % BigInt(2) === BigInt(0)) {
       // Even keys have bigint values
-      if (typeof pair.value !== 'number') {
+      if (typeof pair.value !== 'bigint') {
         throw new Error(
             'Invalid value type for even key ' + pair.type +
-            ': expected number, got ' + typeof pair.value,
+            ': expected bigint, got ' + typeof pair.value,
         );
       }
       this.writer_.writeVarInt62(pair.value);

--- a/lib/msf/msf_classes.js
+++ b/lib/msf/msf_classes.js
@@ -202,7 +202,7 @@ shaka.msf.Reader = class {
   /**
    * If the number is greater than 53 bits, it throws an error.
    *
-   * @return {!Promise<number>}
+   * @return {!Promise<bigint>}
    */
   async u62() {
     const result = await this.u62WithSize();
@@ -212,7 +212,7 @@ shaka.msf.Reader = class {
   /**
    * Returns a number and tracks the number of bytes read
    *
-   * @return {!Promise<{value: number, bytesRead: number}>}
+   * @return {!Promise<{value: bigint, bytesRead: number}>}
    */
   async u62WithSize() {
     await this.fillTo_(1);
@@ -224,31 +224,25 @@ shaka.msf.Reader = class {
     if (size === 0) {
       bytesRead = 1;
       const first = this.slice_(1)[0];
-      value = first & 0x3f; // 6 bits
+      value = BigInt(first) & BigInt('0x3f'); // 6 bits
     } else if (size === 1) {
       bytesRead = 2;
       await this.fillTo_(2);
       const slice = this.slice_(2);
       const view = shaka.util.BufferUtils.toDataView(slice);
-      value = view.getInt16(0) & 0x3fff; // 14 bits
+      value = BigInt(view.getInt16(0)) & BigInt('0x3fff'); // 14 bits
     } else if (size === 2) {
       bytesRead = 4;
       await this.fillTo_(4);
       const slice = this.slice_(4);
       const view = shaka.util.BufferUtils.toDataView(slice);
-      value = view.getUint32(0) & 0x3fffffff; // 30 bits
+      value = BigInt(view.getUint32(0)) & BigInt('0x3fffffff'); // 30 bits
     } else if (size === 3) {
       bytesRead = 8;
       await this.fillTo_(8);
       const slice = this.slice_(8);
       const view = shaka.util.BufferUtils.toDataView(slice);
       value = BigInt(view.getBigUint64(0)) & BigInt('0x3fffffffffffffff');
-      if (value <= BigInt(Number.MAX_SAFE_INTEGER)) {
-        value = Number(value);
-      } else {
-        // eslint-disable-next-line no-self-assign
-        value = /** @type {number} */ (/** @type {*} */ (value));
-      }
     } else {
       throw new Error(`invalid size: ${size}`);
     }
@@ -264,7 +258,7 @@ shaka.msf.Reader = class {
     for (let i = 0; i < numPairs; i++) {
       // eslint-disable-next-line no-await-in-loop
       const key = await this.u62();
-      if (key % 2 === 0) {
+      if (key % BigInt(2) === BigInt(0)) {
         // eslint-disable-next-line no-await-in-loop
         const value = await this.u62();
         result.push({type: key, value});

--- a/lib/msf/msf_receiver.js
+++ b/lib/msf/msf_receiver.js
@@ -57,11 +57,9 @@ shaka.msf.Receiver = class {
     // Log each parameter in detail
     if (params && params.length > 0) {
       for (const param of params) {
-        if (typeof param.value === 'number' ||
-            typeof param.value === 'bigint') {
-          const typeOf = typeof param.value;
+        if (typeof param.value === 'bigint') {
           shaka.log.v1(
-              `Parameter ID: ${param.type}, value: ${param.value} (${typeOf})`);
+              `Parameter ID: ${param.type}, value: ${param.value} (bigint)`);
         } else {
           shaka.log.v1(`Parameter ID: ${param.type}, length:
               ${param.value.byteLength} bytes, value:
@@ -134,7 +132,7 @@ shaka.msf.Receiver = class {
       const paramType = typeResult.value;
 
       // Check if the type is even or odd
-      const isEven = paramType % 2 === 0;
+      const isEven = paramType % BigInt(2) === BigInt(0);
 
       if (isEven) {
         // Even type: value is a single var int

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -106,6 +106,14 @@ shaka.msf.TracksManager = class {
       const streamType = await reader.u62();
       shaka.log.debug(`Incoming Unidirectional Stream. Type: ${streamType}`);
 
+      const FETCH_HEADER = BigInt(0x05);
+      const SUBGROUP_HEADER_START_DRAFT_11 = BigInt(0x08);
+      const SUBGROUP_HEADER_END_DRAFT_11 = BigInt(0x0d);
+      const SUBGROUP_HEADER_WITHOUT_EOG_START = BigInt(0x10);
+      const SUBGROUP_HEADER_WITHOUT_EOG_END = BigInt(0x15);
+      const SUBGROUP_HEADER_WITH_EOG_START = BigInt(0x18);
+      const SUBGROUP_HEADER_WITH_EOG_END = BigInt(0x1D);
+
       // Check if this is a SUBGROUP_HEADER stream
       // (draft-11, Section 9.4.2)
       // 0x08-0x0D
@@ -114,12 +122,15 @@ shaka.msf.TracksManager = class {
       // 0x18-0x1D: with EndOfGroup
       // (0x16-0x17 are not defined in the spec)
       const isSubgroupHeader =
-          (streamType >= BigInt(0x08) && streamType <= BigInt(0x0d)) ||
-          (streamType >= BigInt(0x10) && streamType <= BigInt(0x15)) ||
-          (streamType >= BigInt(0x18) && streamType <= BigInt(0x1D));
+          (streamType >= SUBGROUP_HEADER_START_DRAFT_11 &&
+          streamType <= SUBGROUP_HEADER_END_DRAFT_11) ||
+          (streamType >= SUBGROUP_HEADER_WITHOUT_EOG_START &&
+          streamType <= SUBGROUP_HEADER_WITHOUT_EOG_END) ||
+          (streamType >= SUBGROUP_HEADER_WITH_EOG_START &&
+          streamType <= SUBGROUP_HEADER_WITH_EOG_END);
       if (isSubgroupHeader) {
         await this.handleSubgroupStream_(reader, streamType);
-      } else if (streamType === BigInt(0x05)) {
+      } else if (streamType === FETCH_HEADER) {
         // Handle FETCH_HEADER streams if needed
         shaka.log.debug('Received FETCH_HEADER stream (not implemented yet)');
       } else {

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -36,8 +36,8 @@ shaka.msf.TracksManager = class {
     this.msfTransport_ = msfTransport;
     /** @private {shaka.msf.TrackAliasRegistry} */
     this.trackRegistry_ = new shaka.msf.TrackAliasRegistry();
-    /** @private {number} */
-    this.nextRequestId_ = 0;
+    /** @private {bigint} */
+    this.nextRequestId_ = BigInt(0);
     /** @private {!Set<shaka.util.Timer>} */
     this.timersSet_ = new Set();
     /** @private {boolean} */
@@ -49,11 +49,11 @@ shaka.msf.TracksManager = class {
   /**
    * Get the next request ID (even numbers for client requests)
    *
-   * @return {number}
+   * @return {bigint}
    */
   getNextRequestId() {
     const requestId = this.nextRequestId_;
-    this.nextRequestId_ += 2;
+    this.nextRequestId_ += BigInt(2);
     return requestId;
   }
 
@@ -106,8 +106,6 @@ shaka.msf.TracksManager = class {
       const streamType = await reader.u62();
       shaka.log.debug(`Incoming Unidirectional Stream. Type: ${streamType}`);
 
-      const TracksManager = shaka.msf.TracksManager;
-
       // Check if this is a SUBGROUP_HEADER stream
       // (draft-11, Section 9.4.2)
       // 0x08-0x0D
@@ -116,15 +114,12 @@ shaka.msf.TracksManager = class {
       // 0x18-0x1D: with EndOfGroup
       // (0x16-0x17 are not defined in the spec)
       const isSubgroupHeader =
-          (streamType >= TracksManager.SUBGROUP_HEADER_START_DRAFT_11 &&
-          streamType <= TracksManager.SUBGROUP_HEADER_END_DRAFT_11) ||
-          (streamType >= TracksManager.SUBGROUP_HEADER_WITHOUT_EOG_START &&
-          streamType <= TracksManager.SUBGROUP_HEADER_WITHOUT_EOG_END) ||
-          (streamType >= TracksManager.SUBGROUP_HEADER_WITH_EOG_START &&
-          streamType <= TracksManager.SUBGROUP_HEADER_WITH_EOG_END);
+          (streamType >= BigInt(0x08) && streamType <= BigInt(0x0d)) ||
+          (streamType >= BigInt(0x10) && streamType <= BigInt(0x15)) ||
+          (streamType >= BigInt(0x18) && streamType <= BigInt(0x1D));
       if (isSubgroupHeader) {
         await this.handleSubgroupStream_(reader, streamType);
-      } else if (streamType === TracksManager.FETCH_HEADER) {
+      } else if (streamType === BigInt(0x05)) {
         // Handle FETCH_HEADER streams if needed
         shaka.log.debug('Received FETCH_HEADER stream (not implemented yet)');
       } else {
@@ -146,7 +141,7 @@ shaka.msf.TracksManager = class {
    * Handle a SUBGROUP_HEADER stream with automatic buffering and retry.
    *
    * @param {!shaka.msf.Reader} reader
-   * @param {number} streamType
+   * @param {bigint} streamType
    * @return {!Promise}
    * @private
    */
@@ -163,28 +158,30 @@ shaka.msf.TracksManager = class {
       let subgroupId = null;
       const hasExtensions =
         // draft-11
-        streamType === 0x09 || streamType === 0x0b || streamType === 0x0d ||
+        streamType === BigInt(0x09) || streamType === BigInt(0x0b) ||
+        streamType === BigInt(0x0d) ||
         // draft-14
-        streamType === 0x11 || streamType === 0x13 || streamType === 0x15 ||
-        streamType === 0x19 || streamType === 0x1b || streamType === 0x1d;
+        streamType === BigInt(0x11) || streamType === BigInt(0x13) ||
+        streamType === BigInt(0x15) || streamType === BigInt(0x19) ||
+        streamType === BigInt(0x1b) || streamType === BigInt(0x1d);
 
       // SubgroupID = 0 (implicit)
       // draft-11: 0x08-0x09
-      if (streamType === 0x08 || streamType === 0x09 ||
-          streamType === 0x10 || streamType === 0x11 ||
-          streamType === 0x18 || streamType === 0x19) {
-        subgroupId = 0;
+      if (streamType === BigInt(0x08) || streamType === BigInt(0x09) ||
+          streamType === BigInt(0x10) || streamType === BigInt(0x11) ||
+          streamType === BigInt(0x18) || streamType === BigInt(0x19)) {
+        subgroupId = BigInt(0);
         shaka.log.debug(`Subgroup ID: ${subgroupId} (implicit)`);
       // draft-11: 0x0a-0x0b
-      } else if (streamType === 0x0a || streamType === 0x0b ||
-          streamType === 0x12 || streamType === 0x13 ||
-          streamType === 0x1a || streamType === 0x1b) {
+      } else if (streamType === BigInt(0x0a) || streamType === BigInt(0x0b) ||
+          streamType === BigInt(0x12) || streamType === BigInt(0x13) ||
+          streamType === BigInt(0x1a) || streamType === BigInt(0x1b)) {
         // SubgroupID = first Object ID (will be set when first object is read)
         shaka.log.debug('Subgroup ID will be set to the first Object ID');
       // draft-11: 0x0c-0x0d
-      } else if (streamType === 0x0c || streamType === 0x0d ||
-          streamType === 0x14 || streamType === 0x15 ||
-          streamType === 0x1c || streamType === 0x1d) {
+      } else if (streamType === BigInt(0x0c) || streamType === BigInt(0x0d) ||
+           streamType === BigInt(0x14) || streamType === BigInt(0x15) ||
+           streamType === BigInt(0x1c) || streamType === BigInt(0x1d)) {
         // SubgroupID is explicitly provided
         subgroupId = await reader.u62();
         shaka.log.debug(`Subgroup ID: ${subgroupId} (explicit)`);
@@ -223,11 +220,13 @@ shaka.msf.TracksManager = class {
         if (hasExtensions) {
           // eslint-disable-next-line no-await-in-loop
           const extensionHeadersLength = await reader.u62();
-          if (extensionHeadersLength > 0) {
+          if (extensionHeadersLength > BigInt(0)) {
+            // Convert bigint to number for reading bytes
+            const extensionLength = Number(extensionHeadersLength);
             // eslint-disable-next-line no-await-in-loop
-            extensions = await reader.read(extensionHeadersLength);
+            extensions = await reader.read(extensionLength);
             shaka.log.debug(
-                `Read ${extensionHeadersLength} bytes of extension headers`);
+                `Read ${extensionLength} bytes of extension headers`);
           }
         }
 
@@ -238,17 +237,17 @@ shaka.msf.TracksManager = class {
 
         // Read object status if payload length is zero
         let objectStatus = null;
-        if (payloadLength === 0) {
+        if (payloadLength === BigInt(0)) {
           // eslint-disable-next-line no-await-in-loop
           objectStatus = await reader.u62();
           shaka.log.debug(`Object status: ${objectStatus}`);
         }
 
         // Read the object data
-        const data = payloadLength > 0 ?
+        const data = payloadLength > BigInt(0) ?
             // eslint-disable-next-line no-await-in-loop
             await reader.read(Number(payloadLength)) : new Uint8Array([]);
-        if (payloadLength > 0) {
+        if (payloadLength > BigInt(0)) {
           shaka.log.debug(`Read ${data.byteLength} bytes of object data`);
         }
 
@@ -364,7 +363,7 @@ shaka.msf.TracksManager = class {
   /**
    * Notify all callbacks registered for a track
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @param {shaka.msf.Utils.MOQObject} obj
    * @private
    */
@@ -414,7 +413,7 @@ shaka.msf.TracksManager = class {
    * @param {string} namespace
    * @param {string} trackName
    * @param {shaka.msf.Utils.ObjectCallback} callback
-   * @return {!Promise<number>}
+   * @return {!Promise<bigint>}
    */
   async subscribeTrack(namespace, trackName, callback) {
     shaka.log.debug(`Subscribing to track ${namespace}:${trackName}`);
@@ -513,7 +512,7 @@ shaka.msf.TracksManager = class {
   /**
    * Unsubscribe from a track by track alias
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @return {!Promise}
    */
   async unsubscribeTrack(trackAlias) {
@@ -568,41 +567,6 @@ shaka.msf.TracksManager = class {
   }
 };
 
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.FETCH_HEADER = 0x05;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_START_DRAFT_11 = 0x08;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_END_DRAFT_11 = 0x0d;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_WITHOUT_EOG_START = 0x10;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_WITHOUT_EOG_END = 0x15;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_WITH_EOG_START = 0x18;
-
-/**
- * @private @const {number}
- */
-shaka.msf.TracksManager.SUBGROUP_HEADER_WITH_EOG_END = 0x1D;
-
 
 /**
  * Registry for track aliases that maps between namespace+trackName and
@@ -615,9 +579,6 @@ shaka.msf.TrackAliasRegistry = class {
 
     /** @private {Map<string, shaka.msf.Utils.TrackInfo>} */
     this.trackAliasToInfo_ = new Map();
-
-    /** @private {number} */
-    this.nextTrackAlias_ = 1;
   }
 
   /**
@@ -636,8 +597,8 @@ shaka.msf.TrackAliasRegistry = class {
    * Register a track with a specific alias (draft-14: server assigns the alias)
    * @param {string} namespace
    * @param {string} trackName
-   * @param {number} requestId
-   * @param {number} trackAlias
+   * @param {bigint} requestId
+   * @param {bigint} trackAlias
    */
   registerTrackWithAlias(namespace, trackName, requestId, trackAlias) {
     const key = this.getNamespaceTrackKey_(namespace, trackName);
@@ -680,7 +641,7 @@ shaka.msf.TrackAliasRegistry = class {
   /**
    * Get track info from trackAlias
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @return {shaka.msf.Utils.TrackInfo}
    */
   getTrackInfoFromAlias(trackAlias) {
@@ -690,7 +651,7 @@ shaka.msf.TrackAliasRegistry = class {
   /**
    * Register a callback for a track
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @param {shaka.msf.Utils.ObjectCallback} callback
    */
   registerCallback(trackAlias, callback) {
@@ -711,7 +672,7 @@ shaka.msf.TrackAliasRegistry = class {
   /**
    * Unregister a specific callback for a track
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @param {shaka.msf.Utils.ObjectCallback} callback
    */
   unregisterCallback(trackAlias, callback) {
@@ -735,7 +696,7 @@ shaka.msf.TrackAliasRegistry = class {
   /**
    * Unregister all callbacks for a track
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    */
   unregisterAllCallbacks(trackAlias) {
     const info = this.trackAliasToInfo_.get(trackAlias.toString());
@@ -755,7 +716,7 @@ shaka.msf.TrackAliasRegistry = class {
   /**
    * Get all callbacks for a track
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @return {!Array<shaka.msf.Utils.ObjectCallback>}
    */
   getCallbacks(trackAlias) {
@@ -769,7 +730,6 @@ shaka.msf.TrackAliasRegistry = class {
   clear() {
     this.trackNameToInfo_.clear();
     this.trackAliasToInfo_.clear();
-    this.nextTrackAlias_ = 1;
     shaka.log.debug('Cleared all track registrations');
   }
 };

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -30,15 +30,15 @@ shaka.msf.MSFTransport = class {
     /** @private {?WebTransport} */
     this.webTransport_ = null;
 
-    /** @private {number} */
-    this.nextRequestId_ = 0;
+    /** @private {bigint} */
+    this.nextRequestId_ = BigInt(0);
 
     /** @private {!Set<function(Array<string>)>} */
     this.publishNamespaceCallbacks_ = new Set();
 
     /**
      * @private {!Map<shaka.msf.Utils.MessageType,
-     *                Map<number, shaka.msf.Utils.MessageHandler>>}
+     *                Map<bigint, shaka.msf.Utils.MessageHandler>>}
      */
     this.messageHandlers_ = new Map();
 
@@ -90,9 +90,9 @@ shaka.msf.MSFTransport = class {
     const params = [
       {
         // MAX_REQUEST_ID parameter type
-        type: 0x02,
+        type: BigInt(0x02),
         // Allow server to send up to 64 request-type messages
-        value: 64,
+        value: BigInt(64),
       },
     ];
     await sender.client({versions, params});
@@ -142,11 +142,11 @@ shaka.msf.MSFTransport = class {
    * According to the MOQ Transport spec, client request IDs are even numbers
    * starting at 0 and increment by 2 for each new request.
    *
-   * @return {number}
+   * @return {bigint}
    */
   getNextRequestId() {
     const requestId = this.nextRequestId_;
-    this.nextRequestId_ += 2;
+    this.nextRequestId_ += BigInt(2);
     shaka.log.debug(`Generated new request ID: ${requestId}`);
     return requestId;
   }
@@ -230,7 +230,7 @@ shaka.msf.MSFTransport = class {
    * Register a handler for a specific message kind and request ID
    *
    * @param {shaka.msf.Utils.MessageType} kind
-   * @param {number} requestId
+   * @param {bigint} requestId
    * @param {shaka.msf.Utils.MessageHandler} handler
    * @return {function()} A function to unregister the handler
    */
@@ -271,7 +271,7 @@ shaka.msf.MSFTransport = class {
    * @param {string} namespace
    * @param {string} trackName
    * @param {shaka.msf.Utils.ObjectCallback} callback
-   * @return {!Promise<number>}
+   * @return {!Promise<bigint>}
    */
   subscribeTrack(namespace, trackName, callback) {
     if (!this.tracksManager_) {
@@ -285,7 +285,7 @@ shaka.msf.MSFTransport = class {
   /**
    * Unsubscribe from a track by track alias
    *
-   * @param {number} trackAlias
+   * @param {bigint} trackAlias
    * @return {!Promise}
    */
   async unsubscribeTrack(trackAlias) {
@@ -341,7 +341,7 @@ shaka.msf.MSFConnection = class {
 
   /**
    * Get the next request ID from the client
-   * @return {number}
+   * @return {bigint}
    */
   getNextRequestId() {
     return this.msfTransport_.getNextRequestId();

--- a/lib/msf/msf_utils.js
+++ b/lib/msf/msf_utils.js
@@ -89,8 +89,8 @@ shaka.msf.Utils.SetupType = {
 
 /**
  * @typedef {{
- *   type: number,
- *   value: (number|!Uint8Array),
+ *   type: bigint,
+ *   value: (bigint|!Uint8Array),
  * }}
  */
 shaka.msf.Utils.KeyValuePair;
@@ -98,9 +98,9 @@ shaka.msf.Utils.KeyValuePair;
 
 /**
  * @typedef {{
- *   group: number,
- *   object: number,
- *   subgroup: ?(number|undefined)
+ *   group: bigint,
+ *   object: bigint,
+ *   subgroup: ?(bigint|undefined)
  * }}
  */
 shaka.msf.Utils.Location;
@@ -109,7 +109,7 @@ shaka.msf.Utils.Location;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
+ *   requestId: bigint,
  *   namespace: Array<string>,
  *   name: string,
  *   subscriberPriority: number,
@@ -117,7 +117,7 @@ shaka.msf.Utils.Location;
  *   forward: boolean,
  *   filterType: shaka.msf.Utils.FilterType,
  *   startLocation: (shaka.msf.Utils.Location|undefined),
- *   endGroup: (number|undefined),
+ *   endGroup: (bigint|undefined),
  *   params: Array<shaka.msf.Utils.KeyValuePair>,
  * }}
  */
@@ -127,9 +127,9 @@ shaka.msf.Utils.Subscribe;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
- *   trackAlias: number,
- *   expires: number,
+ *   requestId: bigint,
+ *   trackAlias: bigint,
+ *   expires: bigint,
  *   groupOrder: shaka.msf.Utils.GroupOrder,
  *   contentExists: boolean,
  *   largest: (shaka.msf.Utils.Location|undefined),
@@ -142,10 +142,10 @@ shaka.msf.Utils.SubscribeOk;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
- *   code: number,
+ *   requestId: bigint,
+ *   code: bigint,
  *   reason: string,
- *   trackAlias: number,
+ *   trackAlias: bigint,
  * }}
  */
 shaka.msf.Utils.SubscribeError;
@@ -154,9 +154,9 @@ shaka.msf.Utils.SubscribeError;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
+ *   requestId: bigint,
  *   startLocation: shaka.msf.Utils.Location,
- *   endGroup: number,
+ *   endGroup: bigint,
  *   subscriberPriority: number,
  *   forward: boolean,
  *   params: Array<shaka.msf.Utils.KeyValuePair>,
@@ -168,7 +168,7 @@ shaka.msf.Utils.SubscribeUpdate;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
+ *   requestId: bigint,
  * }}
  */
 shaka.msf.Utils.Unsubscribe;
@@ -177,8 +177,8 @@ shaka.msf.Utils.Unsubscribe;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
- *   code: number,
+ *   requestId: bigint,
+ *   code: bigint,
  *   streamCount: number,
  *   reason: string,
  * }}
@@ -189,7 +189,7 @@ shaka.msf.Utils.PublishDone;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
+ *   requestId: bigint,
  *   namespace: Array<string>,
  *   params: Array<shaka.msf.Utils.KeyValuePair>,
  * }}
@@ -200,7 +200,7 @@ shaka.msf.Utils.PublishNamespace;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
+ *   requestId: bigint,
  *   namespace: Array<string>,
  * }}
  */
@@ -210,8 +210,8 @@ shaka.msf.Utils.PublishNamespaceOk;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   requestId: number,
- *   code: number,
+ *   requestId: bigint,
+ *   code: bigint,
  *   reason: string,
  * }}
  */
@@ -230,7 +230,7 @@ shaka.msf.Utils.UnpublishNamespace;
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   maximumRequestId: number,
+ *   maximumRequestId: bigint,
  * }}
  */
 shaka.msf.Utils.RequestsBlocked;
@@ -284,11 +284,11 @@ shaka.msf.Utils.MessageHandler;
 
 /**
  * @typedef {{
- *   trackAlias: number,
+ *   trackAlias: bigint,
  *   location: shaka.msf.Utils.Location,
  *   data: !Uint8Array,
  *   extensions: ?(Uint8Array|undefined),
- *   status: ?(number|undefined)
+ *   status: ?(bigint|undefined)
  * }}
  */
 shaka.msf.Utils.MOQObject;
@@ -304,8 +304,8 @@ shaka.msf.Utils.ObjectCallback;
  * @typedef {{
  *   namespace: string,
  *   trackName: string,
- *   trackAlias: number,
- *   requestId: number,
+ *   trackAlias: bigint,
+ *   requestId: bigint,
  *   callbacks: !Array<shaka.msf.Utils.ObjectCallback>,
  * }}
  */

--- a/lib/util/data_view_writer.js
+++ b/lib/util/data_view_writer.js
@@ -196,19 +196,17 @@ shaka.util.DataViewWriter = class {
 
   /**
    * Variable-length unsigned integer (up to 62 bits).
-   * @param {!number} value
+   * @param {!bigint} value
    */
   writeVarInt62(value) {
-    if (value < 0) {
+    if (value < BigInt(0)) {
       throw new Error(`Underflow: ${value}`);
     }
 
-    if (value <= Number.MAX_SAFE_INTEGER) {
-      this.writeVarInt53(value);
+    if (value <= BigInt(Number.MAX_SAFE_INTEGER)) {
+      this.writeVarInt53(Number(value));
       return;
     }
-
-    const v = BigInt(value);
 
     const maskFF = BigInt(0xff);
     const mask0F = BigInt(0x0f);
@@ -216,14 +214,14 @@ shaka.util.DataViewWriter = class {
 
     this.ensureSpace_(8);
 
-    this.writeUint8(Number(((v >> BigInt(56)) & mask0F) | prefixC0));
-    this.writeUint8(Number((v >> BigInt(48)) & maskFF));
-    this.writeUint8(Number((v >> BigInt(40)) & maskFF));
-    this.writeUint8(Number((v >> BigInt(32)) & maskFF));
-    this.writeUint8(Number((v >> BigInt(24)) & maskFF));
-    this.writeUint8(Number((v >> BigInt(16)) & maskFF));
-    this.writeUint8(Number((v >> BigInt(8)) & maskFF));
-    this.writeUint8(Number(v & maskFF));
+    this.writeUint8(Number(((value >> BigInt(56)) & mask0F) | prefixC0));
+    this.writeUint8(Number((value >> BigInt(48)) & maskFF));
+    this.writeUint8(Number((value >> BigInt(40)) & maskFF));
+    this.writeUint8(Number((value >> BigInt(32)) & maskFF));
+    this.writeUint8(Number((value >> BigInt(24)) & maskFF));
+    this.writeUint8(Number((value >> BigInt(16)) & maskFF));
+    this.writeUint8(Number((value >> BigInt(8)) & maskFF));
+    this.writeUint8(Number(value & maskFF));
   }
 
   /**

--- a/test/msf/buffer_control_writer_unit.js
+++ b/test/msf/buffer_control_writer_unit.js
@@ -1,4 +1,4 @@
-describe('shaka.msf.BufferControlWriter', () => {
+filterDescribe('shaka.msf.BufferControlWriter', isMSFSupported, () => {
   /** @type {!shaka.msf.BufferControlWriter} */
   let writer;
 
@@ -23,7 +23,7 @@ describe('shaka.msf.BufferControlWriter', () => {
   it('should reset the buffer', () => {
     const msg = {
       kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
-      requestId: 123,
+      requestId: BigInt(123),
     };
     writer.marshalUnsubscribe(msg);
     const beforeReset = writer.getBytes().length;
@@ -38,7 +38,7 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal a valid Subscribe message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
-        requestId: 1,
+        requestId: BigInt(1),
         namespace: ['ns1', 'ns2'],
         name: 'track1',
         subscriberPriority: 1,
@@ -55,7 +55,7 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should throw if startLocation is missing for absolute filter', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
-        requestId: 1,
+        requestId: BigInt(1),
         namespace: [],
         name: 'track1',
         subscriberPriority: 1,
@@ -72,12 +72,12 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal a SubscribeOk message with content', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE_OK,
-        requestId: 1,
-        trackAlias: 2,
-        expires: 100,
+        requestId: BigInt(1),
+        trackAlias: BigInt(2),
+        expires: BigInt(100),
         groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
         contentExists: true,
-        largest: {group: 1, object: 2},
+        largest: {group: BigInt(1), object: BigInt(2)},
         params: [],
       };
       writer.marshalSubscribeOk(msg);
@@ -87,9 +87,9 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should throw if largest is missing when contentExists is true', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE_OK,
-        requestId: 1,
-        trackAlias: 2,
-        expires: 100,
+        requestId: BigInt(1),
+        trackAlias: BigInt(2),
+        expires: BigInt(100),
         groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
         contentExists: true,
         largest: undefined,
@@ -103,10 +103,10 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal a SubscribeError message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE_ERROR,
-        requestId: 1,
-        code: 404,
+        requestId: BigInt(1),
+        code: BigInt(404),
         reason: 'Not found',
-        trackAlias: 5,
+        trackAlias: BigInt(5),
       };
       writer.marshalSubscribeError(msg);
       expect(writer.getBytes().length).toBeGreaterThan(0);
@@ -117,8 +117,8 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal a PublishDone message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.PUBLISH_DONE,
-        requestId: 1,
-        code: 0,
+        requestId: BigInt(1),
+        code: BigInt(0),
         reason: 'Done',
         streamCount: 3,
       };
@@ -131,7 +131,7 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal an PublishNamespace message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE,
-        requestId: 1,
+        requestId: BigInt(1),
         namespace: ['ns'],
         params: [],
       };
@@ -144,7 +144,7 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal an PublishNamespaceOk message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_OK,
-        requestId: 1,
+        requestId: BigInt(1),
         namespace: ['ns'],
       };
       writer.marshalPublishNamespaceOk(msg);
@@ -156,7 +156,7 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal an Unsubscribe message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
-        requestId: 1,
+        requestId: BigInt(1),
       };
       writer.marshalUnsubscribe(msg);
       expect(writer.getBytes().length).toBeGreaterThan(0);
@@ -167,8 +167,8 @@ describe('shaka.msf.BufferControlWriter', () => {
     it('should marshal an PublishNamespaceError message', () => {
       const msg = {
         kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_ERROR,
-        requestId: 1,
-        code: 500,
+        requestId: BigInt(1),
+        code: BigInt(500),
         reason: 'Server error'}
         ;
       writer.marshalPublishNamespaceError(msg);
@@ -212,8 +212,8 @@ describe('shaka.msf.BufferControlWriter', () => {
   it('marshalSubscribe writes correct message type and length', () => {
     const msg = {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
-      requestId: 1,
-      trackAlias: 2,
+      requestId: BigInt(1),
+      trackAlias: BigInt(2),
       namespace: ['ns1', 'ns2'],
       name: 'trackName',
       subscriberPriority: 1,
@@ -236,12 +236,12 @@ describe('shaka.msf.BufferControlWriter', () => {
   it('marshalSubscribeOk writes correct message type and largest location', () => {
     const msg = {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE_OK,
-      requestId: 5,
-      trackAlias: 2,
-      expires: 1234,
+      requestId: BigInt(5),
+      trackAlias: BigInt(2),
+      expires: BigInt(1234),
       groupOrder: shaka.msf.Utils.GroupOrder.DESCENDING,
       contentExists: true,
-      largest: {group: 10, object: 20},
+      largest: {group: BigInt(10), object: BigInt(20)},
       params: [],
     };
 
@@ -265,7 +265,7 @@ describe('shaka.msf.BufferControlWriter', () => {
   it('marshalUnsubscribe writes correct message type and requestId', () => {
     const msg = {
       kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
-      requestId: 42,
+      requestId: BigInt(42),
     };
 
     writer.marshalUnsubscribe(msg);

--- a/test/msf/msf_classes_unit.js
+++ b/test/msf/msf_classes_unit.js
@@ -1,4 +1,4 @@
-describe('shaka.msf.Reader', () => {
+filterDescribe('shaka.msf.Reader', isMSFSupported, () => {
   /** @type {!shaka.msf.Reader} */
   let reader;
 
@@ -124,15 +124,15 @@ describe('shaka.msf.Reader', () => {
 
     const pairs = await reader.keyValuePairs();
     expect(pairs.length).toBe(2);
-    expect(pairs[0]).toEqual({type: 2, value: 3});
-    expect(pairs[1].type).toBe(1);
+    expect(pairs[0]).toEqual({type: BigInt(2), value: BigInt(3)});
+    expect(pairs[1].type).toBe(BigInt(1));
     expect(shaka.util.StringUtils.fromUTF8(
         /** @type {!ArrayBufferView} */ (pairs[1].value),
     )).toBe('A');
   });
 });
 
-describe('shaka.msf.Writer', () => {
+filterDescribe('shaka.msf.Writer', isMSFSupported, () => {
   /** @type {!shaka.msf.Writer} */
   let writer;
 
@@ -176,7 +176,7 @@ describe('shaka.msf.Writer', () => {
   });
 });
 
-describe('shaka.msf.Receiver', () => {
+filterDescribe('shaka.msf.Receiver', isMSFSupported, () => {
   let reader;
   let receiver;
 
@@ -201,7 +201,7 @@ describe('shaka.msf.Receiver', () => {
         if (offset >= buffer.length) {
           throw new Error('unexpected end of stream');
         }
-        const value = buffer[offset++];
+        const value = BigInt(buffer[offset++]);
         return {value, bytesRead: 1};
       },
       read: (length) => {
@@ -252,8 +252,8 @@ describe('shaka.msf.Receiver', () => {
     const result = await receiver.server();
     expect(result.version).toBe(1);
     expect(result.params.length).toBe(1);
-    expect(result.params[0].type).toBe(2);
-    expect(result.params[0].value).toBe(42);
+    expect(result.params[0].type).toBe(BigInt(2));
+    expect(result.params[0].value).toBe(BigInt(42));
   });
 
   it('should throw error if server type is invalid', async () => {
@@ -272,7 +272,7 @@ describe('shaka.msf.Receiver', () => {
   });
 });
 
-describe('shaka.msf.Sender', () => {
+filterDescribe('shaka.msf.Sender', isMSFSupported, () => {
   let sender;
   /** @type {!Array<!Uint8Array>} */
   let writtenChunks;
@@ -297,8 +297,14 @@ describe('shaka.msf.Sender', () => {
     const clientSetup = {
       versions: [1],
       params: [
-        {type: 2, value: 42},
-        {type: 3, value: new Uint8Array([0xde, 0xad])},
+        {
+          type: BigInt(2),
+          value: BigInt(42),
+        },
+        {
+          type: BigInt(3),
+          value: new Uint8Array([0xde, 0xad]),
+        },
       ],
     };
 

--- a/test/msf/msf_control_stream_unit.js
+++ b/test/msf/msf_control_stream_unit.js
@@ -1,4 +1,4 @@
-describe('shaka.msf.ControlStream', () => {
+filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
   /** @type {!shaka.msf.ControlStream} */
   let controlStream;
 

--- a/test/msf/msf_parser_unit.js
+++ b/test/msf/msf_parser_unit.js
@@ -1,4 +1,4 @@
-describe('shaka.msf.MSFParser', () => {
+filterDescribe('shaka.msf.MSFParser', isMSFSupported, () => {
   /** @type {!shaka.test.FakeNetworkingEngine} */
   let fakeNetEngine;
   /** @type {!shaka.msf.MSFParser} */

--- a/test/test/boot.js
+++ b/test/test/boot.js
@@ -518,6 +518,38 @@ function checkTrueDrmSupport() {
 }
 
 /**
+ * Check if MSF parser is supported.
+ * @return {boolean}
+ */
+window.isMSFSupported = () => {
+  if (!isBigIntSupported()) {
+    return false;
+  }
+  if (!isWritableStreamSupported()) {
+    return false;
+  }
+  if (!isReadableStreamSupported()) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Check if ReadableStream is supported.
+ * @return {boolean}
+ */
+function isBigIntSupported() {
+  let supported = false;
+  try {
+    supported = typeof window.BigInt === 'function';
+    // eslint-disable-next-line no-restricted-syntax
+  } catch (e) {
+    // Ignore errors
+  }
+  return supported;
+}
+
+/**
  * Check if ReadableStream is supported.
  * @return {boolean}
  */
@@ -542,7 +574,14 @@ function isReadableStreamSupported() {
  * @return {boolean}
  */
 function isWritableStreamSupported() {
-  return typeof WritableStream !== 'undefined';
+  let supported = false;
+  try {
+    supported = typeof window.WritableStream === 'function';
+    // eslint-disable-next-line no-restricted-syntax
+  } catch (e) {
+    // Ignore errors
+  }
+  return supported;
 }
 
 /**

--- a/test/test/externs/filters.js
+++ b/test/test/externs/filters.js
@@ -42,3 +42,6 @@ var xfilterDescribe = function(name, cond, callback) {};
 
 /** @return {boolean} */
 var offlineSupported = function() {};
+
+/** @return {boolean} */
+var isMSFSupported = function() {};

--- a/test/util/data_view_writer_unit.js
+++ b/test/util/data_view_writer_unit.js
@@ -70,18 +70,27 @@ describe('DataViewWriter', () => {
 
   describe('varInt62', () => {
     it('writes small values with varInt62 using varInt53 path', () => {
-      writer.writeVarInt62(0x1234);
+      if (!isBigIntSupported()) {
+        pending('BigInt is not supported by the platform.');
+      }
+      writer.writeVarInt62(BigInt(0x1234));
       const bytes = writer.getBytes();
       expect(bytes.length).toBe(2);
     });
 
     it('throws on negative values', () => {
-      expect(() => writer.writeVarInt62(-1)).toThrow();
+      if (!isBigIntSupported()) {
+        pending('BigInt is not supported by the platform.');
+      }
+      expect(() => writer.writeVarInt62(BigInt(-1))).toThrow();
     });
 
     it('writes varInt53 values via varInt62 path for numbers <= 53-bit', () => {
+      if (!isBigIntSupported()) {
+        pending('BigInt is not supported by the platform.');
+      }
       const val = Number.MAX_SAFE_INTEGER;
-      writer.writeVarInt62(val);
+      writer.writeVarInt62(BigInt(val));
       const bytes = writer.getBytes();
       expect(bytes.length).toBe(8);
     });


### PR DESCRIPTION
Many relays use large numbers and with the current implementation it doesn't always work.

See Closure's limitations here:
https://github.com/google/closure-compiler/wiki/BigInt-support