### PR TITLE
ci: reuse a single player build across instances

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -23,8 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  build:
+    name: Build Player
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -38,13 +38,18 @@ jobs:
           distribution: zulu
           java-version: 21
 
-      - name: Lint
-        run: python3 build/check.py
+      - name: Build Player
+        timeout-minutes: 20
+        run: python3 build/all.py --only-es5
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-build
+          path: dist/
 
   build_and_test:
-    # Don't waste time doing a full matrix of test runs when there was an
-    # obvious linter error.
-    needs: lint
+    needs: build
     strategy:
       matrix:
         include:
@@ -158,22 +163,20 @@ jobs:
 
       # Some CI images (self-hosted or otherwise) don't have the minimum Java
       # version necessary for the compiler (Java 21).
-      - uses: actions/setup-java@v4
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          distribution: zulu
-          java-version: 21
-
-      - name: Build Player
-        timeout-minutes: 20
-        run: python3 build/all.py --only-es5
+          name: player-build
+          path: dist/
 
       - name: Test Player
-        timeout-minutes: 15
+        timeout-minutes: 20
         shell: bash
         run: |
           browser=${{ matrix.browser }}
 
           python3 build/test.py \
+            --no-build \
             --browsers "$browser" \
             --reporters spec --spec-hide-passed \
             ${{ matrix.extra_flags }}
@@ -231,9 +234,6 @@ jobs:
           retention-days: 5
 
   build_in_docker:
-    # Don't waste time doing a full matrix of test runs when there was an
-    # obvious linter error.
-    needs: lint
     name: Docker
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR builds one player for every testing instance - just thought that building 13 separate ones made the whole pipeline too long.