### PR TITLE
fix(HLS): Add support for DTS and DTS-HD audio codec variants

### DIFF
--- a/lib/util/manifest_parser_utils.js
+++ b/lib/util/manifest_parser_utils.js
@@ -328,7 +328,8 @@ shaka.util.ManifestParserUtils.AUDIO_CODEC_REGEXPS = [
   /^mp4a/,
   /^[ae]c-3$/,
   /^ac-4/,
-  /^dts[cex]$/, // DTS Digital Surround (dtsc), DTS Express (dtse), DTS:X (dtsx)
+  // DTS variants: dts, dtsc, dtse, dtsh, dtsx
+  /^dts[cehx]?$/,
   /^iamf/,
   /^mhm[12]/, // MPEG-H Audio LC
   /^ac3$/, // sometimes ac3 is used instead of ac-3

--- a/project-words.txt
+++ b/project-words.txt
@@ -248,6 +248,7 @@ buffersource
 cabac
 cbcs
 cdna
+cehx
 cenc
 certurl
 cicp
@@ -273,7 +274,9 @@ dref
 drms
 dtsc
 dtse
+dtsh
 dtsx
+dtsz
 dtvcc
 dvav
 dvcc

--- a/test/util/manifest_parser_utils_unit.js
+++ b/test/util/manifest_parser_utils_unit.js
@@ -25,6 +25,54 @@ describe('ManifestParserUtils', () => {
           'audio', ['mp2v']);
       expect(result).toBeNull();
     });
+
+    it('recognizes DTS audio codec', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dts']);
+      expect(result).toBe('dts');
+    });
+
+    it('recognizes DTS-HD (dtsh) audio codec', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dtsh']);
+      expect(result).toBe('dtsh');
+    });
+
+    it('recognizes DTS Digital Surround (dtsc)', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dtsc']);
+      expect(result).toBe('dtsc');
+    });
+
+    it('recognizes DTS Express (dtse)', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dtse']);
+      expect(result).toBe('dtse');
+    });
+
+    it('recognizes DTS:X (dtsx)', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dtsx']);
+      expect(result).toBe('dtsx');
+    });
+
+    it('returns DTS variant from mixed codec list', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['avc1.42E01E', 'dtsh']);
+      expect(result).toBe('dtsh');
+    });
+
+    it('does not match DTS codecs as video', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'video', ['dts']);
+      expect(result).toBeNull();
+    });
+
+    it('does not match invalid DTS-like strings', () => {
+      const result = ManifestParserUtils.guessCodecsSafe(
+          'audio', ['dtsz']);
+      expect(result).toBeNull();
+    });
   });
 
   describe('resolveUris', () => {


### PR DESCRIPTION
Add DTS (dts), DTS-HD (dtsh), DTS Digital Surround (dtsc), DTS Express (dtse), and DTS:X (dtsx) to AUDIO_CODEC_REGEXPS using a single merged regex /^dts[cehx]?$/.

Include regression tests for all new codec variants.