### PR TITLE
fix(MSF): Improve buffer management

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2841,7 +2841,8 @@ shaka.media.StreamingEngine = class {
         this.manifest_.presentationTimeline.getSeekRangeEnd();
 
     let overflow = bufferedBehind - bufferBehind;
-    if (seekRangeEnd - seekRangeStart > evictionGoal) {
+    if (seekRangeEnd - seekRangeStart > evictionGoal ||
+        this.manifest_.type == shaka.media.ManifestParser.MSF) {
       overflow = Math.max(bufferedBehind - bufferBehind,
           seekRangeStart - evictionGoal - startTime);
     }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2841,6 +2841,8 @@ shaka.media.StreamingEngine = class {
         this.manifest_.presentationTimeline.getSeekRangeEnd();
 
     let overflow = bufferedBehind - bufferBehind;
+    // For MSF there is no seek range (LIVE without seek), so we need evict
+    // when the seekable range is less than the eviction goal.
     if (seekRangeEnd - seekRangeStart > evictionGoal ||
         this.manifest_.type == shaka.media.ManifestParser.MSF) {
       overflow = Math.max(bufferedBehind - bufferBehind,

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1187,6 +1187,9 @@ shaka.media.StreamingEngine = class {
    */
   createSegmentPrefetch_(stream) {
     const ContentType = shaka.util.ManifestParserUtils.ContentType;
+    if (this.manifest_.type == shaka.media.ManifestParser.MSF) {
+      return null;
+    }
     if (stream.type === ContentType.VIDEO &&
         this.config_.disableVideoPrefetch) {
       return null;
@@ -1826,7 +1829,8 @@ shaka.media.StreamingEngine = class {
       // may wind up requesting the previous segment to be safe.
       // inaccurateManifestTolerance should be 0 for low latency streaming.
       let inaccurateTolerance =
-          (this.manifest_.sequenceMode || this.shouldUseCrossBoundaryLogic_()) ?
+          (this.manifest_.sequenceMode || this.shouldUseCrossBoundaryLogic_() ||
+          this.manifest_.type === shaka.media.ManifestParser.MSF) ?
           0 : this.config_.inaccurateManifestTolerance;
       let lookupTime = Math.max(presentationTime - inaccurateTolerance, 0);
       const duration = this.playerInterface_.mediaSourceEngine.getDuration();
@@ -2840,14 +2844,16 @@ shaka.media.StreamingEngine = class {
     const seekRangeEnd =
         this.manifest_.presentationTimeline.getSeekRangeEnd();
 
+    const duration = seekRangeEnd - seekRangeStart;
+
     let overflow = bufferedBehind - bufferBehind;
-    if (seekRangeEnd - seekRangeStart > evictionGoal) {
+    if (duration > evictionGoal) {
       overflow = Math.max(bufferedBehind - bufferBehind,
           seekRangeStart - evictionGoal - startTime);
     } else if (this.manifest_.type == shaka.media.ManifestParser.MSF) {
       // For MSF there is no seek range (LIVE without seek), so we need evict
       // when the seekable range is less than the eviction goal.
-      evictionGoal *= 2;
+      evictionGoal = Math.max(evictionGoal + 1, evictionGoal + duration);
       overflow = Math.max(bufferedBehind - bufferBehind,
           seekRangeStart - evictionGoal - startTime);
     }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -2833,7 +2833,7 @@ shaka.media.StreamingEngine = class {
     }
     const bufferedBehind = presentationTime - startTime;
 
-    const evictionGoal = this.config_.evictionGoal;
+    let evictionGoal = this.config_.evictionGoal;
 
     const seekRangeStart =
         this.manifest_.presentationTimeline.getSeekRangeStart();
@@ -2841,10 +2841,13 @@ shaka.media.StreamingEngine = class {
         this.manifest_.presentationTimeline.getSeekRangeEnd();
 
     let overflow = bufferedBehind - bufferBehind;
-    // For MSF there is no seek range (LIVE without seek), so we need evict
-    // when the seekable range is less than the eviction goal.
-    if (seekRangeEnd - seekRangeStart > evictionGoal ||
-        this.manifest_.type == shaka.media.ManifestParser.MSF) {
+    if (seekRangeEnd - seekRangeStart > evictionGoal) {
+      overflow = Math.max(bufferedBehind - bufferBehind,
+          seekRangeStart - evictionGoal - startTime);
+    } else if (this.manifest_.type == shaka.media.ManifestParser.MSF) {
+      // For MSF there is no seek range (LIVE without seek), so we need evict
+      // when the seekable range is less than the eviction goal.
+      evictionGoal *= 2;
       overflow = Math.max(bufferedBehind - bufferBehind,
           seekRangeStart - evictionGoal - startTime);
     }

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -676,11 +676,12 @@ shaka.msf.MSFParser = class {
 
         const timelineLocked = this.presentationTimeline_.isStartTimeLocked();
 
-        // Before the timeline is locked, pass 0 as the eviction start to
-        // prevent mergeAndEvict from discarding segments prematurely.
-        const evictionStart = timelineLocked ?
-            this.presentationTimeline_.getSegmentAvailabilityStart() : 0;
-        stream.segmentIndex.mergeAndEvict([reference], evictionStart);
+        if (timelineLocked) {
+          stream.segmentIndex.mergeAndEvict([reference],
+              this.presentationTimeline_.getSegmentAvailabilityStart());
+        } else {
+          stream.segmentIndex.merge([reference])
+        }
 
         this.presentationTimeline_.notifySegments([reference]);
 

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -220,6 +220,7 @@ shaka.msf.MSFParser = class {
 
     this.createVariants_();
 
+    this.manifest_.isLowLatency = this.presentationTimeline_.isDynamic();
     this.manifest_.variants = this.variants_;
     this.manifest_.textStreams = this.textStreams_;
 
@@ -677,10 +678,11 @@ shaka.msf.MSFParser = class {
         const timelineLocked = this.presentationTimeline_.isStartTimeLocked();
 
         if (timelineLocked) {
-          stream.segmentIndex.mergeAndEvict([reference],
+          const evictTime = Math.min(reference.startTime - 2,
               this.presentationTimeline_.getSegmentAvailabilityStart());
+          stream.segmentIndex.mergeAndEvict([reference], evictTime);
         } else {
-          stream.segmentIndex.merge([reference])
+          stream.segmentIndex.merge([reference]);
         }
 
         this.presentationTimeline_.notifySegments([reference]);

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -643,7 +643,7 @@ shaka.msf.MSFParser = class {
       /** @type {?shaka.util.PublicPromise} */
       let promise = new shaka.util.PublicPromise();
       this.subscribeToTrack(track, trackKey, (obj) => {
-        if (!stream.segmentIndex) {
+        if (!stream.segmentIndex || !obj.data.byteLength) {
           return;
         }
         const SegmentUtils = shaka.media.SegmentUtils;


### PR DESCRIPTION
Allow evict the buffer more aggressive in MSF streams
Do not create a prefetch because for MSF it is not necessary because the data is always in the segments.
Set MSF streams as low latency.