### PR TITLE
fix: Avoid duplicate segment downloads during stream switching

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1887,14 +1887,10 @@ shaka.media.StreamingEngine = class {
       // We try to avoid this by searching a
       // segmentIterator with a drift of 150ms ahead in
       // time, this prevents AV sync issues later.
-      const tolerance =
-          shaka.media.StreamingEngine
-              .SEGMENT_BOUNDARY_TOLERANCE_;
+      const tolerance = shaka.media.StreamingEngine.SEGMENT_BOUNDARY_TOLERANCE_;
       if (ref != null &&
-          shaka.util.NumberUtils.isFloatEqual(
-              ref.endTime, time, tolerance)) {
-        ref = this.resolveSegmentBoundaryRef_(
-            mediaState, ref, time, reverse);
+          shaka.util.NumberUtils.isFloatEqual(ref.endTime, time, tolerance)) {
+        ref = this.resolveSegmentBoundaryRef_(mediaState, ref, time, reverse);
       }
       return ref;
     } else {

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1777,6 +1777,52 @@ shaka.media.StreamingEngine = class {
 
 
   /**
+   * When the segment iterator returns a reference whose end time
+   * matches the lookup time (within tolerance), it is likely a
+   * duplicate of the segment that was just appended. This method
+   * resolves the ambiguity by re-querying the index at a slightly
+   * later time so the next segment is returned instead.
+   *
+   * @param {!shaka.media.StreamingEngine.MediaState_} mediaState
+   * @param {shaka.media.SegmentReference} ref
+   * @param {number} time
+   * @param {boolean} reverse
+   * @return {shaka.media.SegmentReference}
+   * @private
+   */
+  resolveSegmentBoundaryRef_(mediaState, ref, time, reverse) {
+    const logPrefix =
+        shaka.media.StreamingEngine.logPrefix_(mediaState);
+    const tolerance =
+        shaka.media.StreamingEngine.SEGMENT_BOUNDARY_TOLERANCE_;
+    const origRef = ref;
+    const adjustedTime = time + tolerance;
+
+    // Get segment iterator for adjusted time.
+    mediaState.segmentIterator =
+        mediaState.stream.segmentIndex.getIteratorForTime(
+            adjustedTime, false, reverse);
+    ref = mediaState.segmentIterator &&
+        mediaState.segmentIterator.next().value;
+
+    if (ref != null && ref != origRef) {
+      shaka.log.info(logPrefix, 'resolveSegmentBoundaryRef_',
+          'ref was [', origRef.startTime, '-', origRef.endTime,
+          '] for', time, 'which is now [', ref.startTime, '-',
+          ref.endTime, '] for', adjustedTime);
+      return ref;
+    }
+
+    shaka.log.warning(logPrefix,
+        'resolveSegmentBoundaryRef_',
+        'cannot find segment for drifted time',
+        adjustedTime,
+        'High chances of AV sync issues.');
+    return origRef;
+  }
+
+
+  /**
    * Gets the SegmentReference of the next segment needed.
    *
    * @param {shaka.media.StreamingEngine.MediaState_} mediaState
@@ -1826,10 +1872,29 @@ shaka.media.StreamingEngine = class {
             mediaState.stream.segmentIndex.getIteratorForTime(
                 time, /* allowNonIndependent= */ false, reverse);
       }
