### PR TITLE
fix(UI): sync seek position with hover and onChange timestamp using consistent position calculation

### DIFF
--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -286,8 +286,20 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    const percent =
-        Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    // The thumb is @thumb-size (12px) wide.  To map click position to value
+    // correctly, we use the thumb's movement range
+    // [rect.left + 6, rect.right - 6] so that clicking at the visual center
+    // of the thumb yields the exact value, and clicking at either extreme
+    // clamps cleanly to min/max.  This matches the Blink engine's own
+    // SetPositionFromPoint() formula in slider_thumb_element.cc:
+    // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc
+    // 12 is the value of @thumb-size in range_elements.less.  Note: for
+    // everything to work, this value has to be synchronized.
+    const thumbRadius = 6; // half of @thumb-size in range_elements.less
+    const minX = rect.left + thumbRadius;
+    const maxX = rect.right - thumbRadius;
+    const clampedX = Math.max(minX, Math.min(maxX, clientX));
+    const percent = (clampedX - minX) / (maxX - minX);
 
     let value = min + percent * (max - min);
     value = Math.round((value - min) / step) * step + min;

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -281,7 +281,10 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
    * @return {number}
    */
   getValueFromPosition(clientX) {
+    // Get the bounding rectangle of the range input element
     const rect = this.bar.getBoundingClientRect();
+
+    // Parse the min, max, and step attributes from the input element
     const min = parseFloat(this.bar.min);
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -48,6 +48,9 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     /** @private {boolean} */
     this.isChanging_ = false;
 
+    /** @private {boolean} */
+    this.isMouseChanging_ = false;
+
     /** @protected {!HTMLInputElement} */
     this.bar =
       /** @type {!HTMLInputElement} */ (document.createElement('input'));
@@ -74,20 +77,45 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
       this.bar.disabled = false;
     });
 
