### PR TITLE
chore: Factor out agent attribution instructions

### DIFF
--- a/AGENT-ATTRIBUTION.md
+++ b/AGENT-ATTRIBUTION.md
@@ -1,0 +1,16 @@
+# AI Agent Attribution Instructions
+
+We welcome contributions that were written or assisted by AI coding agents.  However, any commit that involved AI assistance must say so clearly.
+
+Attribution is important when using agents for coding.  Commits should be authored by the human contributor and co‑signed by the AI agent(s).  Always use a 'Co-Authored-By' trailer in commit messages.
+
+The format generally is: "Co-Authored-By: <Tool Name> (<Current Model Name or Version>) <email address>".  Substitute the actual names and versions at runtime.
+
+For GitHub to link these to the correct accounts, these specific email addresses should be used by these common models:
+  - Gemini (including gemini-cli and other Gemini models and agent integrations): gemini-cli@users.noreply.github.com
+  - Claude (including Claude Code and other integrations of Claude): noreply@anthropic.com
+  - Copilot (including Microsoft Copilot, GitHub Copilot, or other variations): 198982749+Copilot@users.noreply.github.com
+  - ChatGPT (including Codex and other integrations): chatgpt-codex-connector[bot]@users.noreply.github.com
+  - Cursor: cursoragent@cursor.com
+  - Warp: agent@warp.dev
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,7 @@
 
 ## Attribution
 
-Attribution is important when using agents for coding.  Commits should be authored by the human contributor and co‑signed by the AI agent(s).  Always use a 'Co-Authored-By' trailer in commit messages.
-
-The format generally is: "Co-Authored-By: <Current Model Name and/or Version> <email address>".  Substitute the actual model name/version at runtime.
-
-For GitHub to link these to the correct accounts, these specific email addresses should be used by these common models:
-  - Gemini (including gemini-cli and other Gemini models and agent integrations): gemini-cli@users.noreply.github.com
-  - Claude (including Claude Code and other integrations of Claude): noreply@anthropic.com
-  - Copilot (including Microsoft Copilot, GitHub Copilot, or other variations): 198982749+Copilot@users.noreply.github.com
-  - ChatGPT (including Codex and other integrations): chatgpt-codex-connector[bot]@users.noreply.github.com
-  - Cursor: cursoragent@cursor.com
-  - Warp: agent@warp.dev
+Read [AGENT-ATTRIBUTION.md](AGENT-ATTRIBUTION.md) for attribution details.
 
 ## Project Overview
 


### PR DESCRIPTION
To prepare to sync these common instructions across repos, factor them out into their own file.