### PR TITLE
perf(TS): Eliminate per-PES wrapper array allocations in parse loop

### DIFF
--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -31,8 +31,14 @@ shaka.util.TsParser = class {
     /** @private {?string} */
     this.videoCodec_ = null;
 
-    /** @private {!Array<!Array<Uint8Array>>} */
+    /** @private {!Array<!Uint8Array>} Flat list of all video TS packets. */
     this.videoData_ = [];
+
+    /**
+     * Index into videoData_ where each video PES unit starts.
+     * @private {!Array<number>}
+     */
+    this.videoDataPesIndices_ = [];
 
     /** @private {!Array<shaka.extern.MPEG_PES>} */
     this.videoPes_ = [];
@@ -43,8 +49,14 @@ shaka.util.TsParser = class {
     /** @private {?string} */
     this.audioCodec_ = null;
 
-    /** @private {!Array<!Array<Uint8Array>>} */
+    /** @private {!Array<!Uint8Array>} Flat list of all audio TS packets. */
     this.audioData_ = [];
+
+    /**
+     * Index into audioData_ where each audio PES unit starts.
+     * @private {!Array<number>}
+     */
+    this.audioDataPesIndices_ = [];
 
     /** @private {!Array<shaka.extern.MPEG_PES>} */
     this.audioPes_ = [];
@@ -52,8 +64,14 @@ shaka.util.TsParser = class {
     /** @private {?number} */
     this.id3Pid_ = null;
 
-    /** @private {!Array<!Array<Uint8Array>>} */
+    /** @private {!Array<!Uint8Array>} Flat list of all ID3 TS packets. */
     this.id3Data_ = [];
+
+    /**
+     * Index into id3Data_ where each ID3 PES unit starts.
+     * @private {!Array<number>}
+     */
+    this.id3DataPesIndices_ = [];
 
     /** @private {?number} */
     this.referencePts_ = null;
@@ -75,10 +93,13 @@ shaka.util.TsParser = class {
    */
   clearData() {
     this.videoData_ = [];
+    this.videoDataPesIndices_ = [];
     this.videoPes_ = [];
     this.audioData_ = [];
+    this.audioDataPesIndices_ = [];
     this.audioPes_ = [];
     this.id3Data_ = [];
+    this.id3DataPesIndices_ = [];
   }
 
   /**
@@ -187,36 +208,33 @@ shaka.util.TsParser = class {
           case this.videoPid_: {
             const videoData = data.subarray(offset, start + packetLength);
             if (payloadUnitStartIndicator) {
-              this.videoData_.push([videoData]);
-            } else if (this.videoData_.length) {
-              const prevVideoData = this.videoData_[this.videoData_.length - 1];
-              if (prevVideoData) {
-                this.videoData_[this.videoData_.length - 1].push(videoData);
-              }
+              // Record where this new PES unit starts in the flat packet array.
+              this.videoDataPesIndices_.push(this.videoData_.length);
+              this.videoData_.push(videoData);
+            } else if (this.videoDataPesIndices_.length) {
+              this.videoData_.push(videoData);
             }
             break;
           }
           case this.audioPid_: {
             const audioData = data.subarray(offset, start + packetLength);
             if (payloadUnitStartIndicator) {
-              this.audioData_.push([audioData]);
-            } else if (this.audioData_.length) {
-              const prevAudioData = this.audioData_[this.audioData_.length - 1];
-              if (prevAudioData) {
-                this.audioData_[this.audioData_.length - 1].push(audioData);
-              }
+              // Record where this new PES unit starts in the flat packet array.
+              this.audioDataPesIndices_.push(this.audioData_.length);
+              this.audioData_.push(audioData);
+            } else if (this.audioDataPesIndices_.length) {
+              this.audioData_.push(audioData);
             }
             break;
           }
           case this.id3Pid_: {
             const id3Data = data.subarray(offset, start + packetLength);
             if (payloadUnitStartIndicator) {
-              this.id3Data_.push([id3Data]);
-            } else if (this.id3Data_.length) {
-              const prevId3Data = this.id3Data_[this.id3Data_.length - 1];
-              if (prevId3Data) {
-                this.id3Data_[this.id3Data_.length - 1].push(id3Data);
-              }
+              // Record where this new PES unit starts in the flat packet array.
+              this.id3DataPesIndices_.push(this.id3Data_.length);
+              this.id3Data_.push(id3Data);
+            } else if (this.id3DataPesIndices_.length) {
+              this.id3Data_.push(id3Data);
             }
             break;
           }
@@ -432,6 +450,22 @@ shaka.util.TsParser = class {
       offset += esInfoLength + 5;
     }
     return result;
+  }
+
+  /**
+   * Concatenate all TS packets that belong to a single PES unit.
+   *
+   * @param {!Array<!Uint8Array>} packets Flat list of all TS packets for a PID.
+   * @param {!Array<number>} pesIndices Start index in `packets` for each PES.
+   * @param {number} pesIdx Index into `pesIndices` for the desired PES.
+   * @return {!Uint8Array}
+   * @private
+   */
+  concatPesPackets_(packets, pesIndices, pesIdx) {
+    const first = pesIndices[pesIdx];  // inclusive
+    const end = pesIdx + 1 < pesIndices.length ?  // exclusive
+        pesIndices[pesIdx + 1] : packets.length;
+    return shaka.util.Uint8ArrayUtils.concatRange(packets, first, end);
   }
 
   /**
@@ -696,8 +730,9 @@ shaka.util.TsParser = class {
   getMetadata() {
     const timescale = shaka.util.TsParser.Timescale;
     const metadata = [];
-    for (const id3DataArray of this.id3Data_) {
-      const id3Data = shaka.util.Uint8ArrayUtils.concat(...id3DataArray);
+    for (let pesIdx = 0; pesIdx < this.id3DataPesIndices_.length; pesIdx++) {
+      const id3Data = this.concatPesPackets_(
+          this.id3Data_, this.id3DataPesIndices_, pesIdx);
       const pes = this.parsePES_(id3Data);
       if (pes) {
         metadata.push({
@@ -719,9 +754,12 @@ shaka.util.TsParser = class {
    * @export
    */
   getAudioData() {
-    if (this.audioData_.length && !this.audioPes_.length) {
-      for (const audioDataArray of this.audioData_) {
-        const audioData = shaka.util.Uint8ArrayUtils.concat(...audioDataArray);
+    if (this.audioDataPesIndices_.length && !this.audioPes_.length) {
+      for (let pesIdx = 0;
+        pesIdx < this.audioDataPesIndices_.length;
+        pesIdx++) {
+        const audioData = this.concatPesPackets_(
+            this.audioData_, this.audioDataPesIndices_, pesIdx);
         const pes = this.parsePES_(audioData);
         let previousPes = this.audioPes_.length ?
             this.audioPes_[this.audioPes_.length - 1] : null;
@@ -751,9 +789,12 @@ shaka.util.TsParser = class {
    * @export
    */
   getVideoData(naluProcessing = true) {
-    if (this.videoData_.length && !this.videoPes_.length) {
-      for (const videoDataArray of this.videoData_) {
-        const videoData = shaka.util.Uint8ArrayUtils.concat(...videoDataArray);
+    if (this.videoDataPesIndices_.length && !this.videoPes_.length) {
+      for (let pesIdx = 0;
+        pesIdx < this.videoDataPesIndices_.length;
+        pesIdx++) {
+        const videoData = this.concatPesPackets_(
+            this.videoData_, this.videoDataPesIndices_, pesIdx);
         const pes = this.parsePES_(videoData);
         let previousPes = this.videoPes_.length ?
             this.videoPes_[this.videoPes_.length - 1] : null;

--- a/lib/util/uint8array_utils.js
+++ b/lib/util/uint8array_utils.js
@@ -130,18 +130,29 @@ shaka.util.Uint8ArrayUtils = class {
    * @export
    */
   static concat(...varArgs) {
+    return shaka.util.Uint8ArrayUtils.concatRange(varArgs, 0, varArgs.length);
+  }
+
+  /**
+   * Concatenate a range of buffers from a flat array.
+   * Avoids a subarray allocation compared to concat(...array.slice(s, e)).
+   * @param {!Array<!BufferSource>} array
+   * @param {number=} start Inclusive start index.
+   * @param {number=} end Exclusive end index.
+   * @return {!Uint8Array}
+   */
+  static concatRange(array, start = 0, end = array.length) {
     const BufferUtils = shaka.util.BufferUtils;
     let totalLength = 0;
-    for (let i = 0; i < varArgs.length; ++i) {
-      const value = varArgs[i];
-      totalLength += value.byteLength;
+    for (let i = start; i < end; ++i) {
+      totalLength += array[i].byteLength;
     }
 
     const result = new Uint8Array(totalLength);
     let offset = 0;
 
-    for (let i = 0; i < varArgs.length; ++i) {
-      const value = varArgs[i];
+    for (let i = start; i < end; ++i) {
+      const value = array[i];
       if (ArrayBuffer.isView(value) &&
       /** @type {TypedArray} */ (value).BYTES_PER_ELEMENT === 1) {
         result.set(/** @type {!Uint8Array} */(value), offset);

--- a/test/util/uint8array_utils_unit.js
+++ b/test/util/uint8array_utils_unit.js
@@ -1,0 +1,93 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('Uint8ArrayUtils', () => {
+  const Uint8ArrayUtils = shaka.util.Uint8ArrayUtils;
+
+  describe('concat', () => {
+    it('concatenates two buffers', () => {
+      const a = new Uint8Array([1, 2]);
+      const b = new Uint8Array([3, 4]);
+      expect(Uint8ArrayUtils.concat(a, b))
+          .toEqual(new Uint8Array([1, 2, 3, 4]));
+    });
+
+    it('concatenates three buffers', () => {
+      const a = new Uint8Array([1]);
+      const b = new Uint8Array([2]);
+      const c = new Uint8Array([3]);
+      expect(Uint8ArrayUtils.concat(a, b, c))
+          .toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    it('handles empty buffers', () => {
+      const a = new Uint8Array([1, 2]);
+      const b = new Uint8Array([]);
+      const c = new Uint8Array([3]);
+      expect(Uint8ArrayUtils.concat(a, b, c))
+          .toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    it('returns empty array when called with no args', () => {
+      expect(Uint8ArrayUtils.concat()).toEqual(new Uint8Array([]));
+    });
+
+    it('accepts ArrayBuffer inputs', () => {
+      const a = shaka.util.BufferUtils.toArrayBuffer(new Uint8Array([1, 2]));
+      const b = shaka.util.BufferUtils.toArrayBuffer(new Uint8Array([3, 4]));
+      expect(Uint8ArrayUtils.concat(a, b))
+          .toEqual(new Uint8Array([1, 2, 3, 4]));
+    });
+  });
+
+  describe('concatRange', () => {
+    it('concatenates the full array by default', () => {
+      const arr = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+      expect(Uint8ArrayUtils.concatRange(arr))
+          .toEqual(new Uint8Array([1, 2, 3, 4]));
+    });
+
+    it('concatenates a middle range', () => {
+      const arr = [
+        new Uint8Array([1, 2]),
+        new Uint8Array([3, 4]),
+        new Uint8Array([5, 6]),
+      ];
+      expect(Uint8ArrayUtils.concatRange(arr, 1, 2))
+          .toEqual(new Uint8Array([3, 4]));
+    });
+
+    it('concatenates from start with explicit end', () => {
+      const arr = [
+        new Uint8Array([1]),
+        new Uint8Array([2]),
+        new Uint8Array([3]),
+      ];
+      expect(Uint8ArrayUtils.concatRange(arr, 0, 2))
+          .toEqual(new Uint8Array([1, 2]));
+    });
+
+    it('concatenates from explicit start to end of array', () => {
+      const arr = [
+        new Uint8Array([1]),
+        new Uint8Array([2]),
+        new Uint8Array([3]),
+      ];
+      expect(Uint8ArrayUtils.concatRange(arr, 1))
+          .toEqual(new Uint8Array([2, 3]));
+    });
+
+    it('returns empty array for empty range', () => {
+      const arr = [new Uint8Array([1, 2]), new Uint8Array([3, 4])];
+      expect(Uint8ArrayUtils.concatRange(arr, 1, 1))
+          .toEqual(new Uint8Array([]));
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(Uint8ArrayUtils.concatRange([])).toEqual(new Uint8Array([]));
+    });
+  });
+});


### PR DESCRIPTION
This PR reduces GC pressure during MPEG-TS segment parsing - it replaces nested PES packet arrays with a flat array plus a PES-start index, eliminating per-PES inner array allocations and avoiding spread-operator overhead when concatenating packets - reduces allocations, hence reduces GC pressure on low-end devices during long livestreams