### PR TITLE
perf(Transmuxer): replace identical object literals with named constants

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -77,6 +77,7 @@
 +../../lib/text/web_vtt_generator.js
 
 +../../lib/transmuxer/transmuxer_engine.js
++../../lib/transmuxer/transmuxer_utils.js
 
 +../../lib/util/abortable_operation.js
 +../../lib/util/array_utils.js

--- a/lib/transmuxer/aac_transmuxer.js
+++ b/lib/transmuxer/aac_transmuxer.js
@@ -9,6 +9,7 @@ goog.provide('shaka.transmuxer.AacTransmuxer');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.ADTS');
 goog.require('shaka.transmuxer.TransmuxerEngine');
+goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Id3Utils');
@@ -169,14 +170,7 @@ shaka.transmuxer.AacTransmuxer = class {
           size: header.frameLength,
           duration: ADTS.AAC_SAMPLES_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
       }
       offset += length;

--- a/lib/transmuxer/ac3_transmuxer.js
+++ b/lib/transmuxer/ac3_transmuxer.js
@@ -10,6 +10,7 @@ goog.require('shaka.device.DeviceFactory');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.Ac3');
 goog.require('shaka.transmuxer.TransmuxerEngine');
+goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Id3Utils');
@@ -167,14 +168,7 @@ shaka.transmuxer.Ac3Transmuxer = class {
         size: frame.frameLength,
         duration: Ac3.AC3_SAMPLES_PER_FRAME,
         cts: 0,
-        flags: {
-          isLeading: 0,
-          isDependedOn: 0,
-          hasRedundancy: 0,
-          degradPrio: 0,
-          dependsOn: 2,
-          isNonSync: 0,
-        },
+        flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
       });
       offset += frame.frameLength;
     }

--- a/lib/transmuxer/ec3_transmuxer.js
+++ b/lib/transmuxer/ec3_transmuxer.js
@@ -9,6 +9,7 @@ goog.provide('shaka.transmuxer.Ec3Transmuxer');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.Ec3');
 goog.require('shaka.transmuxer.TransmuxerEngine');
+goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Id3Utils');
@@ -161,14 +162,7 @@ shaka.transmuxer.Ec3Transmuxer = class {
         size: frame.frameLength,
         duration: Ec3.EC3_SAMPLES_PER_FRAME,
         cts: 0,
-        flags: {
-          isLeading: 0,
-          isDependedOn: 0,
-          hasRedundancy: 0,
-          degradPrio: 0,
-          dependsOn: 2,
-          isNonSync: 0,
-        },
+        flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
       });
       offset += frame.frameLength;
     }

--- a/lib/transmuxer/mp3_transmuxer.js
+++ b/lib/transmuxer/mp3_transmuxer.js
@@ -9,6 +9,7 @@ goog.provide('shaka.transmuxer.Mp3Transmuxer');
 goog.require('shaka.media.Capabilities');
 goog.require('shaka.transmuxer.MpegAudio');
 goog.require('shaka.transmuxer.TransmuxerEngine');
+goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Id3Utils');
@@ -141,14 +142,7 @@ shaka.transmuxer.Mp3Transmuxer = class {
           size: header.frameLength,
           duration: MpegAudio.MPEG_AUDIO_SAMPLE_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
       }
       offset += header.frameLength;

--- a/lib/transmuxer/transmuxer_utils.js
+++ b/lib/transmuxer/transmuxer_utils.js
@@ -1,0 +1,58 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.transmuxer.TransmuxerUtils');
+
+goog.requireType('shaka.util.Mp4Generator');
+
+
+/**
+ * Shared constants for transmuxer implementations.
+ */
+shaka.transmuxer.TransmuxerUtils = class {};
+
+/**
+ * Shared sample flags for audio frames.
+ * Reused across all samples to avoid per-frame object allocation.
+ *
+ * @const {!shaka.util.Mp4Generator.Mp4SampleFlags}
+ */
+shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS = Object.freeze({
+  isLeading: 0,
+  isDependedOn: 0,
+  hasRedundancy: 0,
+  degradPrio: 0,
+  dependsOn: 2,
+  isNonSync: 0,
+});
+
+/**
+ * Shared sample flags for video keyframes.
+ *
+ * @const {!shaka.util.Mp4Generator.Mp4SampleFlags}
+ */
+shaka.transmuxer.TransmuxerUtils.VIDEO_KEYFRAME_FLAGS = Object.freeze({
+  isLeading: 0,
+  isDependedOn: 0,
+  hasRedundancy: 0,
+  degradPrio: 0,
+  dependsOn: 2,
+  isNonSync: 0,
+});
+
+/**
+ * Shared sample flags for video non-keyframes.
+ *
+ * @const {!shaka.util.Mp4Generator.Mp4SampleFlags}
+ */
+shaka.transmuxer.TransmuxerUtils.VIDEO_NON_KEYFRAME_FLAGS = Object.freeze({
+  isLeading: 0,
+  isDependedOn: 0,
+  hasRedundancy: 0,
+  degradPrio: 0,
+  dependsOn: 1,
+  isNonSync: 1,
+});

