### PR TITLE
perf(net): avoid array allocations in XHR header parsing to reduce GC pressure

### DIFF
--- a/lib/net/http_xhr_plugin.js
+++ b/lib/net/http_xhr_plugin.js
@@ -144,9 +144,12 @@ shaka.net.HttpXHRPlugin = class {
     const headerLines = xhr.getAllResponseHeaders().trim().split('\r\n');
     const headers = {};
     for (const header of headerLines) {
-      /** @type {!Array<string>} */
-      const parts = header.split(': ');
-      headers[parts[0].toLowerCase()] = parts.slice(1).join(': ');
+      // use +2 to skip past the ': ' separator.
+      const separatorIndex = header.indexOf(': ');
+      if (separatorIndex !== -1) {
+        headers[header.slice(0, separatorIndex).toLowerCase()] =
+            header.slice(separatorIndex + 2);
+      }
     }
     return headers;
   }


### PR DESCRIPTION
This PR reduces GC pressure in the XHR networking plugin by dropping array creation in the header loop - again adding some help to lower-end hardware