### PR TITLE
fix: Avoid duplicate segment downloads during stream switching

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1762,6 +1762,45 @@ shaka.media.StreamingEngine = class {
     return mediaState.lastSegmentReference.endTime;
   }
 
+  /**
+   * Tries to avoid duplicate segment ref due to inaccuracy (if found)
+   * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
+   * @param {shaka.media.SegmentReference} ref
+   * @param {number} time
+   * @param {boolean} reverse
+   * @return {shaka.media.SegmentReference}
+   * @private
+   */
+  tryAvoidDuplicateSegmentRef_(mediaState, ref, time, reverse) {
+    const logPrefix = shaka.media.StreamingEngine.logPrefix_(mediaState);
+    const originalRef = ref;
+    const adjustedTime = time + 0.15;
+
+    // get segment iterator for adjusted time
+    mediaState.segmentIterator =
+        mediaState.stream.segmentIndex.getIteratorForTime(
+            adjustedTime, false, reverse);
+    ref = mediaState.segmentIterator &&
+        mediaState.segmentIterator.next().value;
+
+    if (ref != null && ref != originalRef) {
+      shaka.log.info(logPrefix,
+          'tryAvoidDuplicateSegmentRef_',
+          'ref was [', originalRef.startTime, '-', originalRef.endTime, ']',
+          'for', time,
+          'which is now [', ref.startTime, '-', ref.endTime, ']',
+          'for', adjustedTime);
+      return ref;
+    }
+
+    // if we are here, we wanted to find a segment for adjusted time but
+    // couldn't. This means we will possibly see AV sync issues,
+    // but we can only warn and return original segment ref
+    shaka.log.warning(logPrefix, 'tryAvoidDuplicateSegmentRef_',
+        'cannot find segment for drifted time', adjustedTime,
+        'High chances of AV sync issues.');
+    return originalRef;
+  }
 
   /**
    * Gets the SegmentReference of the next segment needed.
@@ -1780,6 +1819,7 @@ shaka.media.StreamingEngine = class {
         mediaState.stream.segmentIndex,
         'segment index should have been generated already');
 
+    const isDiffNegligible = (a, b, threshold) => Math.abs(a - b) < threshold;
     if (mediaState.segmentIterator) {
       // Something is buffered from the same Stream.  Use the current position
       // in the segment index.  This is updated via next() after each segment is
@@ -1789,9 +1829,8 @@ shaka.media.StreamingEngine = class {
         // In HLS sometimes the segment iterator adds or removes segments very
         // quickly, so we have to be sure that we do not add the last segment
         // again, tolerating a difference of 1ms.
-        const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
         const lastStartTime = mediaState.lastSegmentReference.startTime;
-        if (isDiffNegligible(lastStartTime, ref.startTime)) {
+        if (isDiffNegligible(lastStartTime, ref.startTime, 0.001)) {
           ref = mediaState.segmentIterator.next().value;
         }
       }
@@ -1811,10 +1850,22 @@ shaka.media.StreamingEngine = class {
             mediaState.stream.segmentIndex.getIteratorForTime(
                 time, /* allowNonIndependent= */ false, reverse);
       }
-      const ref = mediaState.segmentIterator &&
+      let ref = mediaState.segmentIterator &&
           mediaState.segmentIterator.next().value;
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment', 'endTime:', time);
+      }
+
+      // When we get segment ref using lastSegmentReference or bufferEnd,
+      // segmentIterator can return last segment reference due to:
+      // a) floating point rounding off error
+      // b) discontinuous segments
+      // which would lead to duplicate segment download.
+      // we try to avoid this by searching a segmentIterator with a drift of
+      // 150ms ahead in time, this prevents AV sync issues later.
+      if (ref != null &&
+          isDiffNegligible(ref.endTime, time, 0.15)) {
+        ref = this.tryAvoidDuplicateSegmentRef_(mediaState, ref, time, reverse);
       }
       return ref;
     } else {

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4214,6 +4214,39 @@ describe('StreamingEngine', () => {
     };
   }
 
+  describe('avoids duplicate segment downloads', () => {
+    it('skips segment within 150ms of lookup time', async () => {
+      setupVod();
+      mediaSourceEngine =
+          new shaka.test.FakeMediaSourceEngine(segmentData, 0);
+      createStreamingEngine();
+
+      // Start playback.
+      streamingEngine.switchVariant(variant);
+      streamingEngine.switchTextStream(textStream);
+      await streamingEngine.start();
+      playing = true;
+
+      // Simulate buffering the first segment (0-10s).
+      await runTest(() => {
+        if (presentationTimeInSeconds == 3) {
+          // After a few seconds, switch to the alternate variant to trigger
+          // the code path where segmentIterator is null and the engine
+          // looks up a segment by lastSegmentReference.endTime or bufferEnd.
+          streamingEngine.switchVariant(
+              alternateVariant, /* clearBuffer= */ true);
+        }
+      });
+
+      // The test passes if no errors occurred during the switch.
+      // The fix ensures that when the segment iterator returns a segment
+      // whose endTime is within 150ms of the lookup time (indicating a
+      // potential duplicate), it adjusts the time forward to find the
+      // next segment instead.
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
   /**
    * Create a valid segment index for |alternateStream| based on |baseStream|
    * segment index.


### PR DESCRIPTION
When the segment iterator is null (due to seek or variant switch), the streaming engine uses lastSegmentReference.endTime or bufferEnd to look up the next segment. Due to floating point rounding errors and segment discontinuities, the iterator can return the same segment reference again, causing duplicate downloads and AV sync issues.

Add tryAvoidDuplicateSegmentRef_ method that detects when the returned segment endTime is within 150ms of the lookup time (indicating a potential duplicate) and adjusts the lookup time forward to find the correct next segment. Also refactor isDiffNegligible to accept a configurable threshold parameter.