### PR TITLE
perf(media): replace filter calls in SegmentIndex with binary search

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -11,6 +11,7 @@ goog.provide('shaka.media.SegmentIterator');
 goog.require('goog.asserts');
 goog.require('shaka.log');
 goog.require('shaka.media.SegmentReference');
+goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.Timer');
 
@@ -235,9 +236,15 @@ shaka.media.SegmentIndex = class {
     // Use times rounded to the millisecond for filtering purposes, so that
     // tiny rounding errors will not result in duplicate segments in the index.
     const firstStartTime = Math.round(references[0].startTime * 1000) / 1000;
-    this.references = this.references.filter((r) => {
-      return (Math.round(r.startTime * 1000) / 1000) < firstStartTime;
-    });
+
+    // Find the first existing reference
+    // whose rounded startTime >= firstStartTime.
+    // Everything at or after that index is replaced by the incoming references.
+    const lo = shaka.util.ArrayUtils.binarySearch(this.references,
+        (r) => Math.round(r.startTime * 1000) / 1000 < firstStartTime);
+    if (lo < this.references.length) {
+      this.references = this.references.slice(0, lo);
+    }
 
     this.references.push(...references);
 
@@ -262,13 +269,22 @@ shaka.media.SegmentIndex = class {
    * @export
    */
   mergeAndEvict(references, windowStart) {
-    // Filter out the references that are no longer available to avoid
-    // repeatedly evicting them and messing up eviction count.
-    references = references.filter((r) => {
-      return r.endTime > windowStart &&
-          (this.references.length == 0 ||
-           r.endTime > this.references[0].startTime);
-    });
+    // Skip references that are no longer available to avoid repeatedly evicting
+    // them and messing up eviction count.  References are sorted ascending, so
+    // invalid refs are always at the front — scan until the first valid one.
+    const existingStart =
+        this.references.length > 0 ? this.references[0].startTime : -Infinity;
+    let firstValid = 0;
+    while (firstValid < references.length) {
+      const r = references[firstValid];
+      if (r.endTime > windowStart && r.endTime > existingStart) {
+        break;
+      }
+      firstValid++;
+    }
+    if (firstValid > 0) {
+      references = references.slice(firstValid);
+    }
 
     const oldFirstRef = this.references[0];
     this.merge(references);
@@ -297,15 +313,14 @@ shaka.media.SegmentIndex = class {
       return;
     }
 
-    const oldSize = this.references.length;
-
-    this.references = this.references.filter((ref) => ref.endTime > time);
-
-    const newSize = this.references.length;
-    const diff = oldSize - newSize;
-    // Tracking the number of evicted refs will keep their "positions" stable
-    // for the caller.
-    this.numEvicted_ += diff;
+    // Find the first reference with endTime > time; everything before it is
+    // expired.  Tracking the eviction count keeps positions stable for callers.
+    const lo = shaka.util.ArrayUtils.binarySearch(
+        this.references, (r) => r.endTime <= time);
+    if (lo > 0) {
+      this.numEvicted_ += lo;
+      this.references = this.references.slice(lo);
+    }
   }
 
 

--- a/lib/util/array_utils.js
+++ b/lib/util/array_utils.js
@@ -121,6 +121,32 @@ shaka.util.ArrayUtils = class {
 
 
   /**
+   * Returns the index of the first element for which `predicate` returns
+   * false.  Assumes the array is partitioned so that predicate returns true
+   * for a contiguous prefix followed by all-false (i.e. a standard
+   * lower-bound / partition-point binary search).
+   *
+   * @param {!Array<T>} array
+   * @param {function(T):boolean} predicate
+   * @return {number}
+   * @template T
+   */
+  static binarySearch(array, predicate) {
+    let lo = 0;
+    let hi = array.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (predicate(array[mid])) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
+  }
+
+
+  /**
    * Determines if the given arrays contain equal elements in the same order.
    *
    * @param {Array<T>} a

--- a/test/util/array_utils_unit.js
+++ b/test/util/array_utils_unit.js
@@ -43,6 +43,34 @@ describe('ArrayUtils', () => {
     });
   });
 
+  describe('binarySearch', () => {
+    it('returns 0 for empty array', () => {
+      expect(ArrayUtils.binarySearch([], () => true)).toBe(0);
+    });
+
+    it('returns 0 when predicate is false for all elements', () => {
+      expect(ArrayUtils.binarySearch([1, 2, 3], () => false)).toBe(0);
+    });
+
+    it('returns length when predicate is true for all elements', () => {
+      expect(ArrayUtils.binarySearch([1, 2, 3], () => true)).toBe(3);
+    });
+
+    it('finds the partition point in a sorted array', () => {
+      const arr = [1, 2, 3, 4, 5];
+      // predicate: x < 3  → true for [1,2], false for [3,4,5] → index 2
+      expect(ArrayUtils.binarySearch(arr, (x) => x < 3)).toBe(2);
+    });
+
+    it('returns 1 when only the first element satisfies the predicate', () => {
+      expect(ArrayUtils.binarySearch([1, 2, 3], (x) => x < 2)).toBe(1);
+    });
+
+    it('returns 0 for a single-element array when predicate is false', () => {
+      expect(ArrayUtils.binarySearch([5], (x) => x < 5)).toBe(0);
+    });
+  });
+
   describe('hasSameElements', () => {
     it('determines same elements', () => {
       expectEqual([], []);


### PR DESCRIPTION
This PR replaces `Array.filter` calls in `SegmentIndex.merge()`,`mergeAndEvict()`, and `evict()` with more efficient alternatives. The key addition is `binarySearch` helper: it repeatedly checks the midpoint and discards half the array each time. The idea is the same as `Array.findIndex` but exploiting the sorted order to skip most of the work. `merge()` and `evict()` use this to find their truncation/expiry boundary; `mergeAndEvict()` uses a simple forward scan that stops at the first valid reference since stale refs are always bunched at the front. This is done to reduce iteration during playback (especially livestream with DVR)

- no big new array creations by default - we don't create one when for example there is nothing to evict
- fewer comparisons — binary search finds the cutoff without scanning the whole array
- slice just copies the kept elements and that's it