-      const ref = mediaState.segmentIterator &&
+      let ref = mediaState.segmentIterator &&
           mediaState.segmentIterator.next().value;
       if (ref == null) {
         shaka.log.warning(logPrefix, 'cannot find segment', 'endTime:', time);
+      }
+
+      // When we get segment ref using lastSegmentReference
+      // or bufferEnd, segmentIterator can return last
+      // segment reference due to:
+      // a) floating point rounding off error
+      // b) discontinuous segments
+      // which would lead to duplicate segment download.
+      // We try to avoid this by searching a
+      // segmentIterator with a drift of 150ms ahead in
+      // time, this prevents AV sync issues later.
+      const tolerance =
+          shaka.media.StreamingEngine
+              .SEGMENT_BOUNDARY_TOLERANCE_;
+      if (ref != null &&
+          shaka.util.NumberUtils.isFloatEqual(
+              ref.endTime, time, tolerance)) {
+        ref = this.resolveSegmentBoundaryRef_(
+            mediaState, ref, time, reverse);
       }
       return ref;
     } else {
@@ -3840,3 +3905,18 @@ shaka.media.StreamingEngine.CROSS_BOUNDARY_END_THRESHOLD_ = 1;
  * @private
  */
 shaka.media.StreamingEngine.LOOKUP_TIME_DURATION_THRESHOLD_ = 1;
+
+
+/**
+ * Tolerance in seconds used to detect and resolve segment boundary
+ * ambiguity.  When a stream switch causes the segment iterator to
+ * return a reference whose end time is within this tolerance of the
+ * lookup time, the reference is likely a duplicate of the segment
+ * that was just appended.  A small forward nudge of 150 ms is
+ * enough to land inside the next segment without risking A/V sync
+ * drift.
+ *
+ * @const {number}
+ * @private
+ */
+shaka.media.StreamingEngine.SEGMENT_BOUNDARY_TOLERANCE_ = 0.15;

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4497,9 +4497,6 @@ describe('StreamingEngine', () => {
     // iterator can return the last segment reference due to
     // floating point rounding or discontinuous segments.
     // The fix detects this and searches with a 150ms drift.
-
-    const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
-
     beforeEach(() => {
       manifest = shaka.test.ManifestGenerator.generate(
           (manifest) => {

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4491,4 +4491,132 @@ describe('StreamingEngine', () => {
           text: [true, true, true, true],
         });
       });
+
+  describe('avoid duplicate segment downloads', () => {
+    // Regression test: when switching streams, the segment
+    // iterator can return the last segment reference due to
+    // floating point rounding or discontinuous segments.
+    // The fix detects this and searches with a 150ms drift.
+
+    const segmentType = shaka.net.NetworkingEngine.RequestType.SEGMENT;
+
+    beforeEach(() => {
+      manifest = shaka.test.ManifestGenerator.generate(
+          (manifest) => {
+            manifest.presentationTimeline.setDuration(60);
+            manifest.addVariant(0, (variant) => {
+              variant.addAudio(10, (stream) => {
+                stream.useSegmentTemplate(
+                    'audio-10-%d.mp4', 10);
+              });
+              variant.addVideo(11, (stream) => {
+                stream.useSegmentTemplate(
+                    'video-11-%d.mp4', 10);
+              });
+            });
+            manifest.addVariant(1, (variant) => {
+              variant.addAudio(12, (stream) => {
+                stream.useSegmentTemplate(
+                    'audio-12-%d.mp4', 10);
+              });
+              variant.addVideo(13, (stream) => {
+                stream.useSegmentTemplate(
+                    'video-13-%d.mp4', 10);
+              });
+            });
+          });
+
+      netEngine = new shaka.test.FakeNetworkingEngine();
+      netEngine.setDefaultValue(new ArrayBuffer(0));
+
+      mediaSourceEngine =
+          new shaka.test.FakeMediaSourceEngine({});
+      const bufferEnd = {audio: 0, video: 0};
+      mediaSourceEngine.clear.and.callFake((type) => {
+        bufferEnd[type] = 0;
+        return Promise.resolve();
+      });
+      mediaSourceEngine.bufferedAheadOf.and.returnValue(0);
+      mediaSourceEngine.bufferStart.and.returnValue(0);
+      mediaSourceEngine.setStreamProperties.and.returnValue(
+          Promise.resolve());
+      mediaSourceEngine.remove.and.returnValue(
+          Promise.resolve());
+
+      mediaSourceEngine.appendBuffer.and.callFake(
+          (type, data, reference) => {
+            bufferEnd[type] =
+                reference && reference.endTime;
+            return Promise.resolve();
+          });
+      mediaSourceEngine.bufferEnd.and.callFake((type) => {
+        return bufferEnd[type];
+      });
+      mediaSourceEngine.bufferedAheadOf.and.callFake(
+          (type, start) => {
+            return Math.max(0, bufferEnd[type] - start);
+          });
+      mediaSourceEngine.isBuffered.and.callFake(
+          (type, time) => {
+            return time >= 0 && time < bufferEnd[type];
+          });
+
+      playing = false;
+      presentationTimeInSeconds = 0;
+      createStreamingEngine();
+    });
+
+    it('does not re-fetch segments after switch', async () => {
+      const initialVariant = manifest.variants[0];
+      const newVariant = manifest.variants[1];
+
+      streamingEngine.switchVariant(initialVariant);
+      await streamingEngine.start();
+      playing = true;
+
+      // Let some segments buffer from the initial variant.
+      await Util.fakeEventLoop(3);
+
+      // Switch variant mid-playback. This nulls the
+      // segmentIterator for the new stream, triggering
+      // the else-if branch in getSegmentReferenceNeeded_.
+      streamingEngine.switchVariant(
+          newVariant, /* clearBuffer= */ true);
+
+      // Let the engine process the switch and buffer.
+      await Util.fakeEventLoop(5);
+
+      // Collect all segment URIs requested across the
+      // entire test run.
+      const segmentType =
+          shaka.net.NetworkingEngine.RequestType.SEGMENT;
+      const requestedUris =
+          netEngine.request.calls.all()
+              .filter((c) => c.args[0] === segmentType)
+              .map((c) => c.args[1].uris[0]);
+
+      // Each segment URI should appear at most once —
+      // no duplicate downloads.
+      const seen = new Set();
+      for (const uri of requestedUris) {
+        expect(seen.has(uri))
+            .withContext(`duplicate request: ${uri}`)
+            .toBe(false);
+        seen.add(uri);
+      }
+
+      // Verify the new variant's segments were actually
+      // requested (the fix didn't suppress all fetches).
+      const hasNewAudio = requestedUris.some(
+          (u) => u.startsWith('audio-12-'));
+      const hasNewVideo = requestedUris.some(
+          (u) => u.startsWith('video-13-'));
+      expect(hasNewAudio)
+          .withContext('new audio segments requested')
+          .toBe(true);
+      expect(hasNewVideo)
+          .withContext('new video segments requested')
+          .toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
When segment iterator is null (due to seek or variant switch), the streaming engine relies on lastSegmentReference or bufferEnd to get the right segment iterator and segment reference. Due to floating point rounding errors and segment discontinuities, the engine can end up fetching the same segment reference again, causing AV sync issues (off by one segment duration).

This fix detects when the returned segment reference ends at approximately the same time as the lookup time (within 150ms tolerance) and searches ahead with a small drift to find the correct next segment, preventing duplicate downloads.

Also replaces inline isDiffNegligible lambda with
shaka.util.NumberUtils.isFloatEqual for consistency with the codebase's existing float comparison utility.