--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -16,6 +16,7 @@ goog.require('shaka.transmuxer.H265');
 goog.require('shaka.transmuxer.MpegAudio');
 goog.require('shaka.transmuxer.Opus');
 goog.require('shaka.transmuxer.TransmuxerEngine');
+goog.require('shaka.transmuxer.TransmuxerUtils');
 goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.Id3Utils');
@@ -345,14 +346,7 @@ shaka.transmuxer.TsTransmuxer = class {
           size: missingFrameData.byteLength,
           duration: ADTS.AAC_SAMPLES_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
         overflowBytes = null;
         nextStartOffset = null;
@@ -391,14 +385,7 @@ shaka.transmuxer.TsTransmuxer = class {
             size: header.frameLength,
             duration: ADTS.AAC_SAMPLES_PER_FRAME,
             cts: 0,
-            flags: {
-              isLeading: 0,
-              isDependedOn: 0,
-              hasRedundancy: 0,
-              degradPrio: 0,
-              dependsOn: 2,
-              isNonSync: 0,
-            },
+            flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
           });
         }
         offset += length;
@@ -442,14 +429,7 @@ shaka.transmuxer.TsTransmuxer = class {
           size: silenceFrame.byteLength,
           duration: ADTS.AAC_SAMPLES_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
         currentPts += ADTS.AAC_SAMPLES_PER_FRAME / info.sampleRate * timescale;
       }
@@ -529,14 +509,7 @@ shaka.transmuxer.TsTransmuxer = class {
           size: frame.frameLength,
           duration: Ac3.AC3_SAMPLES_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
         offset += frame.frameLength;
       }
@@ -623,14 +596,7 @@ shaka.transmuxer.TsTransmuxer = class {
           size: frame.frameLength,
           duration: Ec3.EC3_SAMPLES_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
         offset += frame.frameLength;
       }
@@ -712,14 +678,7 @@ shaka.transmuxer.TsTransmuxer = class {
             size: header.frameLength,
             duration: MpegAudio.MPEG_AUDIO_SAMPLE_PER_FRAME,
             cts: 0,
-            flags: {
-              isLeading: 0,
-              isDependedOn: 0,
-              hasRedundancy: 0,
-              degradPrio: 0,
-              dependsOn: 2,
-              isNonSync: 0,
-            },
+            flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
           });
         }
         offset += header.frameLength;
@@ -820,14 +779,7 @@ shaka.transmuxer.TsTransmuxer = class {
           size: sample.byteLength,
           duration: Opus.OPUS_AUDIO_SAMPLE_PER_FRAME,
           cts: 0,
-          flags: {
-            isLeading: 0,
-            isDependedOn: 0,
-            hasRedundancy: 0,
-            degradPrio: 0,
-            dependsOn: 2,
-            isNonSync: 0,
-          },
+          flags: shaka.transmuxer.TransmuxerUtils.AUDIO_SAMPLE_FLAGS,
         });
         offset = index + size;
       }
@@ -914,14 +866,9 @@ shaka.transmuxer.TsTransmuxer = class {
         size: videoSample.data.byteLength,
         duration: duration,
         cts: Math.round((videoSample.pts || 0) - (videoSample.dts || 0)),
-        flags: {
-          isLeading: 0,
-          isDependedOn: 0,
-          hasRedundancy: 0,
-          degradPrio: 0,
-          dependsOn: videoSample.isKeyframe ? 2 : 1,
-          isNonSync: videoSample.isKeyframe ? 0 : 1,
-        },
+        flags: videoSample.isKeyframe ?
+            shaka.transmuxer.TransmuxerUtils.VIDEO_KEYFRAME_FLAGS :
+            shaka.transmuxer.TransmuxerUtils.VIDEO_NON_KEYFRAME_FLAGS,
       });
     }
 
@@ -1013,14 +960,9 @@ shaka.transmuxer.TsTransmuxer = class {
         size: frame.data.byteLength,
         duration: duration,
         cts: Math.round((pes.pts || 0) - (pes.dts || 0)),
-        flags: {
-          isLeading: 0,
-          isDependedOn: 0,
-          hasRedundancy: 0,
-          degradPrio: 0,
-          dependsOn: frame.isKeyframe ? 2 : 1,
-          isNonSync: frame.isKeyframe ? 0 : 1,
-        },
+        flags: frame.isKeyframe ?
+            shaka.transmuxer.TransmuxerUtils.VIDEO_KEYFRAME_FLAGS :
+            shaka.transmuxer.TransmuxerUtils.VIDEO_NON_KEYFRAME_FLAGS,
       });
     }
 


### PR DESCRIPTION
In TS Transmuxer, Replaces 9 identical inline Mp4SampleFlags object literals across 7 stream info methods with 3 named constants (AUDIO_SAMPLE_FLAGS_, VIDEO_KEYFRAME_FLAGS_, VIDEO_NON_KEYFRAME_FLAGS_)                             

- Reduces duplication and improves readability — each constant makes the shared object payload referenced
- As a side benefit, eliminates per-frame object allocations during transmuxing, reducing GC pressure on low-end devices like Tizen/LG etc.