### PR TITLE
fix: Call endOfStream when no data available close to duration

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1651,6 +1651,29 @@ shaka.media.StreamingEngine = class {
     const reference = this.getSegmentReferenceNeeded_(
         mediaState, presentationTime, bufferEnd);
     if (!reference) {
+      // When close to end but no buffer exists and no segment
+      // reference found, mark as end of stream instead of
+      // retrying indefinitely. Only for static content.
+      if (!this.manifest_.presentationTimeline.isDynamic() &&
+          timeUntilEnd < oneMicrosecond) {
+        shaka.log.info(logPrefix,
+            'Close to end with no buffer and no segment reference.',
+            'Marking as end of stream.');
+        mediaState.endOfStream = true;
+
+        if (mediaState.type == ContentType.VIDEO) {
+          // Since the text stream of CEA closed captions doesn't have update
+          // timer, we have to set the text endOfStream based on the video
+          // stream's endOfStream state.
+          const textState = this.mediaStates_.get(ContentType.TEXT);
+          if (textState &&
+              shaka.media.StreamingEngine.isEmbeddedText_(textState)) {
+            textState.endOfStream = true;
+          }
+        }
+        return null;
+      }
+
       // The segment could not be found, does not exist, or is not available.
       // In any case just try again... if the manifest is incomplete or is not
       // being updated then we'll idle forever; otherwise, we'll end up getting

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -970,6 +970,49 @@ describe('StreamingEngine', () => {
     netEngine.expectNoRequest('1_text_3', segmentType, segmentContext);
   });
 
+  // Regression test: when playback is near the end of the presentation and
+  // no segment reference is available, endOfStream should be called instead
+  // of retrying indefinitely.
+  it('calls endOfStream when close to duration with no segment', async () => {
+    setupVod();
+    mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
+    createStreamingEngine();
+
+    // Here we go!
+    streamingEngine.switchVariant(variant);
+    streamingEngine.switchTextStream(textStream);
+    await streamingEngine.start();
+    playing = true;
+
+    // Let the streaming engine buffer some content first.
+    await runTest(() => {
+      // Once we've buffered a bit, jump the presentation time to just
+      // before the end of the presentation and make the segment index
+      // return null for all future lookups.
+      if (presentationTimeInSeconds >= 5) {
+        // Set time to be within 1 microsecond of the duration (40s).
+        presentationTimeInSeconds = 39.9999999;
+        playing = false;
+
+        // Override the segment index to return null, simulating no
+        // available segment reference near the end.
+        for (const stream of [audioStream, videoStream, textStream]) {
+          if (stream.segmentIndex) {
+            stream.segmentIndex.getIteratorForTime = () => {
+              const iterator = {
+                current: () => null,
+                next: () => ({value: null, done: true}),
+              };
+              return iterator;
+            };
+          }
+        }
+      }
+    });
+
+    expect(mediaSourceEngine.endOfStream).toHaveBeenCalled();
+  });
+
   it('does not buffer one media type ahead of another', async () => {
     setupVod();
     mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);


### PR DESCRIPTION
When playback reaches near the end of the presentation but no buffer exists and no segment reference is found, the player continuously retries without properly detecting end-of-stream, preventing the ended event from firing.

When close to end (timeUntilEnd < oneMicrosecond) with no buffer and no segment reference, immediately mark as end-of-stream instead of retrying indefinitely. Also propagate the endOfStream state to embedded CEA text streams when the video stream reaches end.