### PR TITLE
perf(HLS): reduce GC pressure when parsing HLS manifest tags

### DIFF
--- a/lib/hls/manifest_text_parser.js
+++ b/lib/hls/manifest_text_parser.js
@@ -14,7 +14,6 @@ goog.require('shaka.hls.Tag');
 goog.require('shaka.hls.Utils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.StringUtils');
-goog.require('shaka.util.TextParser');
 
 
 /**
@@ -227,49 +226,109 @@ shaka.hls.ManifestTextParser = class {
             2b. Otherwise, items are attributes.
        3. If there is no ":", it's a simple tag with no attributes and no value.
     */
-    const blocks = word.match(
-        shaka.hls.ManifestTextParser.STATIC_PATTERNS.tagBlocks);
-    if (!blocks) {
+    const {name, data} = shaka.hls.ManifestTextParser.splitTag_(word);
+
+    // No data means a simple tag: #EXT-X-ENDLIST, #EXT-X-DISCONTINUITY
+    if (data === null) {
+      return new shaka.hls.Tag(id, name, []);
+    }
+
+    // No '=' means value-only, no attributes.
+    // Covers EXTINF, EXT-X-TARGETDURATION, EXT-X-MEDIA-SEQUENCE, etc.
+    if (data.indexOf('=') === -1) {
+      return new shaka.hls.Tag(id, name, [], data);
+    }
+
+    // Has attributes — full parse needed
+    const attributes = shaka.hls.ManifestTextParser.parseAttributes_(data);
+    return new shaka.hls.Tag(id, name, attributes.list, attributes.value);
+  }
+
+  /**
+   * Splits a raw HLS tag string into its name and data portions.
+   * Validates that the tag name starts with 'EXT'.
+   *
+   * @param {string} word Raw tag line, e.g. '#EXT-X-MEDIA:TYPE=AUDIO'
+   * @return {{name: string, data: ?string}}
+   * @private
+   */
+  static splitTag_(word) {
+    const colonIndex = word.indexOf(':');
+    const name = colonIndex === -1 ?
+        word.substring(1) : word.substring(1, colonIndex);
+
+    if (!name.startsWith('EXT')) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
           shaka.util.Error.Code.INVALID_HLS_TAG,
           word);
     }
-    const name = blocks[1];
-    const data = blocks[2];
-    const attributes = [];
-    let value;
 
-    if (data) {
-      const parser = new shaka.util.TextParser(data);
-      let blockAttrs;
+    const data = colonIndex === -1 ? null : word.substring(colonIndex + 1);
+    return {name, data};
+  }
 
-      // re-using global regex: reset lastIndex
-      shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex.lastIndex = 0;
-      const blockValue = parser.readRegex(
-          shaka.hls.ManifestTextParser.STATIC_PATTERNS.valueRegex);
+  /**
+   * Parses the data portion of an HLS tag into an optional leading value
+   * and a list of key=value attributes.
+   *
+   * @param {string} data
+   * @return {{value: ?string, list: !Array<!shaka.hls.Attribute>}}
+   * @private
+   */
+  static parseAttributes_(data) {
+    const list = [];
+    let value = null;
+    let pos = 0;
 
-      if (blockValue) {
-        value = blockValue[1];
-      }
-
-      // re-using global regex: reset lastIndex
-      shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex.lastIndex = 0;
-      blockAttrs = parser.readRegex(
-          shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
-      while (blockAttrs) {
-        const attrName = blockAttrs[1];
-        const attrValue = blockAttrs[2] || blockAttrs[3];
-        const attribute = new shaka.hls.Attribute(attrName, attrValue);
-        attributes.push(attribute);
-        parser.skipWhitespace();
-        blockAttrs = parser.readRegex(
-            shaka.hls.ManifestTextParser.STATIC_PATTERNS.attributeRegex);
-      }
+    // A leading value exists if the first comma comes before the first '='
+    const firstComma = data.indexOf(',');
+    const firstEquals = data.indexOf('=');
+    if (firstComma !== -1 && firstComma < firstEquals) {
+      value = data.substring(0, firstComma);
+      pos = firstComma + 1;
     }
 
-    return new shaka.hls.Tag(id, name, attributes, value);
+    // Parse comma-separated key=value pairs
+    while (pos < data.length) {
+      // Skip optional spaces after comma (HLS spec allows it)
+      while (data[pos] === ' ') {
+        pos++;
+      }
+
+      const eqPos = data.indexOf('=', pos);
+      if (eqPos === -1) {
+        break;
+      }
+
+      const attrName = data.substring(pos, eqPos);
+      pos = eqPos + 1;
+
+      // Read attribute value (quoted or unquoted)
+      let attrValue;
+      if (data[pos] === '"') {
+        pos++;
+        const closeQuote = data.indexOf('"', pos);
+        attrValue = closeQuote === -1 ?
+            data.substring(pos) : data.substring(pos, closeQuote);
+        pos = closeQuote === -1 ? data.length : closeQuote + 1;
+      } else {
+        const commaPos = data.indexOf(',', pos);
+        attrValue = commaPos === -1 ?
+            data.substring(pos) : data.substring(pos, commaPos);
+        pos = commaPos === -1 ? data.length : commaPos;
+      }
+
+      // Skip comma separator
+      if (pos < data.length && data[pos] === ',') {
+        pos++;
+      }
+
+      list.push(new shaka.hls.Attribute(attrName, attrValue));
+    }
+
+    return {value, list};
   }
 };
 


### PR DESCRIPTION
Replaces regex and TextParser with indexOf/substring in `ManifestTextParser.parseTag`

This is also done to reduce GC allocation per one tag by removing TextParser instance, regex spawns and result arrays. Mostly targeting older devices like Tizen 3-6, WebOS 4, Xbox One