### PR TITLE
perf(player): stop recreating functions on video time update

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -8019,6 +8019,44 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   }
 
   /**
+   * Checks whether the current playback percent has crossed a quartile
+   * threshold, updating completionPercent_ if so.
+   *
+   * @param {number} quartilePercent
+   * @param {number} currentPercent
+   * @return {boolean}
+   * @private
+   */
+  isQuartile_(quartilePercent, currentPercent) {
+    const NumberUtils = shaka.util.NumberUtils;
+    const tolerance = 0.01;
+
+    if ((NumberUtils.isFloatEqual(quartilePercent, currentPercent,
+        tolerance) ||
+        currentPercent > quartilePercent) &&
+        this.completionPercent_ < quartilePercent) {
+      this.completionPercent_ = quartilePercent;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Pauses the video if a custom playRangeEnd is set and playback has ended.
+   *
+   * @private
+   */
+  checkEnded_() {
+    if (this.config_ && this.config_.playRangeEnd != Infinity) {
+      // Make sure the video stops when we reach the end.
+      // This is required when there is a custom playRangeEnd specified.
+      if (this.isEnded()) {
+        this.video_.pause();
+      }
+    }
+  }
+
+  /**
    * Callback for video progress events
    *
    * @private
@@ -8027,30 +8065,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!this.video_) {
       return;
     }
-
-    const isQuartile = (quartilePercent, currentPercent) => {
-      const NumberUtils = shaka.util.NumberUtils;
-      const tolerance = 0.01;
-
-      if ((NumberUtils.isFloatEqual(quartilePercent, currentPercent,
-          tolerance) ||
-          currentPercent > quartilePercent) &&
-          this.completionPercent_ < quartilePercent) {
-        this.completionPercent_ = quartilePercent;
-        return true;
-      }
-      return false;
-    };
-
-    const checkEnded = () => {
-      if (this.config_ && this.config_.playRangeEnd != Infinity) {
-        // Make sure the video stops when we reach the end.
-        // This is required when there is a custom playRangeEnd specified.
-        if (this.isEnded()) {
-          this.video_.pause();
-        }
-      }
-    };
 
     const seekRange = this.seekRange();
     const duration = seekRange.end - seekRange.start;
@@ -8064,23 +8078,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const percent = completionRatio * 100;
 
     let event;
-    if (isQuartile(0, percent)) {
+    if (this.isQuartile_(0, percent)) {
       event = shaka.Player.makeEvent_(shaka.util.FakeEvent.EventName.Started);
-    } else if (isQuartile(25, percent)) {
+    } else if (this.isQuartile_(25, percent)) {
       event = shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.FirstQuartile);
-    } else if (isQuartile(50, percent)) {
+    } else if (this.isQuartile_(50, percent)) {
       event = shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.Midpoint);
-    } else if (isQuartile(75, percent)) {
+    } else if (this.isQuartile_(75, percent)) {
       event = shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.ThirdQuartile);
-    } else if (isQuartile(100, percent) || percent > 100) {
+    } else if (this.isQuartile_(100, percent) || percent > 100) {
       event = shaka.Player.makeEvent_(
           shaka.util.FakeEvent.EventName.Complete);
-      checkEnded();
+      this.checkEnded_();
     } else {
-      checkEnded();
+      this.checkEnded_();
     }
 
     if (event) {


### PR DESCRIPTION
This PR extracts `isQuartile()` and `checkEnded()` from `onVideoProgress` into class methods to avoid recreating closures on every `timeupdate` event, improving readability but also somewhat reducing GC pressure on TV devices.