### PR TITLE
perf(VTT): reduce GC pressure in VTT text parser

### DIFF
--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -203,7 +203,7 @@ shaka.text.VttTextParser = class {
     }
 
     // Skip comment blocks.
-    if (/^NOTE($|[ \t])/.test(text[0])) {
+    if (shaka.text.VttTextParser.REGEX_NOTE_.test(text[0])) {
       return;
     }
 
@@ -353,7 +353,7 @@ shaka.text.VttTextParser = class {
     }
 
     // Skip comment blocks.
-    if (/^NOTE($|[ \t])/.test(text[0])) {
+    if (shaka.text.VttTextParser.REGEX_NOTE_.test(text[0])) {
       return null;
     }
 
@@ -363,13 +363,14 @@ shaka.text.VttTextParser = class {
     }
 
     let id = null;
+    let lineIndex = 0;
     if (!text[0].includes('-->')) {
       id = text[0];
-      text.splice(0, 1);
+      lineIndex = 1;
     }
 
     // Parse the times.
-    const parser = new shaka.util.TextParser(text[0]);
+    const parser = new shaka.util.TextParser(text[lineIndex]);
     let start = parser.parseTime();
     const expect = parser.readRegex(/[ \t]+-->[ \t]+/g);
     let end = parser.parseTime();
@@ -388,7 +389,14 @@ shaka.text.VttTextParser = class {
     }
 
     // Get the payload.
-    const payload = text.slice(1).join('\n').trim();
+    let payload = '';
+    for (let i = lineIndex + 1; i < text.length; i++) {
+      if (i > lineIndex + 1) {
+        payload += '\n';
+      }
+      payload += text[i];
+    }
+    payload = payload.trim();
 
     let cue = null;
     if (styles.has('global')) {
@@ -432,21 +440,18 @@ shaka.text.VttTextParser = class {
   static parseCueSetting(cue, word, regions) {
     const VttTextParser = shaka.text.VttTextParser;
     let results = null;
-    if ((results = /^align:(start|middle|center|end|left|right)$/.exec(word))) {
+    if ((results = VttTextParser.REGEX_ALIGN_.exec(word))) {
       VttTextParser.setTextAlign_(cue, results[1]);
-    } else if ((results = /^vertical:(lr|rl)$/.exec(word))) {
+    } else if ((results = VttTextParser.REGEX_VERTICAL_.exec(word))) {
       VttTextParser.setVerticalWritingMode_(cue, results[1]);
-    } else if ((results = /^size:([\d.]+)%$/.exec(word))) {
+    } else if ((results = VttTextParser.REGEX_SIZE_.exec(word))) {
       cue.size = Number(results[1]);
-    } else if ((results =
-        // eslint-disable-next-line @stylistic/max-len
-        /^position:([\d.]+)%(?:,(line-left|line-right|middle|center|start|end|auto))?$/
-            .exec(word))) {
+    } else if ((results = VttTextParser.REGEX_POSITION_.exec(word))) {
       cue.position = Number(results[1]);
       if (results[2]) {
         VttTextParser.setPositionAlign_(cue, results[2]);
       }
-    } else if ((results = /^region:(.*)$/.exec(word))) {
+    } else if ((results = VttTextParser.REGEX_REGION_.exec(word))) {
       const region = VttTextParser.getRegionById_(regions, results[1]);
       if (region) {
         cue.region = region;
@@ -574,7 +579,7 @@ shaka.text.VttTextParser = class {
   static parsedLineValueAndInterpretation_(cue, word) {
     const Cue = shaka.text.Cue;
     let results = null;
-    if ((results = /^line:([\d.]+)%(?:,(start|end|center))?$/.exec(word))) {
+    if ((results = shaka.text.VttTextParser.REGEX_LINE_PCT_.exec(word))) {
       cue.lineInterpretation = Cue.lineInterpretation.PERCENTAGE;
       cue.line = Number(results[1]);
       if (results[2]) {
@@ -584,7 +589,7 @@ shaka.text.VttTextParser = class {
         cue.lineAlign = Cue.lineAlign[results[2].toUpperCase()];
       }
     } else if ((results =
-                    /^line:(-?\d+)(?:,(start|end|center))?$/.exec(word))) {
+                    shaka.text.VttTextParser.REGEX_LINE_NUM_.exec(word))) {
       cue.lineInterpretation = Cue.lineInterpretation.LINE_NUMBER;
       cue.line = Number(results[1]);
       if (results[2]) {
@@ -613,6 +618,35 @@ shaka.text.VttTextParser.MPEG_TIMESCALE_ = 90000;
  * @private
  */
 shaka.text.VttTextParser.TS_ROLLOVER_ = 0x200000000;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_NOTE_ = /^NOTE($|[ \t])/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_ALIGN_ =
+    /^align:(start|middle|center|end|left|right)$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_VERTICAL_ = /^vertical:(lr|rl)$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_SIZE_ = /^size:([\d.]+)%$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_POSITION_ =
+    // eslint-disable-next-line @stylistic/max-len
+    /^position:([\d.]+)%(?:,(line-left|line-right|middle|center|start|end|auto))?$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_REGION_ = /^region:(.*)$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_LINE_PCT_ =
+    /^line:([\d.]+)%(?:,(start|end|center))?$/;
+
+/** @private @const {!RegExp} */
+shaka.text.VttTextParser.REGEX_LINE_NUM_ =
+    /^line:(-?\d+)(?:,(start|end|center))?$/;
 
 shaka.text.TextEngine.registerParser(
     'text/vtt', () => new shaka.text.VttTextParser());


### PR DESCRIPTION
This PR:

replaces `splice` with an index variable to avoid array shifts on every cue parse
replaces `slice(1).join('\n')` with a manual loop to eliminate two intermediate allocations per cue  
hoists inline regex literals to static class constants, fixing unreliable literal caching in older Chromium version (helps TV devices and Xbox)