### PR TITLE
fix: Increase tolerance for duplicate segment detection

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -37,6 +37,7 @@ goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.MimeUtils');
 goog.require('shaka.util.Mp4BoxParsers');
 goog.require('shaka.util.Mp4Parser');
+goog.require('shaka.util.NumberUtils');
 goog.require('shaka.util.Timer');
 goog.require('shaka.util.Uint8ArrayUtils');
 
@@ -1800,12 +1801,16 @@ shaka.media.StreamingEngine = class {
       if (ref && mediaState.lastSegmentReference) {
         // In HLS sometimes the segment iterator adds or removes segments very
         // quickly, so we have to be sure that we do not add the last segment
-        // again, tolerating a difference of 1ms.
-        const isDiffNegligible = (a, b) => Math.abs(a - b) < 0.001;
-        const lastStartTime = mediaState.lastSegmentReference.startTime;
-        const lastEndTime = mediaState.lastSegmentReference.endTime;
-        if (isDiffNegligible(lastStartTime, ref.startTime) &&
-            isDiffNegligible(lastEndTime, ref.endTime)) {
+        // again, tolerating a difference of 2ms.
+        const NumberUtils = shaka.util.NumberUtils;
+        const lastStartTime =
+            mediaState.lastSegmentReference.startTime;
+        const lastEndTime =
+            mediaState.lastSegmentReference.endTime;
+        if (NumberUtils.isFloatEqual(
+            lastStartTime, ref.startTime, 0.002) &&
+            NumberUtils.isFloatEqual(
+                lastEndTime, ref.endTime, 0.002)) {
           ref = mediaState.segmentIterator.next().value;
         }
       }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1806,8 +1806,7 @@ shaka.media.StreamingEngine = class {
         const lastStartTime = mediaState.lastSegmentReference.startTime;
         const lastEndTime = mediaState.lastSegmentReference.endTime;
         if (NumberUtils.isFloatEqual(lastStartTime, ref.startTime, 0.002) &&
-            NumberUtils.isFloatEqual(
-                lastEndTime, ref.endTime, 0.002)) {
+            NumberUtils.isFloatEqual(lastEndTime, ref.endTime, 0.002)) {
           ref = mediaState.segmentIterator.next().value;
         }
       }

--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1803,12 +1803,9 @@ shaka.media.StreamingEngine = class {
         // quickly, so we have to be sure that we do not add the last segment
         // again, tolerating a difference of 2ms.
         const NumberUtils = shaka.util.NumberUtils;
-        const lastStartTime =
-            mediaState.lastSegmentReference.startTime;
-        const lastEndTime =
-            mediaState.lastSegmentReference.endTime;
-        if (NumberUtils.isFloatEqual(
-            lastStartTime, ref.startTime, 0.002) &&
+        const lastStartTime = mediaState.lastSegmentReference.startTime;
+        const lastEndTime = mediaState.lastSegmentReference.endTime;
+        if (NumberUtils.isFloatEqual(lastStartTime, ref.startTime, 0.002) &&
             NumberUtils.isFloatEqual(
                 lastEndTime, ref.endTime, 0.002)) {
           ref = mediaState.segmentIterator.next().value;

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4425,4 +4425,70 @@ describe('StreamingEngine', () => {
       return Promise.resolve();
     });
   }
+
+  // Regression test: the duplicate segment detection tolerance should be
+  // 2ms, not 1ms.  Some HLS streams have segment iterator timing
+  // inaccuracies between 1ms and 2ms that cause the same segment to be
+  // re-downloaded, leading to AV sync issues.
+  it('tolerates up to 2ms difference in duplicate segment detection',
+      async () => {
+        setupVod();
+        mediaSourceEngine =
+            new shaka.test.FakeMediaSourceEngine(segmentData);
+        createStreamingEngine();
+
+        // After the first video segment is fetched, modify the segment
+        // index so that position 0 returns a reference with startTime
+        // shifted by 1.5ms.  This simulates an HLS segment list update
+        // where the same logical segment reappears with a slightly
+        // different start time due to floating-point inaccuracy.
+        let firstVideoSegmentAppended = false;
+        onSegmentAppended.and.callFake(
+            (start, end, contentType) => {
+              if (contentType === ContentType.VIDEO &&
+                  !firstVideoSegmentAppended) {
+                firstVideoSegmentAppended = true;
+
+                // Monkey-patch the video segment index's get() so
+                // that position 0 now returns a near-duplicate ref
+                // (startTime shifted by 1.5ms).
+                const idx = videoStream.segmentIndex;
+                const origGet = idx.get;
+                idx.get = (pos) => {
+                  // eslint-disable-next-line no-restricted-syntax
+                  const seg = origGet.call(idx, pos);
+                  if (seg && pos === 0) {
+                    return new shaka.media.SegmentReference(
+                        seg.startTime + 0.0015,
+                        seg.endTime + 0.0015,
+                        seg.getUrisInner,
+                        /* startByte= */ 0,
+                        /* endByte= */ null,
+                        seg.initSegmentReference,
+                        seg.timestampOffset,
+                        seg.appendWindowStart,
+                        seg.appendWindowEnd,
+                    );
+                  }
+                  return seg;
+                };
+              }
+            });
+
+        streamingEngine.switchVariant(variant);
+        streamingEngine.switchTextStream(textStream);
+        await streamingEngine.start();
+        playing = true;
+
+        await runTest();
+
+        // With 2ms tolerance the shifted segment (1.5ms diff) is
+        // detected as a duplicate and skipped.  All four segments
+        // should still be buffered normally.
+        expect(mediaSourceEngine.segments).toEqual({
+          audio: [true, true, true, true],
+          video: [true, true, true, true],
+          text: [true, true, true, true],
+        });
+      });
 });


### PR DESCRIPTION
In HLS, the segment iterator can add or remove segments rapidly, causing the same segment to reappear with a slightly different start time. The existing duplicate detection used a 1ms tolerance, but some streams exhibit timing inaccuracies between 1ms and 2ms, causing the same segment to be downloaded twice. This leads to AV sync issues because the duplicate segment shifts the buffer by one segment duration.

Increase the tolerance from 1ms to 2ms to cover these cases.