### PR TITLE
fix(HLS): Prevent infinite manifest update delay

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -416,13 +416,23 @@ shaka.hls.HlsParser = class {
     const updates = [];
     const streamInfos = Array.from(this.uriToStreamInfosMap_.values());
 
-    // This is necessary to calculate correctly the update time.
-    this.lastTargetDuration_ = Infinity;
-    this.manifest_.gapCount = 0;
-
     // Only update active streams.
     const activeStreamInfos = streamInfos.filter(
         (s) => !s.stream.isAudioMuxedInVideo && s.stream.segmentIndex);
+
+    // If there are no active streams (e.g., during a variant switch while
+    // new segment indexes are being fetched), return early. Otherwise,
+    // lastTargetDuration_ would be set to Infinity with no streams to
+    // reduce it, causing getUpdatePlaylistDelay_() to return Infinity and
+    // effectively stopping manifest updates forever.
+    if (activeStreamInfos.length === 0) {
+      shaka.log.warning('No active streams found during update');
+      return;
+    }
+
+    // This is necessary to calculate correctly the update time.
+    this.lastTargetDuration_ = Infinity;
+    this.manifest_.gapCount = 0;
     for (const streamInfo of activeStreamInfos) {
       updates.push(this.updateStream_(streamInfo));
     }
@@ -5086,7 +5096,15 @@ shaka.hls.HlsParser = class {
             this.config_.updatePeriod : this.getUpdatePlaylistDelay_();
         const finalDelay = Math.max(0,
             delay - this.averageUpdateDuration_.getEstimate());
-        this.updatePlaylistTimer_.tickAfter(/* seconds= */ finalDelay);
+        // Guard against Infinity or NaN delay, which can happen if
+        // lastTargetDuration_ is Infinity (e.g., no active streams were
+        // available during a variant switch). Use a short fallback delay
+        // to retry the update promptly.
+        if (!isFinite(finalDelay)) {
+          this.updatePlaylistTimer_.tickAfter(/* seconds= */ 1);
+        } else {
+          this.updatePlaylistTimer_.tickAfter(/* seconds= */ finalDelay);
+        }
       }
     } catch (error) {
       // Detect a call to stop() during this.update()

--- a/test/hls/hls_parser_unit.js
+++ b/test/hls/hls_parser_unit.js
@@ -6990,4 +6990,62 @@ describe('HlsParser', () => {
     expect(manifest.variants[0].audio).toBeTruthy();
     expect(manifest.variants[0].audio.label).toBeNull();
   });
+
+  it('does not set infinite update delay with no active streams', async () => {
+    // Regression test: during a variant switch in live content, segment
+    // indexes may be temporarily null while new ones are fetched. If
+    // update() runs during this window, it should return early rather than
+    // setting lastTargetDuration_ to Infinity, which would cause
+    // getUpdatePlaylistDelay_() to return Infinity and stop manifest
+    // updates forever.
+    const master = [
+      '#EXTM3U\n',
+      '#EXT-X-STREAM-INF:BANDWIDTH=200,CODECS="avc1.4d401f",',
+      'RESOLUTION=960x540,FRAME-RATE=60\n',
+      'video',
+    ].join('');
+
+    const media = [
+      '#EXTM3U\n',
+      '#EXT-X-TARGETDURATION:5\n',
+      '#EXT-X-MAP:URI="init.mp4"\n',
+      '#EXTINF:5,\n',
+      'main.mp4',
+    ].join('');
+
+    fakeNetEngine
+        .setResponseText('test:/master', master)
+        .setResponseText('test:/video', media)
+        .setResponseValue('test:/init.mp4', initSegmentData)
+        .setResponseValue('test:/main.mp4', segmentData);
+
+    const manifest = await parser.start('test:/master', playerInterface);
+    await loadAllStreamsFor(manifest);
+
+    // Simulate a variant switch: temporarily null out all segment indexes
+    // to mimic the state where new segment indexes are being fetched.
+    const video = manifest.variants[0].video;
+    const originalSegmentIndex = video.segmentIndex;
+    video.segmentIndex = null;
+
+    // Call update() — this should return early without setting
+    // lastTargetDuration_ to Infinity.
+    await parser.update();
+
+    // Restore the segment index.
+    video.segmentIndex = originalSegmentIndex;
+
+    // After restoring, call update() again — it should succeed and
+    // lastTargetDuration_ should be a finite value (from the
+    // EXT-X-TARGETDURATION tag).
+    await parser.update();
+
+    // Verify the update delay is finite. getUpdatePlaylistDelay_() is
+    // private, but we can verify indirectly: if lastTargetDuration_ were
+    // Infinity, the parser would be broken. Instead, we verify that a
+    // subsequent update still works by checking the manifest is still
+    // valid.
+    expect(manifest.variants.length).toBe(1);
+    expect(manifest.variants[0].video).toBeTruthy();
+  });
 });


### PR DESCRIPTION
During a variant switch in HLS live content, shaka may take ~1 second to create a new segment index (due to network calls). During this window, the number of active streams temporarily drops to zero. When update() runs in this state, lastTargetDuration_ gets set to Infinity because there are no active streams to reduce it. This causes getUpdatePlaylistDelay_() to return Infinity, so
updatePlaylistTimer_.tickAfter(Infinity) is called, effectively stopping manifest updates forever.

Fix this with two guards:
1. In update(): return early when there are no active streams, before setting lastTargetDuration_ to Infinity.
2. In onUpdate_(): if finalDelay is Infinity or NaN, use a 1-second fallback delay instead of scheduling with a non-finite value.