### PR TITLE
fix(UI): sync seekbar on timestamp position value between mousemove and onChange in firefox

### DIFF
--- a/ui/range_element.js
+++ b/ui/range_element.js
@@ -281,25 +281,34 @@ shaka.ui.RangeElement = class extends shaka.ui.Element {
    * @return {number}
    */
   getValueFromPosition(clientX) {
+    // Get the bounding rectangle of the range input element
     const rect = this.bar.getBoundingClientRect();
+
+    // Parse the min, max attributes from the input element
     const min = parseFloat(this.bar.min);
     const max = parseFloat(this.bar.max);
     const step = parseFloat(this.bar.step) || 1;
 
-    // thumbRadius is half of @thumb-size, as defined in range_elements.less.
-    // The browser renders the thumb only within the movement range
-    // [rect.left + thumbRadius, rect.right - thumbRadius], so we must apply
-    // the same offset when mapping a click position back to a value.
-    // Note: thumbRadius must stay in sync with @thumb-size in
-    // range_elements.less.
-    const thumbRadius = 6; // half of @thumb-size in range_elements.less
-    const minX = rect.left + thumbRadius;
-    const maxX = rect.right - thumbRadius;
+    // Define the effective range of the thumb movement
+    // 12 is the value of @thumb-size in range_elements.less. Note: for
+    // everything to work, this value has to be synchronized.
+    const thumbWidth = 12;
+    const minX = rect.left + thumbWidth / 2;
+    const maxX = rect.right - thumbWidth / 2;
+
+    // Clamp the touch X position to stay within the thumb's movement range
     const clampedX = Math.max(minX, Math.min(maxX, clientX));
+
+    // Calculate the percentage of the track that the clamped X represents
     const percent = (clampedX - minX) / (maxX - minX);
 
+    // Convert the percentage into a value within the input's range
     let value = min + percent * (max - min);
+
+    // Round the value to the nearest step
     value = Math.round((value - min) / step) * step + min;
+
+    // Ensure the value stays within the min and max bounds
     value = Math.min(max, Math.max(min, value));
 
     return value;

--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -215,10 +215,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
         return;
       }
       const value = this.getValueFromPosition(event.clientX);
-      const rect = this.bar.getBoundingClientRect();
-      // Pixels from the left of the range element
-      const mousePosition = Math.max(0, event.clientX - rect.left);
-      this.showThumbnailAndTime_(mousePosition, value);
+      this.showThumbnailAtValue_(value);
     });
 
     this.eventManager.listen(this.container, 'mouseleave', () => {
@@ -297,14 +294,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
     this.seekTimer_.tickAfter(/* seconds= */ 0.125);
 
     if (!this.controls.anySettingsMenusAreOpen()) {
-      const min = parseFloat(this.bar.min);
-      const max = parseFloat(this.bar.max);
-      const rect = this.bar.getBoundingClientRect();
-      const value = Math.round(this.getValue());
-      const thumbSize = 12; // @thumb-size in range_elements.less
-      const scale = (rect.width - thumbSize) / (max - min);
-      const position = (value - min) * scale + thumbSize / 2;
-      this.showThumbnailAndTime_(position, value);
+      this.showThumbnailAtValue_(this.getValue());
     } else {
       this.hideThumbnailTimeContainer_();
     }
@@ -580,6 +570,20 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
   /** @private */
   updateAriaLabel_() {
     this.bar.ariaLabel = this.localization.resolve(shaka.ui.Locales.Ids.SEEK);
+  }
+
+  /**
+   * @param {number} value
+   * @private
+   */
+  showThumbnailAtValue_(value) {
+    const min = parseFloat(this.bar.min);
+    const max = parseFloat(this.bar.max);
+    const rect = this.bar.getBoundingClientRect();
+    const thumbSize = 12; // @thumb-size in range_elements.less
+    const scale = (rect.width - thumbSize) / (max - min);
+    const position = (value - min) * scale + thumbSize / 2;
+    this.showThumbnailAndTime_(position, value);
   }
 
   /**


### PR DESCRIPTION
### Problem
The hover tooltip(mousemove) and the click tooltip(onChange) used different formulas to calculate position.

- mousemove:   `const mousePosition = Math.max(0, event.clientX - rect.left);``
- onchange: `const position = (value - min) * scale + thumbSize / 2;`

### Fix

Extract a shared `showThumbnailAtValue_()` method so that both hover and click use the same vlaue -> position formula


### Firefox with long term video

https://github.com/user-attachments/assets/97ea4b98-800c-4df0-8795-d5af2e311e4c

### Firefox with short term video

https://github.com/user-attachments/assets/b829cb5d-a531-4772-a320-b10a059af45a

Related Issues to #9327 
Related PR to #9827, #9818 