### PR TITLE
perf(DASH): drop array operations on unique IDs when parsing periods

### DIFF
--- a/lib/dash/dash_parser.js
+++ b/lib/dash/dash_parser.js
@@ -1694,16 +1694,17 @@ shaka.dash.DashParser = class {
     // For dynamic manifests, we use rep IDs internally, and they must be
     // unique.
     if (context.dynamic) {
-      const ids = [];
-      for (const set of adaptationSets) {
-        for (const id of set.representationIds) {
-          ids.push(id);
+      const uniqueIds = new Set();
+      let totalIds = 0;
+      for (let i = 0; i < adaptationSets.length; i++) {
+        const repIds = adaptationSets[i].representationIds;
+        for (let j = 0; j < repIds.length; j++) {
+          uniqueIds.add(repIds[j]);
+          totalIds++;
         }
       }
 
-      const uniqueIds = new Set(ids);
-
-      if (ids.length != uniqueIds.size) {
+      if (totalIds != uniqueIds.size) {
         throw new shaka.util.Error(
             shaka.util.Error.Severity.CRITICAL,
             shaka.util.Error.Category.MANIFEST,
@@ -1720,38 +1721,60 @@ shaka.dash.DashParser = class {
     }
 
     if (dependencyStreamMap.size) {
-      let duplicateAdaptationSets = null;
-      for (const adaptationSet of adaptationSets) {
-        const streamsWithDependencyStream = [];
-        for (const stream of adaptationSet.streams) {
-          if (dependencyStreamMap.has(stream.originalId)) {
-            if (!duplicateAdaptationSets) {
-              const originalContextName = context.name;
-              context.name = 'dependencyStream';
-              duplicateAdaptationSets =
-                  TXml.findChildren(periodInfo.node, 'AdaptationSet')
-                      .map((node, position) =>
-                        this.parseAdaptationSet_(context, position, node))
-                      .filter(Functional.isNotNull);
-              context.name = originalContextName;
+      // Collect which AdaptationSet indices contain streams that need
+      // dependency-stream clones so we only re-parse those specific sets.
+      /** @type {!Map<number, !Array<string>>} */
+      const setsNeedingReparse = new Map();
+      for (let i = 0; i < adaptationSets.length; i++) {
+        const streams = adaptationSets[i].streams;
+        for (let j = 0; j < streams.length; j++) {
+          if (dependencyStreamMap.has(streams[j].originalId)) {
+            if (!setsNeedingReparse.has(i)) {
+              setsNeedingReparse.set(i, []);
             }
-            for (const duplicateAdaptationSet of duplicateAdaptationSets) {
-              const newStream = duplicateAdaptationSet.streams.find(
-                  (s) => s.originalId == stream.originalId);
-              if (newStream) {
-                newStream.dependencyStream =
-                    dependencyStreamMap.get(newStream.originalId);
-                newStream.originalId += newStream.dependencyStream.originalId;
-                newStream.baseOriginalId =
-                    newStream.dependencyStream.baseOriginalId;
-                streamsWithDependencyStream.push(newStream);
-              }
-            }
+            setsNeedingReparse.get(i).push(streams[j].originalId);
           }
         }
-        if (streamsWithDependencyStream.length) {
-          adaptationSet.streams.push(...streamsWithDependencyStream);
-        }
+      }
+
+      if (setsNeedingReparse.size) {
+        const adaptationSetNodes =
+            TXml.findChildren(periodInfo.node, 'AdaptationSet');
+        const originalContextName = context.name;
+        context.name = 'dependencyStream';
+
+        setsNeedingReparse.forEach((originalIds, setIndex) => {
+          const asNode = adaptationSetNodes[setIndex];
+          if (!asNode) {
+            return;
+          }
+          const duplicateSet =
+              this.parseAdaptationSet_(context, setIndex, asNode);
+          if (!duplicateSet) {
+            return;
+          }
+          const streamsWithDependencyStream = [];
+          for (let k = 0; k < originalIds.length; k++) {
+            const origId = originalIds[k];
+            const newStream = duplicateSet.streams.find(
+                (s) => s.originalId == origId);
+            if (newStream) {
+              const depStream =
+                  dependencyStreamMap.get(newStream.originalId || '');
+              newStream.dependencyStream = depStream;
+              newStream.originalId += depStream.originalId;
+              newStream.baseOriginalId =
+                  depStream.baseOriginalId;
+              streamsWithDependencyStream.push(newStream);
+            }
+          }
+          if (streamsWithDependencyStream.length) {
+            adaptationSets[setIndex].streams.push(
+                ...streamsWithDependencyStream);
+          }
+        });
+
+        context.name = originalContextName;
       }
     }
 


### PR DESCRIPTION
Two targeted performance improvements in aimed at reducing overhead on older devices

1. Avoid intermediate array for representation ID uniqueness check

Previously, all representation IDs were pushed into a temporary ids[] array, then a Set  - this PR eliminates the array allocation entirely.

2. Re-parse only affected AdaptationSets for dependency streams

Previously, when any stream had a dependency stream, every AdaptationSet was re-parsed from XML. Now, only the specific AdaptationSet nodes that contain streams with dependencies are re-parsed. This avoids redundant XML traversal and parsing for the common case where most adaptation sets have no dependency streams.