-    this.eventManager.listen(this.controls, 'showingui', (e) => {
+    this.eventManager.listen(this.controls, 'showingui', () => {
       this.showingUITimer_.tickAfter(/* seconds= */ 0);
     });
 
-    this.eventManager.listen(this.controls, 'hidingui', (e) => {
+    this.eventManager.listen(this.controls, 'hidingui', () => {
       this.showingUITimer_.stop();
       this.bar.disabled = true;
     });
 
     this.eventManager.listen(this.bar, 'mousedown', (e) => {
       if (!this.bar.disabled) {
+        // Prevent native range update to use getValueFromPosition()
+        // consistently with the hover preview.
+        e.preventDefault();
+        this.bar.focus();
         this.isChanging_ = true;
+        this.isMouseChanging_ = true;
+        this.setBarValueForMouse_(e);
         this.onChangeStart();
+        this.onChange();
         e.stopPropagation();
+      }
+    });
+
+    this.eventManager.listen(document, 'mousemove', (e) => {
+      if (this.isMouseChanging_) {
+        this.setBarValueForMouse_(e);
+        this.onChange();
+      }
+    });
+
+    this.eventManager.listen(document, 'mouseup', (e) => {
+      if (this.isMouseChanging_) {
+        this.isMouseChanging_ = false;
+        if (this.isChanging_) {
+          this.isChanging_ = false;
+          this.setBarValueForMouse_(e);
+          this.onChangeEnd();
+        }
       }
     });
 
@@ -133,6 +161,8 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     this.eventManager.listen(this.bar, 'mouseup', (e) => {
       if (this.isChanging_) {
         this.isChanging_ = false;
+        this.isMouseChanging_ = false;
+        this.setBarValueForMouse_(e);
         this.onChangeEnd();
         e.stopPropagation();
       }
@@ -141,6 +171,7 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     this.eventManager.listen(this.bar, 'blur', () => {
       if (this.isChanging_) {
         this.isChanging_ = false;
+        this.isMouseChanging_ = false;
         this.onChangeEnd();
       }
     });
@@ -250,37 +281,28 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
    * @return {number}
    */
   getValueFromPosition(clientX) {
-    // Get the bounding rectangle of the range input element
     const rect = this.bar.getBoundingClientRect();
-
-    // Parse the min, max, and step attributes from the input element
     const min = parseFloat(this.bar.min);
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    // Define the effective range of the thumb movement
-    // 12 is the value of @thumb-size in range_elements.less. Note: for
-    // everything to work, this value has to be synchronized.
-    const thumbWidth = 12;
-    const minX = rect.left + thumbWidth / 2;
-    const maxX = rect.right - thumbWidth / 2;
+    const percent =
+        Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
 
-    // Clamp the touch X position to stay within the thumb's movement range
-    const clampedX = Math.max(minX, Math.min(maxX, clientX));
-
-    // Calculate the percentage of the track that the clamped X represents
-    const percent = (clampedX - minX) / (maxX - minX);
-
-    // Convert the percentage into a value within the input's range
     let value = min + percent * (max - min);
-
-    // Round the value to the nearest step
     value = Math.round((value - min) / step) * step + min;
-
-    // Ensure the value stays within the min and max bounds
     value = Math.min(max, Math.max(min, value));
 
     return value;
+  }
+
+  /**
+   * Synchronize the mouse position with the range value.
+   * @param {MouseEvent} event
+   * @private
+   */
+  setBarValueForMouse_(event) {
+    this.bar.value = this.getValueFromPosition(event.clientX);
   }
 
   /**

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -286,15 +286,15 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    // thumbRadius is half of @thumb-size, as defined in range_elements.less.
+    // The thumb is @thumb-size wide, as defined in range_elements.less.
     // The browser renders the thumb only within the movement range
-    // [rect.left + thumbRadius, rect.right - thumbRadius], so we must apply
+    // [rect.left + thumbSize/2, rect.right - thumbSize/2], so we must apply
     // the same offset when mapping a click position back to a value.
-    // Note: thumbRadius must stay in sync with @thumb-size in
+    // Note: thumbSize must stay in sync with @thumb-size in
     // range_elements.less.
-    const thumbRadius = 6; // half of @thumb-size in range_elements.less
-    const minX = rect.left + thumbRadius;
-    const maxX = rect.right - thumbRadius;
+    const thumbSize = 12; // @thumb-size in range_elements.less
+    const minX = rect.left + thumbSize / 2;
+    const maxX = rect.right - thumbSize / 2;
     const clampedX = Math.max(minX, Math.min(maxX, clientX));
     const percent = (clampedX - minX) / (maxX - minX);
 

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -286,20 +286,26 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    // The thumb is @thumb-size wide, as defined in range_elements.less.
-    // The browser renders the thumb only within the movement range
-    // [rect.left + thumbSize/2, rect.right - thumbSize/2], so we must apply
-    // the same offset when mapping a click position back to a value.
-    // Note: thumbSize must stay in sync with @thumb-size in
-    // range_elements.less.
-    const thumbSize = 12; // @thumb-size in range_elements.less
-    const minX = rect.left + thumbSize / 2;
-    const maxX = rect.right - thumbSize / 2;
+    // Define the effective range of the thumb movement
+    // 12 is the value of @thumb-size in range_elements.less. Note: for
+    // everything to work, this value has to be synchronized.
+    const thumbWidth = 12;
+    const minX = rect.left + thumbWidth / 2;
+    const maxX = rect.right - thumbWidth / 2;
+
+    // Clamp the touch X position to stay within the thumb's movement range
     const clampedX = Math.max(minX, Math.min(maxX, clientX));
+
+    // Calculate the percentage of the track that the clamped X represents
     const percent = (clampedX - minX) / (maxX - minX);
 
+    // Convert the percentage into a value within the input's range
     let value = min + percent * (max - min);
+
+    // Round the value to the nearest step
     value = Math.round((value - min) / step) * step + min;
+
+    // Ensure the value stays within the min and max bounds
     value = Math.min(max, Math.max(min, value));
 
     return value;

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -286,15 +286,12 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    // The thumb is @thumb-size (12px) wide.  To map click position to value
-    // correctly, we use the thumb's movement range
-    // [rect.left + 6, rect.right - 6] so that clicking at the visual center
-    // of the thumb yields the exact value, and clicking at either extreme
-    // clamps cleanly to min/max.  This matches the Blink engine's own
-    // SetPositionFromPoint() formula in slider_thumb_element.cc:
-    // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/third_party/blink/renderer/core/html/forms/slider_thumb_element.cc
-    // 12 is the value of @thumb-size in range_elements.less.  Note: for
-    // everything to work, this value has to be synchronized.
+    // thumbRadius is half of @thumb-size, as defined in range_elements.less.
+    // The browser renders the thumb only within the movement range
+    // [rect.left + thumbRadius, rect.right - thumbRadius], so we must apply
+    // the same offset when mapping a click position back to a value.
+    // Note: thumbRadius must stay in sync with @thumb-size in
+    // range_elements.less.
     const thumbRadius = 6; // half of @thumb-size in range_elements.less
     const minX = rect.left + thumbRadius;
     const maxX = rect.right - thumbRadius;

--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -298,11 +298,12 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
 
   /**
    * Synchronize the mouse position with the range value.
-   * @param {MouseEvent} event
+   * @param {Event} event
    * @private
    */
   setBarValueForMouse_(event) {
-    this.bar.value = this.getValueFromPosition(event.clientX);
+    this.bar.value = this.getValueFromPosition(
+        /** @type {MouseEvent} */ (event).clientX);
   }
 
   /**

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -299,9 +299,9 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       const max = parseFloat(this.bar.max);
       const rect = this.bar.getBoundingClientRect();
       const value = Math.round(this.getValue());
-      const thumbRadius = 6;
-      const scale = (rect.width - 2 * thumbRadius) / (max - min);
-      const position = (value - min) * scale + thumbRadius;
+      const thumbSize = 12; // @thumb-size in range_elements.less
+      const scale = (rect.width - thumbSize) / (max - min);
+      const position = (value - min) * scale + thumbSize / 2;
       this.showThumbnailAndTime_(position, value);
     } else {
       this.hideThumbnailTimeContainer_();

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -299,8 +299,9 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       const max = parseFloat(this.bar.max);
       const rect = this.bar.getBoundingClientRect();
       const value = Math.round(this.getValue());
-      const scale = (max - min) / rect.width;
-      const position = (value - min) / scale;
+      const thumbRadius = 6;
+      const scale = (rect.width - 2 * thumbRadius) / (max - min);
+      const position = (value - min) * scale + thumbRadius;
       this.showThumbnailAndTime_(position, value);
     } else {
       this.hideThumbnailTimeContainer_();


### PR DESCRIPTION
### Problem

Previously, click/drag in the seek bar relied on the browser's default range entry event. The hover preview used 'getValueFromPosition()' separately. This resulted in a mismatch between the hover timestamp and the actual search position, This problem was particularly noticeable in long videos.

### FIx

I modified to call `getValueFromPosition()` directory even when click/drag. However click, drag, and touch all go through the same function, so timestamp previews and navigation positions are always sychronized.

In addition, I also fixed a bug where the tooltip moves instaneously when clicking by reflecting the thumbWide correction when we reverse the tooltip position to value in `onChange()`.