### PR TITLE
chore(streaming): iterate on Map directly

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1689,8 +1689,7 @@ shaka.media.StreamingEngine = class {
 
     // Do not let any one stream get far ahead of any other.
     let minTimeNeeded = Infinity;
-    const mediaStates = Array.from(this.mediaStates_.values());
-    for (const otherState of mediaStates) {
+    for (const otherState of this.mediaStates_.values()) {
       // Do not consider embedded captions or muxed audio in this calculation.
       // It could lead to hangs in streaming.
       if (shaka.media.StreamingEngine.isEmbeddedText_(otherState) ||
@@ -2304,10 +2303,13 @@ shaka.media.StreamingEngine = class {
     // which caused the first QuotaExceededError recovers. Doing this ensures
     // we don't reduce the buffering goals too quickly.
 
-    const mediaStates = Array.from(this.mediaStates_.values());
-    const waitingForAnotherStreamToRecover = mediaStates.some((ms) => {
-      return ms != mediaState && ms.recovering;
-    });
+    let waitingForAnotherStreamToRecover = false;
+    for (const ms of this.mediaStates_.values()) {
+      if (ms != mediaState && ms.recovering) {
+        waitingForAnotherStreamToRecover = true;
+        break;
+      }
+    }
 
     if (!waitingForAnotherStreamToRecover) {
       if (this.config_.avoidEvictionOnQuotaExceededError) {


### PR DESCRIPTION
This PR removes the array creation as there is no need to swap the data structure - could be iterated on directly in both cases