### PR TITLE
perf(HLS): parse tag string directly instead of creating an array

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -3786,10 +3786,7 @@ shaka.hls.HlsParser = class {
         const extinfTag =
             shaka.hls.Utils.getFirstTagWithName(segment.tags, 'EXTINF');
         if (extinfTag) {
-          // The EXTINF tag format is '#EXTINF:<duration>,[<title>]'.
-          // We're interested in the duration part.
-          const extinfValues = extinfTag.value.split(',');
-          lastTargetDuration = Number(extinfValues[0]);
+          lastTargetDuration = shaka.hls.Utils.getExtinfDuration(extinfTag);
           break;
         }
         segmentIndex--;
@@ -3885,9 +3882,7 @@ shaka.hls.HlsParser = class {
         const extinfTag = shaka.hls.Utils.getFirstTagWithName(
             playlist.segments[i].tags, 'EXTINF');
         if (extinfTag) {
-          const extinfValues = extinfTag.value.split(',');
-          const duration = Number(extinfValues[0]);
-          presentationDelay += duration;
+          presentationDelay += shaka.hls.Utils.getExtinfDuration(extinfTag);
         } else {
           presentationDelay += this.maxTargetDuration_;
         }
@@ -4223,10 +4218,7 @@ shaka.hls.HlsParser = class {
     // from the parent segment's duration. In this case, use the duration from
     // the parent segment tag.
     if (extinfTag) {
-      // The EXTINF tag format is '#EXTINF:<duration>,[<title>]'.
-      // We're interested in the duration part.
-      const extinfValues = extinfTag.value.split(',');
-      const duration = Number(extinfValues[0]);
+      const duration = shaka.hls.Utils.getExtinfDuration(extinfTag);
       // Skip segments without duration
       if (duration == 0) {
         return null;

--- a/lib/hls/hls_utils.js
+++ b/lib/hls/hls_utils.js
@@ -141,6 +141,19 @@ shaka.hls.Utils = class {
 
 
   /**
+   * Extracts the duration from an EXTINF tag value.
+   * The EXTINF format is '<duration>,[<title>]'.
+   *
+   * @param {!shaka.hls.Tag} tag
+   * @return {number}
+   */
+  static getExtinfDuration(tag) {
+    const value = tag.value;
+    const commaIndex = value.indexOf(',');
+    return Number(commaIndex === -1 ? value : value.substring(0, commaIndex));
+  }
+
+  /**
    * Matches a string to an HLS comment format and returns the result.
    *
    * @param {string} line


### PR DESCRIPTION
Another small healthy change, putting code in one place and reducing GC pressure on TVs