### PR TITLE
feat(MSF): Make subscribe filter type configurable

### DIFF
--- a/build/types/core
+++ b/build/types/core
@@ -1,6 +1,7 @@
 # The core library.  This is always included, regardless of whether it is
 # explicitly listed.
 
++../../lib/abr/buffer_based_abr_manager.js
 +../../lib/abr/ewma.js
 +../../lib/abr/ewma_bandwidth_estimator.js
 +../../lib/abr/simple_abr_manager.js

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -1648,6 +1648,7 @@ shaka.extern.HlsManifestConfiguration;
  * @typedef {{
  *   fingerprintUri: string,
  *   namespaces: !Array<string>,
+ *   subscribeFilterType: string,
  * }}
  *
  * @property {string} fingerprintUri
@@ -1660,6 +1661,15 @@ shaka.extern.HlsManifestConfiguration;
  *   via PublishNamespace messages.
  *   <br>
  *   Defaults to <code>[]</code>.
+ * @property {string} subscribeFilterType
+ *   The filter type used in MoQ SUBSCRIBE messages. Controls how the relay
+ *   delivers data to the subscriber.
+ *   <code>'latest_object'</code> starts from the most recent available data
+ *   (best for live low-latency).
+ *   <code>'next_group'</code> waits for the next group boundary before
+ *   delivering (may cause delays on edge relays with gossip routing).
+ *   <br>
+ *   Defaults to <code>'latest_object'</code>.
  * @exportDoc
  */
 shaka.extern.MsfManifestConfiguration;

--- a/lib/abr/buffer_based_abr_manager.js
+++ b/lib/abr/buffer_based_abr_manager.js
@@ -1,0 +1,409 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+goog.provide('shaka.abr.BufferBasedAbrManager');
+
+goog.require('goog.asserts');
+goog.require('shaka.log');
+goog.require('shaka.util.IReleasable');
+goog.require('shaka.util.Timer');
+
+
+/**
+ * @summary
+ * A buffer-based ABR manager for low-latency live streams (MoQ/MSF).
+ *
+ * Unlike the default bandwidth-based SimpleAbrManager, this manager makes
+ * quality decisions based on buffer health relative to the stream's target
+ * latency. This is better suited for low-latency live streams where
+ * bandwidth estimation is unreliable due to small segment sizes and
+ * push-based delivery (WebTransport/MoQ).
+ *
+ * Down-switch: immediate when buffer drops below 30% of target latency,
+ * or when excessive video frames are dropped.
+ * Up-switch: requires 5 seconds of sustained buffer above 150% of target
+ * latency.
+ *
+ * @implements {shaka.extern.AbrManager}
+ * @implements {shaka.util.IReleasable}
+ * @export
+ */
+shaka.abr.BufferBasedAbrManager = class {
+  constructor() {
+    /** @private {?shaka.extern.AbrManager.SwitchCallback} */
+    this.switch_ = null;
+
+    /** @private {HTMLMediaElement} */
+    this.mediaElement_ = null;
+
+    /** @private {!Array<!shaka.extern.Variant>} */
+    this.variants_ = [];
+
+    /** @private {boolean} */
+    this.isLowLatency_ = false;
+
+    /** @private {boolean} */
+    this.enabled_ = false;
+
+    /**
+     * Target latency in milliseconds. Used to compute buffer thresholds.
+     * Updated via configure() or from the manifest's serviceDescription.
+     * @private {number}
+     */
+    this.targetLatencyMs_ = 2000;
+
+    /**
+     * ABR ladder sorted by pixel count (ascending). Each entry contains
+     * the variant and its resolution metadata.
+     * @private {!Array<{variant: shaka.extern.Variant, pixels: number,
+     *     width: number, height: number, bandwidth: number}>}
+     */
+    this.ladder_ = [];
+
+    /** @private {number} */
+    this.currentIndex_ = -1;
+
+    /** @private {string} */
+    this.state_ = 'stable';
+
+    /** @private {number} */
+    this.stableStart_ = 0;
+
+    /** @private {number} */
+    this.lastDroppedFrames_ = 0;
+
+    /** @private {number} */
+    this.playbackStartTime_ = 0;
+
+    /** @private {shaka.util.Timer} */
+    this.timer_ = null;
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  init(switchCallback) {
+    this.switch_ = switchCallback;
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  stop() {
+    this.switch_ = null;
+    this.variants_ = [];
+    this.enabled_ = false;
+    if (this.timer_) {
+      this.timer_.stop();
+      this.timer_ = null;
+    }
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  release() {
+    this.stop();
+    this.mediaElement_ = null;
+    this.ladder_ = [];
+  }
+
+  /**
+   * Returns the highest-quality variant for initial playback.
+   * Mid-stream switching is handled by evaluate_() calling switch_().
+   *
+   * @param {boolean=} preferFastSwitching
+   * @return {shaka.extern.Variant}
+   * @override
+   * @export
+   */
+  chooseVariant(preferFastSwitching = false) {
+    if (this.ladder_.length > 0) {
+      if (this.currentIndex_ < 0) {
+        this.currentIndex_ = this.ladder_.length - 1;
+        shaka.log.info('[BufferABR] Ladder:',
+            this.ladder_.map((l) => l.height + 'p').join(' < '),
+            'initial:', this.ladder_[this.currentIndex_].height + 'p');
+      }
+      return this.ladder_[this.currentIndex_].variant;
+    }
+    if (this.variants_.length > 0) {
+      return this.variants_[this.variants_.length - 1];
+    }
+    // Should not happen — Shaka always calls setVariants before chooseVariant.
+    goog.asserts.assert(false, 'No variants available');
+    return this.variants_[0];
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  enable() {
+    if (this.enabled_) {
+      return;
+    }
+    this.enabled_ = true;
+    this.playbackStartTime_ = Date.now();
+    this.state_ = 'stable';
+    this.stableStart_ = Date.now();
+    this.lastDroppedFrames_ = 0;
+
+    if (this.ladder_.length > 1) {
+      this.timer_ = new shaka.util.Timer(() => this.evaluate_());
+      this.timer_.tickEvery(
+          shaka.abr.BufferBasedAbrManager.EVALUATE_INTERVAL_S_);
+    }
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  disable() {
+    this.enabled_ = false;
+    if (this.timer_) {
+      this.timer_.stop();
+    }
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  segmentDownloaded(deltaTimeMs, numBytes, allowSwitch, request, context) {
+    // Not used — buffer-based ABR doesn't rely on bandwidth estimation.
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  trySuggestStreams() {}
+
+  /**
+   * @override
+   * @export
+   */
+  getBandwidthEstimate() {
+    return 0;
+  }
+
+  /**
+   * @param {!Array<!shaka.extern.Variant>} variants
+   * @param {boolean} isLowLatency
+   * @return {boolean}
+   * @override
+   * @export
+   */
+  setVariants(variants, isLowLatency) {
+    this.variants_ = variants;
+    this.isLowLatency_ = isLowLatency;
+    this.buildLadder_();
+    return true;
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  playbackRateChanged(rate) {}
+
+  /**
+   * @override
+   * @export
+   */
+  setMediaElement(mediaElement) {
+    this.mediaElement_ = mediaElement;
+  }
+
+  /**
+   * @override
+   * @export
+   */
+  setCmsdManager(cmsdManager) {}
+
+  /**
+   * @override
+   * @export
+   */
+  configure(config) {}
+
+  // --- Private methods ---
+
+  /**
+   * Build the ABR quality ladder from the current variants, sorted by
+   * resolution (pixel count ascending). Deduplicates by resolution,
+   * keeping the highest bandwidth variant for each.
+   * @private
+   */
+  buildLadder_() {
+    const seen = new Map();
+    for (const v of this.variants_) {
+      if (!v.video) {
+        continue;
+      }
+      const w = v.video.width || 0;
+      const h = v.video.height || 0;
+      const pixels = w * h;
+      if (pixels === 0) {
+        continue;
+      }
+      const key = w + 'x' + h;
+      if (!seen.has(key) || v.bandwidth > (seen.get(key).bandwidth || 0)) {
+        seen.set(key, {
+          variant: v,
+          pixels: pixels,
+          width: w,
+          height: h,
+          bandwidth: v.bandwidth || 0,
+        });
+      }
+    }
+    this.ladder_ =
+        Array.from(seen.values()).sort((a, b) => a.pixels - b.pixels);
+  }
+
+  /**
+   * Evaluate buffer health and switch quality if needed.
+   * Called every EVALUATE_INTERVAL_S_ seconds when enabled.
+   * @private
+   */
+  evaluate_() {
+    if (!this.enabled_ || !this.mediaElement_ || this.ladder_.length <= 1) {
+      return;
+    }
+
+    // Grace period: skip evaluation for the first 5s after enable
+    // to let the buffer stabilize after initial playback.
+    if (Date.now() - this.playbackStartTime_ <
+        shaka.abr.BufferBasedAbrManager.GRACE_PERIOD_MS_) {
+      return;
+    }
+
+    const video = this.mediaElement_;
+    const buffered = video.buffered;
+    if (buffered.length === 0) {
+      return;
+    }
+
+    const bufferHealth = buffered.end(buffered.length - 1) - video.currentTime;
+    if (bufferHealth <= 0) {
+      return;
+    }
+
+    const htmlVideo = /** @type {HTMLVideoElement} */ (video);
+    const dropped = htmlVideo.getVideoPlaybackQuality ?
+        htmlVideo.getVideoPlaybackQuality().droppedVideoFrames : 0;
+    const droppedDelta = dropped - this.lastDroppedFrames_;
+    this.lastDroppedFrames_ = dropped;
+
+    const targetSec = this.targetLatencyMs_ / 1000;
+    const downThreshold =
+        targetSec * shaka.abr.BufferBasedAbrManager.DOWN_THRESHOLD_FACTOR_;
+    const upThreshold =
+        targetSec * shaka.abr.BufferBasedAbrManager.UP_THRESHOLD_FACTOR_;
+
+    // DOWN: buffer critically low or excessive dropped frames
+    if ((bufferHealth < downThreshold ||
+        droppedDelta > shaka.abr.BufferBasedAbrManager.MAX_DROPPED_FRAMES_) &&
+        this.currentIndex_ > 0) {
+      const newIndex = this.currentIndex_ - 1;
+      shaka.log.info('[BufferABR] DOWN: buffer=' +
+          bufferHealth.toFixed(2) + 's drops=' + droppedDelta +
+          ' -> ' + this.ladder_[newIndex].height + 'p');
+      this.switchTo_(newIndex);
+      return;
+    }
+
+    // UP: sustained healthy buffer for STABLE_DURATION_MS_
+    if (bufferHealth > upThreshold &&
+        this.currentIndex_ < this.ladder_.length - 1) {
+      if (this.state_ !== 'stable') {
+        this.state_ = 'stable';
+        this.stableStart_ = Date.now();
+      } else if (Date.now() - this.stableStart_ >
+          shaka.abr.BufferBasedAbrManager.STABLE_DURATION_MS_) {
+        const newIndex = this.currentIndex_ + 1;
+        shaka.log.info('[BufferABR] UP: buffer=' +
+            bufferHealth.toFixed(2) + 's stable=' +
+            ((Date.now() - this.stableStart_) / 1000).toFixed(0) +
+            's -> ' + this.ladder_[newIndex].height + 'p');
+        this.switchTo_(newIndex);
+        return;
+      }
+    } else {
+      if (this.state_ === 'stable' && bufferHealth <= upThreshold) {
+        this.stableStart_ = Date.now();
+      }
+    }
+  }
+
+  /**
+   * Switch to a new quality level in the ladder.
+   * @param {number} newIndex
+   * @private
+   */
+  switchTo_(newIndex) {
+    if (newIndex < 0 || newIndex >= this.ladder_.length) {
+      return;
+    }
+    this.currentIndex_ = newIndex;
+    this.state_ = 'recovering';
+    this.stableStart_ = Date.now();
+
+    const variant = this.ladder_[newIndex].variant;
+    if (this.switch_) {
+      this.switch_(variant);
+    }
+  }
+};
+
+
+/**
+ * Evaluate buffer health every 1 second.
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.EVALUATE_INTERVAL_S_ = 1;
+
+/**
+ * Grace period after enable before evaluating (ms).
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.GRACE_PERIOD_MS_ = 5000;
+
+/**
+ * Down-switch when buffer < targetLatency * this factor.
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.DOWN_THRESHOLD_FACTOR_ = 0.3;
+
+/**
+ * Up-switch when buffer > targetLatency * this factor.
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.UP_THRESHOLD_FACTOR_ = 1.5;
+
+/**
+ * Required sustained buffer duration before up-switching (ms).
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.STABLE_DURATION_MS_ = 5000;
+
+/**
+ * Down-switch if more than this many frames dropped in one interval.
+ * @const {number}
+ * @private
+ */
+shaka.abr.BufferBasedAbrManager.MAX_DROPPED_FRAMES_ = 5;

--- a/lib/msf/buffer_control_writer.js
+++ b/lib/msf/buffer_control_writer.js
@@ -179,6 +179,42 @@ shaka.msf.BufferControlWriter = class {
   }
 
   /**
+   * Marshals a Goaway message to the buffer
+   * @param {shaka.msf.Utils.Goaway} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalGoaway(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.GOAWAY, () => {
+      this.writeString_(msg.newSessionUri);
+    });
+  }
+
+  /**
+   * Marshals a MaxRequestId message to the buffer
+   * @param {shaka.msf.Utils.MaxRequestId} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalMaxRequestId(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.MAX_REQUEST_ID, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+    });
+  }
+
+  /**
+   * Marshals a RequestsBlocked message to the buffer
+   * @param {shaka.msf.Utils.RequestsBlocked} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalRequestsBlocked(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.REQUESTS_BLOCKED, () => {
+      this.writer_.writeVarInt62(msg.maximumRequestId);
+    });
+  }
+
+  /**
    * Marshals a Subscribe message to the buffer
    * @param {shaka.msf.Utils.Subscribe} msg
    * @return {!shaka.msf.BufferControlWriter}
@@ -248,7 +284,35 @@ shaka.msf.BufferControlWriter = class {
       this.writer_.writeVarInt62(msg.requestId);
       this.writer_.writeVarInt62(msg.code);
       this.writeString_(msg.reason);
-      this.writer_.writeVarInt62(msg.trackAlias);
+    });
+  }
+
+  /**
+   * Marshals a SubscribeUpdate message to the buffer
+   * @param {shaka.msf.Utils.SubscribeUpdate} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalSubscribeUpdate(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.SUBSCRIBE_UPDATE, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writeLocation_(msg.startLocation);
+      this.writer_.writeVarInt62(msg.endGroup);
+      this.writer_.writeUint8(msg.subscriberPriority);
+      this.writeBoolAsUint8_(msg.forward);
+      this.writeKeyValuePairs_(msg.params);
+    });
+  }
+
+  /**
+   * Marshals an Unsubscribe message to the buffer
+   * @param {shaka.msf.Utils.Unsubscribe} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalUnsubscribe(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.UNSUBSCRIBE, () => {
+      this.writer_.writeVarInt62(msg.requestId);
     });
   }
 
@@ -264,6 +328,80 @@ shaka.msf.BufferControlWriter = class {
       this.writer_.writeVarInt62(msg.code);
       this.writeString_(msg.reason);
       this.writer_.writeVarInt53(msg.streamCount);
+    });
+  }
+
+  /**
+   * Marshals a Publish message to the buffer
+   * @param {shaka.msf.Utils.Publish} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalPublish(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.PUBLISH, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writeTuple_(msg.namespace);
+      this.writeString_(msg.name);
+      this.writer_.writeVarInt62(msg.trackAlias);
+      this.writer_.writeUint8(msg.groupOrder);
+      this.writeBoolAsUint8_(msg.contentExists);
+
+      if (msg.contentExists) {
+        if (!msg.largestLocation) {
+          throw new Error('Missing largestLocation for contentExists');
+        }
+        this.writeLocation_(msg.largestLocation);
+      }
+
+      this.writeBoolAsUint8_(msg.forward);
+      this.writeKeyValuePairs_(msg.params);
+    });
+  }
+
+  /**
+   * Marshals a PublishOk message to the buffer
+   * @param {shaka.msf.Utils.PublishOk} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalPublishOk(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.PUBLISH_OK, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writeBoolAsUint8_(msg.forward);
+      this.writer_.writeUint8(msg.subscriberPriority);
+      this.writer_.writeUint8(msg.groupOrder);
+      this.writer_.writeUint8(msg.filterType);
+
+      if (msg.filterType === shaka.msf.Utils.FilterType.ABSOLUTE_START ||
+          msg.filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
+        if (!msg.startLocation) {
+          throw new Error('Missing startLocation for absolute filter');
+        }
+        this.writeLocation_(msg.startLocation);
+      }
+
+      if (msg.filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
+        if (!msg.endGroup) {
+          throw new Error('Missing endGroup for absolute range filter');
+        }
+        this.writer_.writeVarInt62(msg.endGroup);
+      }
+
+      this.writeKeyValuePairs_(msg.params);
+    });
+  }
+
+  /**
+   * Marshals a PublishError message to the buffer
+   * @param {shaka.msf.Utils.PublishError} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalPublishError(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.PUBLISH_ERROR, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writer_.writeVarInt62(msg.errorCode);
+      this.writeString_(msg.reason);
     });
   }
 
@@ -294,18 +432,6 @@ shaka.msf.BufferControlWriter = class {
   }
 
   /**
-   * Marshals an Unsubscribe message to the buffer
-   * @param {shaka.msf.Utils.Unsubscribe} msg
-   * @return {!shaka.msf.BufferControlWriter}
-   */
-  marshalUnsubscribe(msg) {
-    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
-    return this.marshal_(MessageTypeId.UNSUBSCRIBE, () => {
-      this.writer_.writeVarInt62(msg.requestId);
-    });
-  }
-
-  /**
    * Marshals an PublishNamespaceError message to the buffer
    * @param {shaka.msf.Utils.PublishNamespaceError} msg
    * @return {!shaka.msf.BufferControlWriter}
@@ -320,13 +446,79 @@ shaka.msf.BufferControlWriter = class {
   }
 
   /**
-   * Marshals an UnpublishNamespace message to the buffer
-   * @param {shaka.msf.Utils.UnpublishNamespace} msg
+   * Marshals an PublishNamespaceDone message to the buffer
+   * @param {shaka.msf.Utils.PublishNamespaceDone} msg
    * @return {!shaka.msf.BufferControlWriter}
    */
-  marshalUnpublishNamespace(msg) {
+  marshalPublishNamespaceDone(msg) {
     const MessageTypeId = shaka.msf.Utils.MessageTypeId;
-    return this.marshal_(MessageTypeId.UNPUBLISH_NAMESPACE, () => {
+    return this.marshal_(MessageTypeId.PUBLISH_NAMESPACE_DONE, () => {
+      this.writeTuple_(msg.namespace);
+    });
+  }
+
+  /**
+   * Marshals an PublishNamespaceCancel message to the buffer
+   * @param {shaka.msf.Utils.PublishNamespaceCancel} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalPublishNamespaceCancel(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.PUBLISH_NAMESPACE_CANCEL, () => {
+      this.writeTuple_(msg.namespace);
+      this.writer_.writeVarInt62(msg.errorCode);
+      this.writeString_(msg.reason);
+    });
+  }
+
+  /**
+   * Marshals an SubscribeNamespace message to the buffer
+   * @param {shaka.msf.Utils.SubscribeNamespace} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalSubscribeNamespace(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.SUBSCRIBE_NAMESPACE, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writeTuple_(msg.namespace);
+      this.writeKeyValuePairs_(msg.params);
+    });
+  }
+
+  /**
+   * Marshals an SubscribeNamespaceOk message to the buffer
+   * @param {shaka.msf.Utils.SubscribeNamespaceOk} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalSubscribeNamespaceOk(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.SUBSCRIBE_NAMESPACE_OK, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+    });
+  }
+
+  /**
+   * Marshals an SubscribeNamespaceError message to the buffer
+   * @param {shaka.msf.Utils.SubscribeNamespaceError} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalSubscribeNamespaceError(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.SUBSCRIBE_NAMESPACE_ERROR, () => {
+      this.writer_.writeVarInt62(msg.requestId);
+      this.writer_.writeVarInt62(msg.errorCode);
+      this.writeString_(msg.reason);
+    });
+  }
+
+  /**
+   * Marshals an UnsubscribeNamespace message to the buffer
+   * @param {shaka.msf.Utils.UnsubscribeNamespace} msg
+   * @return {!shaka.msf.BufferControlWriter}
+   */
+  marshalUnsubscribeNamespace(msg) {
+    const MessageTypeId = shaka.msf.Utils.MessageTypeId;
+    return this.marshal_(MessageTypeId.UNSUBSCRIBE_NAMESPACE, () => {
       this.writeTuple_(msg.namespace);
     });
   }

--- a/lib/msf/msf_control_stream.js
+++ b/lib/msf/msf_control_stream.js
@@ -80,20 +80,62 @@ shaka.msf.ControlStreamDecoder = class {
 
     let msgType;
     switch (type) {
+      case shaka.msf.Utils.MessageTypeId.GOAWAY:
+        msgType = shaka.msf.Utils.MessageType.GOAWAY;
+        break;
+      case shaka.msf.Utils.MessageTypeId.MAX_REQUEST_ID:
+        msgType = shaka.msf.Utils.MessageType.MAX_REQUEST_ID;
+        break;
+      case shaka.msf.Utils.MessageTypeId.REQUESTS_BLOCKED:
+        msgType = shaka.msf.Utils.MessageType.REQUESTS_BLOCKED;
+        break;
       case shaka.msf.Utils.MessageTypeId.SUBSCRIBE:
         msgType = shaka.msf.Utils.MessageType.SUBSCRIBE;
         break;
       case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_OK:
         msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_OK;
         break;
-      case shaka.msf.Utils.MessageTypeId.PUBLISH_DONE:
-        msgType = shaka.msf.Utils.MessageType.PUBLISH_DONE;
-        break;
       case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_ERROR:
         msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_ERROR;
         break;
+      case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_UPDATE:
+        msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE;
+        break;
       case shaka.msf.Utils.MessageTypeId.UNSUBSCRIBE:
         msgType = shaka.msf.Utils.MessageType.UNSUBSCRIBE;
+        break;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH_DONE:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH_DONE;
+        break;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH;
+        break;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH_OK:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH_OK;
+        break;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH_ERROR:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH_ERROR;
+        break;
+      case shaka.msf.Utils.MessageTypeId.FETCH:
+        msgType = shaka.msf.Utils.MessageType.FETCH;
+        break;
+      case shaka.msf.Utils.MessageTypeId.FETCH_OK:
+        msgType = shaka.msf.Utils.MessageType.FETCH_OK;
+        break;
+      case shaka.msf.Utils.MessageTypeId.FETCH_ERROR:
+        msgType = shaka.msf.Utils.MessageType.FETCH_ERROR;
+        break;
+      case shaka.msf.Utils.MessageTypeId.FETCH_CANCEL:
+        msgType = shaka.msf.Utils.MessageType.FETCH_CANCEL;
+        break;
+      case shaka.msf.Utils.MessageTypeId.TRACK_STATUS:
+        msgType = shaka.msf.Utils.MessageType.TRACK_STATUS;
+        break;
+      case shaka.msf.Utils.MessageTypeId.TRACK_STATUS_OK:
+        msgType = shaka.msf.Utils.MessageType.TRACK_STATUS_OK;
+        break;
+      case shaka.msf.Utils.MessageTypeId.TRACK_STATUS_ERROR:
+        msgType = shaka.msf.Utils.MessageType.TRACK_STATUS_ERROR;
         break;
       case shaka.msf.Utils.MessageTypeId.PUBLISH_NAMESPACE:
         msgType = shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE;
@@ -104,14 +146,23 @@ shaka.msf.ControlStreamDecoder = class {
       case shaka.msf.Utils.MessageTypeId.PUBLISH_NAMESPACE_ERROR:
         msgType = shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_ERROR;
         break;
-      case shaka.msf.Utils.MessageTypeId.UNPUBLISH_NAMESPACE:
-        msgType = shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH_NAMESPACE_DONE:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE;
+        break;
+      case shaka.msf.Utils.MessageTypeId.PUBLISH_NAMESPACE_CANCEL:
+        msgType = shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL;
         break;
       case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_NAMESPACE:
         msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE;
         break;
-      case shaka.msf.Utils.MessageTypeId.REQUESTS_BLOCKED:
-        msgType = shaka.msf.Utils.MessageType.REQUESTS_BLOCKED;
+      case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_NAMESPACE_OK:
+        msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK;
+        break;
+      case shaka.msf.Utils.MessageTypeId.SUBSCRIBE_NAMESPACE_ERROR:
+        msgType = shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR;
+        break;
+      case shaka.msf.Utils.MessageTypeId.UNSUBSCRIBE_NAMESPACE:
+        msgType = shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE;
         break;
       default:
         throw new Error(`Unknown message type: 0x${type.toString(16)}`);
@@ -131,6 +182,15 @@ shaka.msf.ControlStreamDecoder = class {
     /** @type {shaka.msf.Utils.Message} */
     let result;
     switch (type) {
+      case shaka.msf.Utils.MessageType.GOAWAY:
+        result = await this.goaway_();
+        break;
+      case shaka.msf.Utils.MessageType.MAX_REQUEST_ID:
+        result = await this.maxRequestId_();
+        break;
+      case shaka.msf.Utils.MessageType.REQUESTS_BLOCKED:
+        result = await this.requestsBlocked_();
+        break;
       case shaka.msf.Utils.MessageType.SUBSCRIBE:
         result = await this.subscribe_();
         break;
@@ -140,12 +200,32 @@ shaka.msf.ControlStreamDecoder = class {
       case shaka.msf.Utils.MessageType.SUBSCRIBE_ERROR:
         result = await this.subscribeError_();
         break;
-      case shaka.msf.Utils.MessageType.PUBLISH_DONE:
-        result = await this.publishDone_();
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE:
+        result = await this.subscribeUpdate_();
         break;
       case shaka.msf.Utils.MessageType.UNSUBSCRIBE:
         result = await this.unsubscribe_();
         break;
+      case shaka.msf.Utils.MessageType.PUBLISH_DONE:
+        result = await this.publishDone_();
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH:
+        result = await this.publish_();
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_OK:
+        result = await this.publishOk_();
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_ERROR:
+        result = await this.publishError_();
+        break;
+      case shaka.msf.Utils.MessageType.FETCH:
+      case shaka.msf.Utils.MessageType.FETCH_OK:
+      case shaka.msf.Utils.MessageType.FETCH_ERROR:
+      case shaka.msf.Utils.MessageType.FETCH_CANCEL:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS_OK:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS_ERROR:
+        throw new Error(`Unsupported message type: ${type}`);
       case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE:
         result = await this.publishNamespace_();
         break;
@@ -155,21 +235,69 @@ shaka.msf.ControlStreamDecoder = class {
       case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_ERROR:
         result = await this.publishNamespaceError_();
         break;
-      case shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE:
-        result = await this.unpublishNamespace_();
+      case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE:
+        result = await this.publishNamespaceDone_();
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL:
+        result = await this.publishNamespaceCancel_();
         break;
       case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE:
         result = await this.subscribeNamespace_();
         break;
-      case shaka.msf.Utils.MessageType.REQUESTS_BLOCKED:
-        result = await this.requestsBlocked_();
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK:
+        result = await this.subscribeNamespaceOk_();
+        break;
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR:
+        result = await this.subscribeNamespaceError_();
+        break;
+      case shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE:
+        result = await this.unsubscribeNamespace_();
         break;
       default:
         throw new Error(`Unsupported message type: ${type}`);
     }
 
-    shaka.log.debug('Successfully parsed control message:', result);
+    shaka.log.debug(`Successfully parsed ${type} message:`, result);
     return result;
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.Goaway>}
+   * @private
+   */
+  async goaway_() {
+    const newSessionUri = await this.reader_.string();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.GOAWAY,
+      newSessionUri,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.MaxRequestId>}
+   * @private
+   */
+  async maxRequestId_() {
+    const requestId = await this.reader_.u62();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+      requestId,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.RequestsBlocked>}
+   * @private
+   */
+  async requestsBlocked_() {
+    const maximumRequestId = await this.reader_.u62();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+      maximumRequestId,
+    };
   }
 
   /**
@@ -177,44 +305,27 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async subscribe_() {
-    shaka.log.debug('Parsing Subscribe message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`RequestID: ${requestId}`);
-
     const namespace = await this.reader_.tuple();
-    shaka.log.debug(`Namespace: ${namespace.join('/')}`);
-
     const name = await this.reader_.string();
-    shaka.log.debug(`Name: ${name}`);
-
     const subscriberPriority = await this.reader_.u8();
-    shaka.log.debug(`Subscriber priority: ${subscriberPriority}`);
-
     const groupOrder = await this.decodeGroupOrder_();
-    shaka.log.debug(`Group order: ${groupOrder}`);
-
     const forward = await this.reader_.u8Bool();
-    shaka.log.debug(`Forward: ${forward}`);
-
     const filterType = /** @type {shaka.msf.Utils.FilterType} */(
       await this.reader_.u8());
-    shaka.log.debug(`Filter type: ${filterType}`);
 
     let startLocation;
     if (filterType === shaka.msf.Utils.FilterType.ABSOLUTE_START ||
         filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
       startLocation = await this.location_();
-      shaka.log.debug(`Start Location: ${JSON.stringify(startLocation)}`);
     }
 
     let endGroup;
     if (filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
       endGroup = await this.reader_.u62();
-      shaka.log.debug(`End group: ${endGroup}`);
     }
 
     const params = await this.reader_.keyValuePairs();
-    shaka.log.debug(`Parameters: ${params.length}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
@@ -267,28 +378,15 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async subscribeOk_() {
-    shaka.log.debug('Parsing SubscribeOk message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Request ID: ${requestId}`);
-
     const trackAlias = await this.reader_.u62();
-    shaka.log.debug(`Track Alias: ${trackAlias}`);
-
     const expires = await this.reader_.u62();
-    shaka.log.debug(`Expires: ${expires}`);
-
     const groupOrder = await this.decodeGroupOrder_();
-    shaka.log.debug(`Group order: ${groupOrder}`);
-
     const contentExists = await this.reader_.u8Bool();
-    shaka.log.debug(`Content exists: ${contentExists}`);
 
     let largest;
     if (contentExists) {
       largest = await this.location_();
-      shaka.log.debug(
-          `Largest: group ${largest.group}, object ${largest.object}`,
-      );
     }
 
     const params = await this.reader_.keyValuePairs();
@@ -310,25 +408,53 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async subscribeError_() {
-    shaka.log.debug('Parsing SubscribeError message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Subscribe ID: ${requestId}`);
-
     const code = await this.reader_.u62();
-    shaka.log.debug(`Code: ${code}`);
-
     const reason = await this.reader_.string();
-    shaka.log.debug(`Reason: ${reason}`);
-
-    const trackAlias = await this.reader_.u62();
-    shaka.log.debug(`Track Alias: ${trackAlias}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE_ERROR,
       requestId,
       code,
       reason,
-      trackAlias,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.SubscribeUpdate>}
+   * @private
+   */
+  async subscribeUpdate_() {
+    const requestId = await this.reader_.u62();
+    const subscriptionRequestId = await this.reader_.u62();
+    const startLocation = await this.location_();
+    const endGroup = await this.reader_.u62();
+    const subscriberPriority = await this.reader_.u8();
+    const forward = await this.reader_.u8Bool();
+    const params = await this.reader_.keyValuePairs();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+      requestId,
+      subscriptionRequestId,
+      startLocation,
+      endGroup,
+      subscriberPriority,
+      forward,
+      params,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.Unsubscribe>}
+   * @private
+   */
+  async unsubscribe_() {
+    const requestId = await this.reader_.u62();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      requestId,
     };
   }
 
@@ -337,18 +463,10 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async publishDone_() {
-    shaka.log.debug('Parsing PublishDone message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Subscribe ID: ${requestId}`);
-
     const code = await this.reader_.u62();
-    shaka.log.debug(`Code: ${code}`);
-
     const streamCount = await this.reader_.u53();
-    shaka.log.debug(`Stream count: ${streamCount}`);
-
     const reason = await this.reader_.string();
-    shaka.log.debug(`Reason: ${reason}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.PUBLISH_DONE,
@@ -360,17 +478,91 @@ shaka.msf.ControlStreamDecoder = class {
   }
 
   /**
-   * @return {!Promise<shaka.msf.Utils.Unsubscribe>}
+   * @return {!Promise<shaka.msf.Utils.Publish>}
    * @private
    */
-  async unsubscribe_() {
-    shaka.log.debug('Parsing Unsubscribe message...');
+  async publish_() {
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Subscribe ID: ${requestId}`);
+    const namespace = await this.reader_.tuple();
+    const name = await this.reader_.string();
+    const trackAlias = await this.reader_.u62();
+    const groupOrder = await this.decodeGroupOrder_();
+    const contentExists = await this.reader_.u8Bool();
+
+    let largestLocation;
+    if (contentExists) {
+      largestLocation = await this.location_();
+    }
+
+    const forward = await this.reader_.u8Bool();
+    const params = await this.reader_.keyValuePairs();
 
     return {
-      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH,
       requestId,
+      namespace,
+      name,
+      trackAlias,
+      groupOrder,
+      contentExists,
+      largestLocation,
+      forward,
+      params,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.PublishOk>}
+   * @private
+   */
+  async publishOk_() {
+    const requestId = await this.reader_.u62();
+    const forward = await this.reader_.u8Bool();
+    const subscriberPriority = await this.reader_.u8();
+    const groupOrder = await this.decodeGroupOrder_();
+    const filterType = /** @type {shaka.msf.Utils.FilterType} */(
+      await this.reader_.u8());
+
+    let startLocation;
+    if (filterType === shaka.msf.Utils.FilterType.ABSOLUTE_START ||
+        filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
+      startLocation = await this.location_();
+    }
+
+    let endGroup;
+    if (filterType === shaka.msf.Utils.FilterType.ABSOLUTE_RANGE) {
+      endGroup = await this.reader_.u62();
+    }
+
+    const params = await this.reader_.keyValuePairs();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+      requestId,
+      forward,
+      subscriberPriority,
+      groupOrder,
+      filterType,
+      startLocation,
+      endGroup,
+      params,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.PublishError>}
+   * @private
+   */
+  async publishError_() {
+    const requestId = await this.reader_.u62();
+    const errorCode = await this.reader_.u62();
+    const reason = await this.reader_.string();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+      requestId,
+      errorCode,
+      reason,
     };
   }
 
@@ -379,15 +571,9 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async publishNamespace_() {
-    shaka.log.debug('Parsing PublishNamespace message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Request ID: ${requestId}`);
-
     const namespace = await this.reader_.tuple();
-    shaka.log.debug(`Namespace: ${namespace.join('/')}`);
-
     const params = await this.reader_.keyValuePairs();
-    shaka.log.debug(`Parameters: ${params.length}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE,
@@ -402,17 +588,11 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async publishNamespaceOk_() {
-    shaka.log.debug('Parsing PublishNamespaceOk message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Request ID: ${requestId}`);
-
-    const namespace = await this.reader_.tuple();
-    shaka.log.debug(`Namespace: ${namespace.join('/')}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_OK,
       requestId,
-      namespace,
     };
   }
 
@@ -421,15 +601,9 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async publishNamespaceError_() {
-    shaka.log.debug('Parsing PublishNamespaceError message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Request ID: ${requestId}`);
-
     const code = await this.reader_.u62();
-    shaka.log.debug(`Error code: ${code}`);
-
     const reason = await this.reader_.string();
-    shaka.log.debug(`Error reason: ${reason}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_ERROR,
@@ -440,17 +614,32 @@ shaka.msf.ControlStreamDecoder = class {
   }
 
   /**
-   * @return {!Promise<shaka.msf.Utils.UnpublishNamespace>}
+   * @return {!Promise<shaka.msf.Utils.PublishNamespaceDone>}
    * @private
    */
-  async unpublishNamespace_() {
-    shaka.log.debug('Parsing UnpublishNamespace message...');
+  async publishNamespaceDone_() {
     const namespace = await this.reader_.tuple();
-    shaka.log.debug(`Namespace: ${namespace.join('/')}`);
 
     return {
-      kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
       namespace,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.PublishNamespaceCancel>}
+   * @private
+   */
+  async publishNamespaceCancel_() {
+    const namespace = await this.reader_.tuple();
+    const errorCode = await this.reader_.u62();
+    const reason = await this.reader_.string();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+      namespace,
+      errorCode,
+      reason,
     };
   }
 
@@ -463,15 +652,9 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async subscribeNamespace_() {
-    shaka.log.debug('Parsing SubscribeNamespace message...');
     const requestId = await this.reader_.u62();
-    shaka.log.debug(`Request ID: ${requestId}`);
-
     const namespace = await this.reader_.tuple();
-    shaka.log.debug(`Namespace: ${namespace.join('/')}`);
-
     const params = await this.reader_.keyValuePairs();
-    shaka.log.debug(`Parameters: ${params.length}`);
 
     return {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
@@ -482,18 +665,45 @@ shaka.msf.ControlStreamDecoder = class {
   }
 
   /**
-   * @return {!Promise<shaka.msf.Utils.RequestsBlocked>}
+   * @return {!Promise<shaka.msf.Utils.SubscribeNamespaceOk>}
    * @private
    */
-  async requestsBlocked_() {
-    shaka.log.debug('Parsing REQUESTS_BLOCKED message...');
-    const maximumRequestId = await this.reader_.u62();
-    shaka.log.debug(`Server sent REQUESTS_BLOCKED: maximum request ID is
-        ${maximumRequestId}`);
+  async subscribeNamespaceOk_() {
+    const requestId = await this.reader_.u62();
 
     return {
-      kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
-      maximumRequestId,
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+      requestId,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.SubscribeNamespaceError>}
+   * @private
+   */
+  async subscribeNamespaceError_() {
+    const requestId = await this.reader_.u62();
+    const errorCode = await this.reader_.u62();
+    const reason = await this.reader_.string();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+      requestId,
+      errorCode,
+      reason,
+    };
+  }
+
+  /**
+   * @return {!Promise<shaka.msf.Utils.UnsubscribeNamespace>}
+   * @private
+   */
+  async unsubscribeNamespace_() {
+    const namespace = await this.reader_.tuple();
+
+    return {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
+      namespace,
     };
   }
 };
@@ -519,6 +729,18 @@ shaka.msf.ControlStreamEncoder = class {
 
     // Marshal the message based on its type
     switch (msg.kind) {
+      case shaka.msf.Utils.MessageType.GOAWAY:
+        writer.marshalGoaway(
+            /** @type {!shaka.msf.Utils.Goaway} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.MAX_REQUEST_ID:
+        writer.marshalMaxRequestId(
+            /** @type {!shaka.msf.Utils.MaxRequestId} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.REQUESTS_BLOCKED:
+        writer.marshalRequestsBlocked(
+            /** @type {!shaka.msf.Utils.RequestsBlocked} */ (msg));
+        break;
       case shaka.msf.Utils.MessageType.SUBSCRIBE:
         writer.marshalSubscribe(
             /** @type {!shaka.msf.Utils.Subscribe} */ (msg));
@@ -531,14 +753,38 @@ shaka.msf.ControlStreamEncoder = class {
         writer.marshalSubscribeError(
             /** @type {!shaka.msf.Utils.SubscribeError} */ (msg));
         break;
-      case shaka.msf.Utils.MessageType.PUBLISH_DONE:
-        writer.marshalPublishDone(
-            /** @type {!shaka.msf.Utils.PublishDone} */ (msg));
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE:
+        writer.marshalSubscribeUpdate(
+            /** @type {!shaka.msf.Utils.SubscribeUpdate} */ (msg));
         break;
       case shaka.msf.Utils.MessageType.UNSUBSCRIBE:
         writer.marshalUnsubscribe(
             /** @type {!shaka.msf.Utils.Unsubscribe} */ (msg));
         break;
+      case shaka.msf.Utils.MessageType.PUBLISH_DONE:
+        writer.marshalPublishDone(
+            /** @type {!shaka.msf.Utils.PublishDone} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH:
+        writer.marshalPublish(
+            /** @type {!shaka.msf.Utils.Publish} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_OK:
+        writer.marshalPublishOk(
+            /** @type {!shaka.msf.Utils.PublishOk} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_ERROR:
+        writer.marshalPublishError(
+            /** @type {!shaka.msf.Utils.PublishError} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.FETCH:
+      case shaka.msf.Utils.MessageType.FETCH_OK:
+      case shaka.msf.Utils.MessageType.FETCH_ERROR:
+      case shaka.msf.Utils.MessageType.FETCH_CANCEL:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS_OK:
+      case shaka.msf.Utils.MessageType.TRACK_STATUS_ERROR:
+        throw new Error(`Unsupported message type for encoding: ${msg.kind}`);
       case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE:
         writer.marshalPublishNamespace(
             /** @type {!shaka.msf.Utils.PublishNamespace} */ (msg));
@@ -551,9 +797,29 @@ shaka.msf.ControlStreamEncoder = class {
         writer.marshalPublishNamespaceError(
             /** @type {!shaka.msf.Utils.PublishNamespaceError} */ (msg));
         break;
-      case shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE:
-        writer.marshalUnpublishNamespace(
-            /** @type {!shaka.msf.Utils.UnpublishNamespace} */ (msg));
+      case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE:
+        writer.marshalPublishNamespaceDone(
+            /** @type {!shaka.msf.Utils.PublishNamespaceDone} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL:
+        writer.marshalPublishNamespaceCancel(
+            /** @type {!shaka.msf.Utils.PublishNamespaceCancel} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE:
+        writer.marshalSubscribeNamespace(
+            /** @type {!shaka.msf.Utils.SubscribeNamespace} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK:
+        writer.marshalSubscribeNamespaceOk(
+            /** @type {!shaka.msf.Utils.SubscribeNamespaceOk} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR:
+        writer.marshalSubscribeNamespaceError(
+            /** @type {!shaka.msf.Utils.SubscribeNamespaceError} */ (msg));
+        break;
+      case shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE:
+        writer.marshalUnsubscribeNamespace(
+            /** @type {!shaka.msf.Utils.UnsubscribeNamespace} */ (msg));
         break;
       default:
         throw new Error(`Unsupported message type for encoding: ${msg.kind}`);

--- a/lib/msf/msf_control_stream.js
+++ b/lib/msf/msf_control_stream.js
@@ -34,10 +34,8 @@ shaka.msf.ControlStream = class {
    * @return {!Promise<shaka.msf.Utils.Message>}
    */
   async receive() {
-    shaka.log.debug('Attempting to receive a control message...');
-    const msg = await this.decoder_.message();
-    shaka.log.debug('Received control message:', msg);
-    return msg;
+    const message = await this.decoder_.message();
+    return message;
   }
 
   /**
@@ -68,14 +66,13 @@ shaka.msf.ControlStreamDecoder = class {
    * @private
    */
   async messageType_() {
-    shaka.log.debug('Reading message type...');
     const type = await this.reader_.u53();
-    shaka.log.debug(`Raw message type: 0x${type.toString(16)}`);
 
     // Read the 16-bit MSB length field
     const lengthBytes = await this.reader_.read(2);
     const messageLength = (lengthBytes[0] << 8) | lengthBytes[1]; // MSB format
-    shaka.log.debug(`Message length (16-bit MSB): ${messageLength} bytes,
+    shaka.log.v1(`Raw message type: 0x${type.toString(16)}`,
+        `Message length (16-bit MSB): ${messageLength} bytes,
         actual length: ${this.reader_.getByteLength()}`);
 
     let msgType;
@@ -168,7 +165,7 @@ shaka.msf.ControlStreamDecoder = class {
         throw new Error(`Unknown message type: 0x${type.toString(16)}`);
     }
 
-    shaka.log.debug(`Parsed message type: ${msgType} (0x${type.toString(16)})`);
+    shaka.log.v1(`Parsed message type: ${msgType} (0x${type.toString(16)})`);
     return msgType;
   }
 
@@ -176,7 +173,6 @@ shaka.msf.ControlStreamDecoder = class {
    * @return {!Promise<shaka.msf.Utils.Message>}
    */
   async message() {
-    shaka.log.debug('Parsing control message...');
     const type = await this.messageType_();
 
     /** @type {shaka.msf.Utils.Message} */
@@ -827,7 +823,7 @@ shaka.msf.ControlStreamEncoder = class {
 
     // Get the marshaled bytes and write them to the output stream
     const bytes = writer.getBytes();
-    shaka.log.debug(
+    shaka.log.v1(
         `Marshaled ${bytes.length} bytes for message type: ${msg.kind}`);
 
     // Write the bytes directly to the output stream

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -155,7 +155,12 @@ shaka.msf.MSFParser = class {
     }
 
     try {
-      this.connection_ = await this.msfTransport_.connect(uri, fingerprint);
+      const filterTypeConfig = this.config_.msf.subscribeFilterType || 'latest_object';
+      const filterType = filterTypeConfig === 'next_group' ?
+          shaka.msf.Utils.FilterType.NEXT_GROUP_START :
+          shaka.msf.Utils.FilterType.LATEST_OBJECT;
+      this.connection_ = await this.msfTransport_.connect(
+          uri, fingerprint, filterType);
     } catch (error) {
       if (error instanceof shaka.util.Error) {
         throw error;

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -202,11 +202,14 @@ shaka.msf.MSFParser = class {
     try {
       catalog = await shaka.util.Functional.promiseWithTimeout(
           /* seconds= */ 10, this.catalogPromise_);
-    } catch (e) {
+    } catch (error) {
+      if (error instanceof shaka.util.Error) {
+        throw error;
+      }
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
           shaka.util.Error.Category.MANIFEST,
-          shaka.util.Error.Code.CATALOG_TIMEOUT);
+          shaka.util.Error.Code.MSF_CATALOG_TIMEOUT);
     }
 
     await this.processCatalog_(catalog);
@@ -387,8 +390,17 @@ shaka.msf.MSFParser = class {
       shaka.log.debug(`Successfully subscribed to catalog in namespace:
           ${namespaceStr} with track alias: ${trackAlias}`);
     } catch (error) {
-      shaka.log.error(`Error subscribing to catalog:
-          ${error instanceof Error ? error.message : String(error)}`);
+      shaka.log.error('Error subscribing to catalog:', error);
+      if (error && error.kind == shaka.msf.Utils.MessageType.SUBSCRIBE_ERROR) {
+        this.catalogPromise_.reject(new shaka.util.Error(
+            shaka.util.Error.Severity.CRITICAL,
+            shaka.util.Error.Category.MANIFEST,
+            shaka.util.Error.Code.MSF_NO_CATALOG,
+            error.code,
+            error.reason));
+      } else {
+        this.catalogPromise_.reject(error);
+      }
     }
   }
 

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -431,8 +431,8 @@ shaka.msf.MSFParser = class {
 
       const trackAlias = await this.msfTransport_.subscribeTrack(
           namespace, trackName, (obj) => {
-            shaka.log.debug(
-                `Received object for track ${trackKey} with ${obj}`);
+            shaka.log.v1(
+                `Received object for track ${trackKey} with`, obj);
             callback(obj);
           });
 

--- a/lib/msf/msf_receiver.js
+++ b/lib/msf/msf_receiver.js
@@ -25,16 +25,16 @@ shaka.msf.Receiver = class {
    * @return {!Promise<shaka.msf.Utils.ServerSetup>}
    */
   async server() {
-    const SetupType = shaka.msf.Utils.SetupType;
+    const SERVER_SETUP = shaka.msf.Utils.MessageTypeId.SERVER_SETUP;
     shaka.log.debug('Decoding server setup message...');
 
     const type = await this.reader_.u53();
     shaka.log.debug(`Setup message type: 0x${type.toString(16)}
-        (expected 0x${SetupType.SERVER.toString(16)})`);
+        (expected 0x${SERVER_SETUP.toString(16)})`);
 
-    if (type !== SetupType.SERVER) {
+    if (type !== SERVER_SETUP) {
       const errorMsg =
-          `Server SETUP type must be ${SetupType.SERVER}, got ${type}`;
+          `Server SETUP type must be ${SERVER_SETUP}, got ${type}`;
       shaka.log.error(errorMsg);
       throw new Error(errorMsg);
     }

--- a/lib/msf/msf_receiver.js
+++ b/lib/msf/msf_receiver.js
@@ -26,10 +26,10 @@ shaka.msf.Receiver = class {
    */
   async server() {
     const SERVER_SETUP = shaka.msf.Utils.MessageTypeId.SERVER_SETUP;
-    shaka.log.debug('Decoding server setup message...');
+    shaka.log.v1('Decoding server setup message...');
 
     const type = await this.reader_.u53();
-    shaka.log.debug(`Setup message type: 0x${type.toString(16)}
+    shaka.log.v1(`Setup message type: 0x${type.toString(16)}
         (expected 0x${SERVER_SETUP.toString(16)})`);
 
     if (type !== SERVER_SETUP) {
@@ -42,13 +42,13 @@ shaka.msf.Receiver = class {
     // Read the 16-bit MSB length field
     const lengthBytes = await this.reader_.read(2);
     const messageLength = (lengthBytes[0] << 8) | lengthBytes[1]; // MSB format
-    shaka.log.debug(`Message length (16-bit MSB): ${messageLength} bytes`);
+    shaka.log.v1(`Message length (16-bit MSB): ${messageLength} bytes`);
 
     // Store the current position to validate length later
     const startPosition = this.reader_.getByteLength();
 
     const version = await this.reader_.u53();
-    shaka.log.debug(`Server selected version: 0x${version.toString(16)}`);
+    shaka.log.v1(`Server selected version: 0x${version.toString(16)}`);
 
     const params = await this.parameters();
     shaka.log.v1(

--- a/lib/msf/msf_sender.js
+++ b/lib/msf/msf_sender.js
@@ -39,11 +39,11 @@ shaka.msf.Sender = class {
 
     // Get the bytes from the writer
     const bytes = writer.getBytes();
-    shaka.log.debug(`Client setup message created: ${bytes.length} bytes`);
+    shaka.log.v1(`Client setup message created: ${bytes.length} bytes`);
 
     // Write the entire message in a single operation
     await this.writer_.write(bytes);
 
-    shaka.log.debug('Client setup message sent successfully');
+    shaka.log.v1('Client setup message sent successfully');
   }
 };

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -97,14 +97,14 @@ shaka.msf.TracksManager = class {
    * @private
    */
   async handleIncomingStream_(stream) {
-    shaka.log.debug('Received new incoming unidirectional stream');
+    shaka.log.v1('Received new incoming unidirectional stream');
 
     const reader = new shaka.msf.Reader(new Uint8Array([]), stream);
 
     try {
       // Read the stream type
       const streamType = await reader.u62();
-      shaka.log.debug(`Incoming Unidirectional Stream. Type: ${streamType}`);
+      shaka.log.v1(`Incoming Unidirectional Stream. Type: ${streamType}`);
 
       const FETCH_HEADER = BigInt(0x05);
       const SUBGROUP_HEADER_START_DRAFT_11 = BigInt(0x08);
@@ -163,7 +163,7 @@ shaka.msf.TracksManager = class {
 
       // Read the group ID
       const groupId = await reader.u62();
-      shaka.log.debug(`Track alias: ${trackAlias} Group ID: ${groupId}`);
+      shaka.log.v1(`Track alias: ${trackAlias} Group ID: ${groupId}`);
 
       // Determine subgroup ID based on the stream type
       let subgroupId = null;
@@ -182,25 +182,25 @@ shaka.msf.TracksManager = class {
           streamType === BigInt(0x10) || streamType === BigInt(0x11) ||
           streamType === BigInt(0x18) || streamType === BigInt(0x19)) {
         subgroupId = BigInt(0);
-        shaka.log.debug(`Subgroup ID: ${subgroupId} (implicit)`);
+        shaka.log.v1(`Subgroup ID: ${subgroupId} (implicit)`);
       // draft-11: 0x0a-0x0b
       } else if (streamType === BigInt(0x0a) || streamType === BigInt(0x0b) ||
           streamType === BigInt(0x12) || streamType === BigInt(0x13) ||
           streamType === BigInt(0x1a) || streamType === BigInt(0x1b)) {
         // SubgroupID = first Object ID (will be set when first object is read)
-        shaka.log.debug('Subgroup ID will be set to the first Object ID');
+        shaka.log.v1('Subgroup ID will be set to the first Object ID');
       // draft-11: 0x0c-0x0d
       } else if (streamType === BigInt(0x0c) || streamType === BigInt(0x0d) ||
            streamType === BigInt(0x14) || streamType === BigInt(0x15) ||
            streamType === BigInt(0x1c) || streamType === BigInt(0x1d)) {
         // SubgroupID is explicitly provided
         subgroupId = await reader.u62();
-        shaka.log.debug(`Subgroup ID: ${subgroupId} (explicit)`);
+        shaka.log.v1(`Subgroup ID: ${subgroupId} (explicit)`);
       }
 
       // Read the Publisher Priority (as specified in the SUBGROUP_HEADER)
       const publisherPriority = await reader.u8();
-      shaka.log.debug(`Publisher Priority: ${publisherPriority}`);
+      shaka.log.v1(`Publisher Priority: ${publisherPriority}`);
 
       // Buffer for objects while waiting for track registration
       /** @type {!Array<!shaka.msf.Utils.MOQObject>} */
@@ -216,13 +216,13 @@ shaka.msf.TracksManager = class {
         // Read the object ID
         // eslint-disable-next-line no-await-in-loop
         const objectId = await reader.u62();
-        shaka.log.debug(`Object ID: ${objectId}`);
+        shaka.log.v1(`Object ID: ${objectId}`);
 
         // If this is the first object and subgroupId is null
         // (types 0x0A-0x0B), set the subgroupId to the objectId
         if (isFirstObject && subgroupId === null) {
           subgroupId = objectId;
-          shaka.log.debug(`Subgroup ID set to first Object ID: ${subgroupId}`);
+          shaka.log.v1(`Subgroup ID set to first Object ID: ${subgroupId}`);
         }
         isFirstObject = false;
 
@@ -236,7 +236,7 @@ shaka.msf.TracksManager = class {
             const extensionLength = Number(extensionHeadersLength);
             // eslint-disable-next-line no-await-in-loop
             extensions = await reader.read(extensionLength);
-            shaka.log.debug(
+            shaka.log.v1(
                 `Read ${extensionLength} bytes of extension headers`);
           }
         }
@@ -244,14 +244,14 @@ shaka.msf.TracksManager = class {
         // Read the object payload length
         // eslint-disable-next-line no-await-in-loop
         const payloadLength = await reader.u62();
-        shaka.log.debug(`Object payload length: ${payloadLength}`);
+        shaka.log.v1(`Object payload length: ${payloadLength}`);
 
         // Read object status if payload length is zero
         let objectStatus = null;
         if (payloadLength === BigInt(0)) {
           // eslint-disable-next-line no-await-in-loop
           objectStatus = await reader.u62();
-          shaka.log.debug(`Object status: ${objectStatus}`);
+          shaka.log.v1(`Object status: ${objectStatus}`);
         }
 
         // Read the object data
@@ -259,7 +259,7 @@ shaka.msf.TracksManager = class {
             // eslint-disable-next-line no-await-in-loop
             await reader.read(Number(payloadLength)) : new Uint8Array([]);
         if (payloadLength > BigInt(0)) {
-          shaka.log.debug(`Read ${data.byteLength} bytes of object data`);
+          shaka.log.v1(`Read ${data.byteLength} bytes of object data`);
         }
 
         /** @type {shaka.msf.Utils.MOQObject} */
@@ -362,7 +362,7 @@ shaka.msf.TracksManager = class {
         }
       }
 
-      shaka.log.debug(`Finished processing SUBGROUP_HEADER stream for track
+      shaka.log.v1(`Finished processing SUBGROUP_HEADER stream for track
           ${trackAlias}`);
     } catch (error) {
       // Suppress errors during shutdown - they are expected

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -27,7 +27,8 @@ shaka.msf.TracksManager = class {
    * @param {!shaka.msf.ControlStream} controlStream
    * @param {!shaka.msf.MSFTransport} msfTransport
    */
-  constructor(webTransport, controlStream, msfTransport) {
+  constructor(webTransport, controlStream, msfTransport,
+      subscribeFilterType = shaka.msf.Utils.FilterType.LATEST_OBJECT) {
     /** @private {!WebTransport} */
     this.webTransport_ = webTransport;
     /** @private {!shaka.msf.ControlStream} */
@@ -42,6 +43,8 @@ shaka.msf.TracksManager = class {
     this.timersSet_ = new Set();
     /** @private {boolean} */
     this.isClosing_ = false;
+    /** @private {shaka.msf.Utils.FilterType} */
+    this.subscribeFilterType_ = subscribeFilterType;
 
     this.startListeningForStreams_();
   }
@@ -449,8 +452,8 @@ shaka.msf.TracksManager = class {
       groupOrder: shaka.msf.Utils.GroupOrder.PUBLISHER,
       // Forward mode by default
       forward: true,
-      // No filtering by default
-      filterType: shaka.msf.Utils.FilterType.NEXT_GROUP_START,
+      // Filter type for subscribe — configurable via manifest.msf.subscribeFilterType
+      filterType: this.subscribeFilterType_,
       params: [],
     };
 

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -483,9 +483,8 @@ shaka.msf.TracksManager = class {
             (response) => {
               unregisterOk();
               shaka.log.error(`Received SubscribeError for
-                  ${namespace}:${trackName}: ${JSON.stringify(response)}`);
-              reject(
-                  new Error(`Subscribe failed: ${JSON.stringify(response)}`));
+                  ${namespace}:${trackName}:`, response);
+              reject(response);
             });
 
         // Timeout after 2 seconds

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -49,8 +49,10 @@ shaka.msf.MSFTransport = class {
   /**
    * @param {string} uri
    * @param {?Uint8Array} fingerprint
+   * @param {shaka.msf.Utils.FilterType=} subscribeFilterType
    */
-  async connect(uri, fingerprint) {
+  async connect(uri, fingerprint,
+      subscribeFilterType = shaka.msf.Utils.FilterType.LATEST_OBJECT) {
     if (!window.WebTransport) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -113,7 +115,7 @@ shaka.msf.MSFTransport = class {
 
     // Create tracks manager for handling data streams
     this.tracksManager_ = new shaka.msf.TracksManager(
-        this.webTransport_, controlStream, this);
+        this.webTransport_, controlStream, this, subscribeFilterType);
     shaka.log.v1(
         'Tracks manager created with control stream and client reference');
 

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -72,18 +72,18 @@ shaka.msf.MSFTransport = class {
     }
     this.webTransport_ = new WebTransport(uri, options);
     await this.webTransport_.ready;
-    shaka.log.debug('WebTransport connection established');
+    shaka.log.v1('WebTransport connection established');
 
     /** @type {!WebTransportBidirectionalStream} */
     const stream = await this.webTransport_.createBidirectionalStream();
-    shaka.log.debug('Bidirectional stream created', stream);
+    shaka.log.v1('Bidirectional stream created', stream);
 
     const writer = new shaka.msf.Writer(stream.writable);
     const reader = new shaka.msf.Reader(new Uint8Array([]), stream.readable);
 
     const sender = new shaka.msf.Sender(writer);
     // Send the client setup message
-    shaka.log.debug('Sending client setup message');
+    shaka.log.v1('Sending client setup message');
     const versions = [
       shaka.msf.Utils.Version.DRAFT_14,
     ];
@@ -99,9 +99,9 @@ shaka.msf.MSFTransport = class {
 
     const receiver = new shaka.msf.Receiver(reader);
     // Receive the server setup message
-    shaka.log.debug('Waiting for server setup message');
+    shaka.log.v1('Waiting for server setup message');
     const server = await receiver.server();
-    shaka.log.debug('Received server setup:', server);
+    shaka.log.v1('Received server setup:', server);
 
     if (!versions.includes(server.version)) {
       throw new Error(`Unsupported server version: ${server.version}`);
@@ -109,12 +109,12 @@ shaka.msf.MSFTransport = class {
 
     // Create control stream for handling control messages
     const controlStream = new shaka.msf.ControlStream(reader, writer);
-    shaka.log.debug('Control stream established');
+    shaka.log.v1('Control stream established');
 
     // Create tracks manager for handling data streams
     this.tracksManager_ = new shaka.msf.TracksManager(
         this.webTransport_, controlStream, this);
-    shaka.log.debug(
+    shaka.log.v1(
         'Tracks manager created with control stream and client reference');
 
     // Create a Connection object with the client instance to access
@@ -130,7 +130,7 @@ shaka.msf.MSFTransport = class {
 
   /** @override */
   release() {
-    shaka.log.debug('Closing client connection');
+    shaka.log.v1('Closing client connection');
     this.publishNamespaceCallbacks_.clear();
 
     this.tracksManager_?.release();
@@ -147,7 +147,7 @@ shaka.msf.MSFTransport = class {
   getNextRequestId() {
     const requestId = this.nextRequestId_;
     this.nextRequestId_ += BigInt(2);
-    shaka.log.debug(`Generated new request ID: ${requestId}`);
+    shaka.log.v1(`Generated new request ID: ${requestId}`);
     return requestId;
   }
 
@@ -159,7 +159,7 @@ shaka.msf.MSFTransport = class {
    * @private
    */
   async listenForControlMessages_(controlStream) {
-    shaka.log.debug('Starting to listen for control messages');
+    shaka.log.v1('Starting to listen for control messages');
     try {
       while (true) {
         // eslint-disable-next-line no-await-in-loop
@@ -243,7 +243,7 @@ shaka.msf.MSFTransport = class {
    * @return {function()} A function to unregister the handler
    */
   registerMessageHandler(kind, requestId, handler) {
-    shaka.log.debug(`Registering handler for message kind ${kind} with
+    shaka.log.v1(`Registering handler for message kind ${kind} with
         requestId ${requestId}`);
 
     // Initialize the map for this message kind if it doesn't exist
@@ -264,7 +264,7 @@ shaka.msf.MSFTransport = class {
 
     // Return a function to unregister the handler
     return () => {
-      shaka.log.debug(`Unregistering handler for message kind ${kind} with
+      shaka.log.v1(`Unregistering handler for message kind ${kind} with
           requestId ${requestId}`);
       const handlersMap = this.messageHandlers_.get(kind);
       if (handlersMap) {
@@ -286,7 +286,7 @@ shaka.msf.MSFTransport = class {
       throw new Error('Cannot subscribe: Tracks manager not initialized');
     }
 
-    shaka.log.debug(`Client subscribing to track ${namespace}:${trackName}`);
+    shaka.log.v1(`Client subscribing to track ${namespace}:${trackName}`);
     return this.tracksManager_.subscribeTrack(namespace, trackName, callback);
   }
 
@@ -301,7 +301,7 @@ shaka.msf.MSFTransport = class {
       throw new Error('Cannot unsubscribe: Tracks manager not initialized');
     }
 
-    shaka.log.debug(`Client unsubscribing from track with alias ${trackAlias}`);
+    shaka.log.v1(`Client unsubscribing from track with alias ${trackAlias}`);
     await this.tracksManager_.unsubscribeTrack(trackAlias);
   }
 
@@ -312,12 +312,12 @@ shaka.msf.MSFTransport = class {
    * @return {function()} A function to unregister the callback
    */
   registerPublishNamespaceCallback(callback) {
-    shaka.log.debug('Registering PublishNamespace callback');
+    shaka.log.v1('Registering PublishNamespace callback');
     this.publishNamespaceCallbacks_.add(callback);
 
     // Return a function to unregister the callback
     return () => {
-      shaka.log.debug('Unregistering PublishNamespace callback');
+      shaka.log.v1('Unregistering PublishNamespace callback');
       this.publishNamespaceCallbacks_.delete(callback);
     };
   }
@@ -361,7 +361,7 @@ shaka.msf.MSFConnection = class {
    * @return {!Promise}
    */
   async close(code = 0, reason = '') {
-    shaka.log.debug(`Closing connection with code ${code}: ${reason}`);
+    shaka.log.v1(`Closing connection with code ${code}: ${reason}`);
     this.webTransport_.close({closeCode: code, reason});
     await this.webTransport_.closed;
   }

--- a/lib/msf/msf_utils.js
+++ b/lib/msf/msf_utils.js
@@ -17,20 +17,36 @@ shaka.msf.Utils = class {
  * @enum {number}
  */
 shaka.msf.Utils.MessageTypeId = {
+  CLIENT_SETUP: 0x20,
+  SERVER_SETUP: 0x21,
+  GOAWAY: 0x10,
+  MAX_REQUEST_ID: 0x15,
+  REQUESTS_BLOCKED: 0x1a,
   SUBSCRIBE: 0x3,
   SUBSCRIBE_OK: 0x4,
   SUBSCRIBE_ERROR: 0x5,
   SUBSCRIBE_UPDATE: 0x2,
-  PUBLISH_DONE: 0xb,
   UNSUBSCRIBE: 0xa,
+  PUBLISH_DONE: 0xb,
+  PUBLISH: 0x1d,
+  PUBLISH_OK: 0x1e,
+  PUBLISH_ERROR: 0x1f,
+  FETCH: 0x16,
+  FETCH_OK: 0x18,
+  FETCH_ERROR: 0x19,
+  FETCH_CANCEL: 0x17,
+  TRACK_STATUS: 0xd,
+  TRACK_STATUS_OK: 0xe,
+  TRACK_STATUS_ERROR: 0xf,
   PUBLISH_NAMESPACE: 0x6,
   PUBLISH_NAMESPACE_OK: 0x7,
   PUBLISH_NAMESPACE_ERROR: 0x8,
-  UNPUBLISH_NAMESPACE: 0x9,
+  PUBLISH_NAMESPACE_DONE: 0x9,
+  PUBLISH_NAMESPACE_CANCEL: 0xc,
   SUBSCRIBE_NAMESPACE: 0x11,
-  REQUESTS_BLOCKED: 0x1a,
-  CLIENT_SETUP: 0x20,
-  SERVER_SETUP: 0x21,
+  SUBSCRIBE_NAMESPACE_OK: 0x12,
+  SUBSCRIBE_NAMESPACE_ERROR: 0x13,
+  UNSUBSCRIBE_NAMESPACE: 0x14,
 };
 
 /**
@@ -39,18 +55,34 @@ shaka.msf.Utils.MessageTypeId = {
  * @enum {string}
  */
 shaka.msf.Utils.MessageType = {
+  GOAWAY: 'goaway',
+  MAX_REQUEST_ID: 'max_request_id',
+  REQUESTS_BLOCKED: 'requests_blocked',
   SUBSCRIBE: 'subscribe',
   SUBSCRIBE_OK: 'subscribe_ok',
   SUBSCRIBE_ERROR: 'subscribe_error',
   SUBSCRIBE_UPDATE: 'subscribe_update',
-  PUBLISH_DONE: 'publish_done',
   UNSUBSCRIBE: 'unsubscribe',
+  PUBLISH_DONE: 'publish_done',
+  PUBLISH: 'publish',
+  PUBLISH_OK: 'publish_ok',
+  PUBLISH_ERROR: 'publish_error',
+  FETCH: 'fetch',
+  FETCH_OK: 'fetch_ok',
+  FETCH_ERROR: 'fetch_error',
+  FETCH_CANCEL: 'fetch_cancel',
+  TRACK_STATUS: 'track_status',
+  TRACK_STATUS_OK: 'track_status_ok',
+  TRACK_STATUS_ERROR: 'track_status_error',
   PUBLISH_NAMESPACE: 'publish_namespace',
   PUBLISH_NAMESPACE_OK: 'publish_namespace_ok',
   PUBLISH_NAMESPACE_ERROR: 'publish_namespace_error',
-  UNPUBLISH_NAMESPACE: 'unpublish_namespace',
+  PUBLISH_NAMESPACE_DONE: 'publish_namespace_done',
+  PUBLISH_NAMESPACE_CANCEL: 'publish_namespace_cancel',
   SUBSCRIBE_NAMESPACE: 'subscribe_namespace',
-  REQUESTS_BLOCKED: 'requests_blocked',
+  SUBSCRIBE_NAMESPACE_OK: 'subscribe_namespace_ok',
+  SUBSCRIBE_NAMESPACE_ERROR: 'subscribe_namespace_error',
+  UNSUBSCRIBE_NAMESPACE: 'unsubscribe_namespace',
 };
 
 /**
@@ -80,14 +112,6 @@ shaka.msf.Utils.Version = {
   DRAFT_14: 0xff00000e,
 };
 
-/**
- * @enum {number}
- */
-shaka.msf.Utils.SetupType = {
-  CLIENT: 0x20,
-  SERVER: 0x21,
-};
-
 
 /**
  * @typedef {{
@@ -106,6 +130,33 @@ shaka.msf.Utils.KeyValuePair;
  * }}
  */
 shaka.msf.Utils.Location;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   newSessionUri: string,
+ * }}
+ */
+shaka.msf.Utils.Goaway;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   requestId: bigint,
+ * }}
+ */
+shaka.msf.Utils.MaxRequestId;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   maximumRequestId: bigint,
+ * }}
+ */
+shaka.msf.Utils.RequestsBlocked;
 
 
 /**
@@ -147,7 +198,6 @@ shaka.msf.Utils.SubscribeOk;
  *   requestId: bigint,
  *   code: bigint,
  *   reason: string,
- *   trackAlias: bigint,
  * }}
  */
 shaka.msf.Utils.SubscribeError;
@@ -193,6 +243,50 @@ shaka.msf.Utils.PublishDone;
  *   kind: shaka.msf.Utils.MessageType,
  *   requestId: bigint,
  *   namespace: Array<string>,
+ *   name: string,
+ *   trackAlias: bigint,
+ *   groupOrder: shaka.msf.Utils.GroupOrder,
+ *   contentExists: boolean,
+ *   largestLocation: (shaka.msf.Utils.Location|undefined),
+ *   forward: boolean,
+ *   params: Array<shaka.msf.Utils.KeyValuePair>,
+ * }}
+ */
+shaka.msf.Utils.Publish;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   requestId: bigint,
+ *   forward: boolean,
+ *   subscriberPriority: number,
+ *   groupOrder: shaka.msf.Utils.GroupOrder,
+ *   filterType: shaka.msf.Utils.FilterType,
+ *   startLocation: (shaka.msf.Utils.Location|undefined),
+ *   endGroup: (bigint|undefined),
+ *   params: Array<shaka.msf.Utils.KeyValuePair>,
+ * }}
+ */
+shaka.msf.Utils.PublishOk;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   requestId: bigint,
+ *   errorCode: bigint,
+ *   reason: string,
+ * }}
+ */
+shaka.msf.Utils.PublishError;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   requestId: bigint,
+ *   namespace: Array<string>,
  *   params: Array<shaka.msf.Utils.KeyValuePair>,
  * }}
  */
@@ -203,7 +297,6 @@ shaka.msf.Utils.PublishNamespace;
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
  *   requestId: bigint,
- *   namespace: Array<string>,
  * }}
  */
 shaka.msf.Utils.PublishNamespaceOk;
@@ -226,26 +319,55 @@ shaka.msf.Utils.PublishNamespaceError;
  *   namespace: Array<string>,
  * }}
  */
-shaka.msf.Utils.UnpublishNamespace;
+shaka.msf.Utils.PublishNamespaceDone;
 
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   namespace: Array<string>,
+ *   errorCode: bigint,
+ *   reason: string,
+ * }}
+ */
+shaka.msf.Utils.PublishNamespaceCancel;
 
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
  *   requestId: bigint,
  *   namespace: Array<string>,
+ *   params: Array<shaka.msf.Utils.KeyValuePair>,
  * }}
  */
 shaka.msf.Utils.SubscribeNamespace;
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   requestId: bigint,
+ * }}
+ */
+shaka.msf.Utils.SubscribeNamespaceOk;
 
 
 /**
  * @typedef {{
  *   kind: shaka.msf.Utils.MessageType,
- *   maximumRequestId: bigint,
+ *   requestId: bigint,
+ *   errorCode: bigint,
+ *   reason: string,
  * }}
  */
-shaka.msf.Utils.RequestsBlocked;
+shaka.msf.Utils.SubscribeNamespaceError;
+
+
+/**
+ * @typedef {{
+ *   kind: shaka.msf.Utils.MessageType,
+ *   namespace: Array<string>,
+ * }}
+ */
+shaka.msf.Utils.UnsubscribeNamespace;
 
 
 /**
@@ -267,17 +389,29 @@ shaka.msf.Utils.ServerSetup;
 
 
 /**
- * @typedef {shaka.msf.Utils.Subscribe|shaka.msf.Utils.Unsubscribe|
+ * @typedef {shaka.msf.Utils.Subscribe|
+ *           shaka.msf.Utils.Unsubscribe|
  *           shaka.msf.Utils.PublishNamespaceOk|
- *           shaka.msf.Utils.PublishNamespaceError}
+ *           shaka.msf.Utils.PublishNamespaceError|
+ *           shaka.msf.Utils.Goaway|
+ *           shaka.msf.Utils.MaxRequestId|
+ *           shaka.msf.Utils.Publish|
+ *           shaka.msf.Utils.PublishOk|
+ *           shaka.msf.Utils.PublishError|
+ *           shaka.msf.Utils.UnsubscribeNamespace|
+ *           shaka.msf.Utils.SubscribeNamespaceOk|
+ *           shaka.msf.Utils.SubscribeNamespaceError}
  */
 shaka.msf.Utils.Subscriber;
 
 
 /**
- * @typedef {shaka.msf.Utils.SubscribeOk|shaka.msf.Utils.SubscribeError|
- *           shaka.msf.Utils.PublishDone|shaka.msf.Utils.PublishNamespace|
- *           shaka.msf.Utils.UnpublishNamespace|shaka.msf.Utils.RequestsBlocked|
+ * @typedef {shaka.msf.Utils.SubscribeOk|
+ *           shaka.msf.Utils.SubscribeError|
+ *           shaka.msf.Utils.PublishDone|
+ *           shaka.msf.Utils.PublishNamespace|
+ *           shaka.msf.Utils.PublishNamespaceDone|
+ *           shaka.msf.Utils.RequestsBlocked|
  *           shaka.msf.Utils.SubscribeNamespace}
  */
 shaka.msf.Utils.Publisher;

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -854,7 +854,7 @@ shaka.util.Error.Code = {
    * <br> error.data[0] is the error code.
    * <br> error.data[1] is the reason.
    */
-  'MSF_NO_CATALOG': 4058,
+  'MSF_NO_CATALOG': 4062,
 
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,

--- a/lib/util/error.js
+++ b/lib/util/error.js
@@ -831,7 +831,7 @@ shaka.util.Error.Code = {
   /**
    * A catalog request timed out.
    */
-  'CATALOG_TIMEOUT': 4058,
+  'MSF_CATALOG_TIMEOUT': 4058,
 
   /**
    * AES-256-GCM EXT-X-KEY must not include an IV attribute.
@@ -848,6 +848,13 @@ shaka.util.Error.Code = {
    * <br> error.data[0] is the URI associated with the JSON.
    */
   'DASH_INVALID_JSON': 4061,
+
+  /**
+   * MSF no catalog.
+   * <br> error.data[0] is the error code.
+   * <br> error.data[1] is the reason.
+   */
+  'MSF_NO_CATALOG': 4058,
 
   // RETIRED: 'INCONSISTENT_BUFFER_STATE': 5000,
   // RETIRED: 'INVALID_SEGMENT_INDEX': 5001,

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -180,6 +180,7 @@ shaka.util.PlayerConfiguration = class {
       msf: {
         fingerprintUri: '',
         namespaces: [],
+        subscribeFilterType: 'latest_object',
       },
     };
 

--- a/test/msf/buffer_control_writer_unit.js
+++ b/test/msf/buffer_control_writer_unit.js
@@ -176,13 +176,13 @@ filterDescribe('shaka.msf.BufferControlWriter', isMSFSupported, () => {
     });
   });
 
-  describe('marshalUnpublishNamespace', () => {
-    it('should marshal an UnpublishNamespace message', () => {
+  describe('marshalPublishNamespaceDone', () => {
+    it('should marshal an PublishNamespaceDone message', () => {
       const msg = {
-        kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
         namespace: ['ns'],
       };
-      writer.marshalUnpublishNamespace(msg);
+      writer.marshalPublishNamespaceDone(msg);
       expect(writer.getBytes().length).toBeGreaterThan(0);
     });
   });
@@ -309,5 +309,324 @@ filterDescribe('shaka.msf.BufferControlWriter', isMSFSupported, () => {
     expect(length).toBe(bytes.length - 3);
 
     expect(bytes[3]).toBeGreaterThan(0);
+  });
+
+  describe('marshalSubscribeUpdate', () => {
+    it('should marshal a valid SubscribeUpdate message', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: BigInt(1),
+        startLocation: {group: BigInt(10), object: BigInt(20)},
+        endGroup: BigInt(30),
+        subscriberPriority: 2,
+        forward: true,
+        params: [],
+      };
+      writer.marshalSubscribeUpdate(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('marshalPublish', () => {
+    it('should marshal a Publish with contentExists true', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH,
+        requestId: BigInt(1),
+        namespace: ['ns1'],
+        name: 'track1',
+        trackAlias: BigInt(2),
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        contentExists: true,
+        largestLocation: {group: BigInt(10), object: BigInt(20)},
+        forward: true,
+        params: [],
+      };
+      writer.marshalPublish(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it('should marshal a Publish with contentExists false', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH,
+        requestId: BigInt(1),
+        namespace: ['ns1'],
+        name: 'track1',
+        trackAlias: BigInt(2),
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        contentExists: false,
+        largestLocation: undefined,
+        forward: false,
+        params: [],
+      };
+      writer.marshalPublish(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('marshalPublishOk', () => {
+    it('should marshal with ABSOLUTE_START filter', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: BigInt(1),
+        subscriberPriority: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        forward: true,
+        filterType: shaka.msf.Utils.FilterType.ABSOLUTE_START,
+        startLocation: {group: BigInt(5), object: BigInt(6)},
+        params: [],
+      };
+      writer.marshalPublishOk(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it('should marshal with ABSOLUTE_RANGE filter', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: BigInt(1),
+        subscriberPriority: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        forward: true,
+        filterType: shaka.msf.Utils.FilterType.ABSOLUTE_RANGE,
+        startLocation: {group: BigInt(5), object: BigInt(6)},
+        endGroup: BigInt(10),
+        params: [],
+      };
+      writer.marshalPublishOk(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it('should throw if startLocation is missing for ABSOLUTE_START', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: BigInt(1),
+        subscriberPriority: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        forward: true,
+        filterType: shaka.msf.Utils.FilterType.ABSOLUTE_START,
+        startLocation: undefined,
+        params: [],
+      };
+      expect(() => writer.marshalPublishOk(msg)).toThrow();
+    });
+
+    it('should throw if endGroup is missing for ABSOLUTE_RANGE', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: BigInt(1),
+        subscriberPriority: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        forward: true,
+        filterType: shaka.msf.Utils.FilterType.ABSOLUTE_RANGE,
+        startLocation: {group: BigInt(5), object: BigInt(6)},
+        endGroup: undefined,
+        params: [],
+      };
+      expect(() => writer.marshalPublishOk(msg)).toThrow();
+    });
+  });
+
+  describe('marshalPublishError', () => {
+    it('should marshal a PublishError message', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+        requestId: BigInt(1),
+        errorCode: BigInt(500),
+        reason: 'Error occurred',
+      };
+      writer.marshalPublishError(msg);
+      const bytes = writer.getBytes();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('KeyValuePairs', () => {
+    it('should marshal even key with bigint value', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: BigInt(1),
+        startLocation: {group: BigInt(1), object: BigInt(2)},
+        endGroup: BigInt(5),
+        subscriberPriority: 1,
+        forward: false,
+        params: [{type: BigInt(2), value: BigInt(123)}],
+      };
+      writer.marshalSubscribeUpdate(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal odd key with Uint8Array value', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: BigInt(1),
+        startLocation: {group: BigInt(1), object: BigInt(2)},
+        endGroup: BigInt(5),
+        subscriberPriority: 1,
+        forward: false,
+        params: [{type: BigInt(3), value: new Uint8Array([1, 2, 3])}],
+      };
+      writer.marshalSubscribeUpdate(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should handle empty params array', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: BigInt(1),
+        startLocation: {group: BigInt(1), object: BigInt(2)},
+        endGroup: BigInt(5),
+        subscriberPriority: 1,
+        forward: false,
+        params: [],
+      };
+      writer.marshalSubscribeUpdate(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('marshalPublishNamespaceCancel', () => {
+    it('should marshal a PublishNamespaceCancel message', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+        namespace: ['ns1'],
+        errorCode: BigInt(404),
+        reason: 'Cancelled',
+      };
+      writer.marshalPublishNamespaceCancel(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('marshalSubscribeNamespace variants', () => {
+    it('should marshal SubscribeNamespace', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
+        requestId: BigInt(1),
+        namespace: ['ns1'],
+        params: [],
+      };
+      writer.marshalSubscribeNamespace(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal SubscribeNamespaceOk', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+        requestId: BigInt(1),
+      };
+      writer.marshalSubscribeNamespaceOk(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal SubscribeNamespaceError', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+        requestId: BigInt(1),
+        errorCode: BigInt(500),
+        reason: 'Error',
+      };
+      writer.marshalSubscribeNamespaceError(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal UnsubscribeNamespace', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
+        namespace: ['ns1'],
+      };
+      writer.marshalUnsubscribeNamespace(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Other messages', () => {
+    it('should marshal Goaway', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.GOAWAY,
+        newSessionUri: 'session://new',
+      };
+      writer.marshalGoaway(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal MaxRequestId', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+        requestId: BigInt(42),
+      };
+      writer.marshalMaxRequestId(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+
+    it('should marshal RequestsBlocked', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+        maximumRequestId: BigInt(99),
+      };
+      writer.marshalRequestsBlocked(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('marshalSubscribe with ABSOLUTE_RANGE filter', () => {
+    it('should throw if endGroup is missing', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
+        requestId: BigInt(1),
+        namespace: ['ns1'],
+        name: 'track',
+        subscriberPriority: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        forward: true,
+        filterType: shaka.msf.Utils.FilterType.ABSOLUTE_RANGE,
+        startLocation: {group: BigInt(1), object: BigInt(2)},
+        endGroup: undefined,
+        params: [],
+      };
+      expect(() => writer.marshalSubscribe(msg)).toThrow();
+    });
+  });
+
+  describe('marshalSubscribeOk with contentExists false', () => {
+    it('should marshal without largest', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_OK,
+        requestId: BigInt(1),
+        trackAlias: BigInt(2),
+        expires: BigInt(100),
+        groupOrder: shaka.msf.Utils.GroupOrder.ASCENDING,
+        contentExists: false,
+        largest: undefined,
+        params: [],
+      };
+      writer.marshalSubscribeOk(msg);
+      expect(writer.getBytes().length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Buffer integrity', () => {
+    it('marshalWithLength computes correct length', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        requestId: BigInt(123),
+      };
+      writer.marshalUnsubscribe(msg);
+      const bytes = writer.getBytes();
+      const lengthField = readUint16BE(bytes, 1);
+      expect(lengthField).toBe(bytes.length - 3);
+    });
+
+    it('marshal_ returns the writer for chaining', () => {
+      const msg = {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        requestId: BigInt(1),
+      };
+      const result = writer.marshalUnsubscribe(msg);
+      expect(result).toBe(writer);
+    });
   });
 });

--- a/test/msf/msf_classes_unit.js
+++ b/test/msf/msf_classes_unit.js
@@ -214,11 +214,11 @@ filterDescribe('shaka.msf.Receiver', isMSFSupported, () => {
   }
 
   it('should decode a server setup with no parameters', async () => {
-    const SetupType = shaka.msf.Utils.SetupType;
+    const SERVER_SETUP = shaka.msf.Utils.MessageTypeId.SERVER_SETUP;
 
     // type = SERVER, length = 1, version = 1, param count = 0
     const readerValues = [
-      SetupType.SERVER, // type
+      SERVER_SETUP, // type
       0x00, 0x01,       // message length = 1 byte
       0x01,             // version
       0x00,              // param count = 0
@@ -233,12 +233,12 @@ filterDescribe('shaka.msf.Receiver', isMSFSupported, () => {
   });
 
   it('should decode server setup with numeric parameter', async () => {
-    const SetupType = shaka.msf.Utils.SetupType;
+    const SERVER_SETUP = shaka.msf.Utils.MessageTypeId.SERVER_SETUP;
 
     // type = SERVER, length = 3 bytes, version = 1
     // param count = 1, param type = 2 (even), param value = 42
     const readerValues = [
-      SetupType.SERVER, // type
+      SERVER_SETUP, // type
       0x00, 0x03,       // message length
       0x01,             // version
       0x01,             // param count

--- a/test/msf/msf_control_stream_unit.js
+++ b/test/msf/msf_control_stream_unit.js
@@ -13,11 +13,31 @@ filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
 
   const messages = [
     {
+      kind: shaka.msf.Utils.MessageType.GOAWAY,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.GOAWAY,
+        newSessionUri: 'https://new.session',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+        requestId: 123,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+        maximumRequestId: 456,
+      },
+    },
+    {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
       msg: {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
         requestId: 1,
-        trackAlias: 1,
         namespace: ['ns'],
         name: 'track',
         subscriberPriority: 0,
@@ -45,7 +65,29 @@ filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
         requestId: 1,
         code: 404,
         reason: 'Not found',
-        trackAlias: 1,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: 1,
+        subscriptionRequestId: 2,
+        startLocation: {
+          group: 1,
+          object: 2,
+        },
+        endGroup: 10,
+        subscriberPriority: 0,
+        forward: true,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        requestId: 1,
       },
     },
     {
@@ -59,10 +101,42 @@ filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
       },
     },
     {
-      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH,
       msg: {
-        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        kind: shaka.msf.Utils.MessageType.PUBLISH,
         requestId: 1,
+        namespace: ['ns'],
+        name: 'track',
+        trackAlias: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.PUBLISHER,
+        contentExists: true,
+        largestLocation: {
+          group: 1,
+          object: 2,
+        },
+        forward: true,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: 1,
+        forward: true,
+        subscriberPriority: 0,
+        groupOrder: shaka.msf.Utils.GroupOrder.PUBLISHER,
+        filterType: shaka.msf.Utils.FilterType.NONE,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+        requestId: 1,
+        errorCode: 500,
+        reason: 'Server error',
       },
     },
     {
@@ -79,7 +153,6 @@ filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
       msg: {
         kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_OK,
         requestId: 1,
-        namespace: ['ns'],
       },
     },
     {
@@ -92,9 +165,50 @@ filterDescribe('shaka.msf.ControlStream', isMSFSupported, () => {
       },
     },
     {
-      kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
       msg: {
-        kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
+        namespace: ['ns'],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+        namespace: ['ns'],
+        errorCode: 500,
+        reason: 'Server error',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
+        requestId: 1,
+        namespace: ['ns'],
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+        requestId: 1,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+        requestId: 1,
+        errorCode: 500,
+        reason: 'Server error',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
         namespace: ['ns'],
       },
     },
@@ -154,11 +268,31 @@ describe('shaka.msf.ControlStreamEncoder', () => {
 
   const messages = [
     {
+      kind: shaka.msf.Utils.MessageType.GOAWAY,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.GOAWAY,
+        newSessionUri: 'https://new.session',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.MAX_REQUEST_ID,
+        requestId: 123,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.REQUESTS_BLOCKED,
+        maximumRequestId: 456,
+      },
+    },
+    {
       kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
       msg: {
         kind: shaka.msf.Utils.MessageType.SUBSCRIBE,
         requestId: 1,
-        trackAlias: 1,
         namespace: ['ns'],
         name: 'track',
         subscriberPriority: 0,
@@ -186,7 +320,29 @@ describe('shaka.msf.ControlStreamEncoder', () => {
         requestId: 1,
         code: 404,
         reason: 'Not found',
-        trackAlias: 1,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_UPDATE,
+        requestId: 1,
+        subscriptionRequestId: 2,
+        startLocation: {
+          group: 1,
+          object: 2,
+        },
+        endGroup: 10,
+        subscriberPriority: 0,
+        forward: true,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        requestId: 1,
       },
     },
     {
@@ -200,10 +356,42 @@ describe('shaka.msf.ControlStreamEncoder', () => {
       },
     },
     {
-      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH,
       msg: {
-        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE,
+        kind: shaka.msf.Utils.MessageType.PUBLISH,
         requestId: 1,
+        namespace: ['ns'],
+        name: 'track',
+        trackAlias: 1,
+        groupOrder: shaka.msf.Utils.GroupOrder.PUBLISHER,
+        contentExists: true,
+        largestLocation: {
+          group: 1,
+          object: 2,
+        },
+        forward: true,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_OK,
+        requestId: 1,
+        forward: true,
+        subscriberPriority: 0,
+        groupOrder: shaka.msf.Utils.GroupOrder.PUBLISHER,
+        filterType: shaka.msf.Utils.FilterType.NONE,
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_ERROR,
+        requestId: 1,
+        errorCode: 500,
+        reason: 'Server error',
       },
     },
     {
@@ -220,7 +408,6 @@ describe('shaka.msf.ControlStreamEncoder', () => {
       msg: {
         kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_OK,
         requestId: 1,
-        namespace: ['ns'],
       },
     },
     {
@@ -233,9 +420,50 @@ describe('shaka.msf.ControlStreamEncoder', () => {
       },
     },
     {
-      kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
       msg: {
-        kind: shaka.msf.Utils.MessageType.UNPUBLISH_NAMESPACE,
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_DONE,
+        namespace: ['ns'],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.PUBLISH_NAMESPACE_CANCEL,
+        namespace: ['ns'],
+        errorCode: 500,
+        reason: 'Server error',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE,
+        requestId: 1,
+        namespace: ['ns'],
+        params: [],
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_OK,
+        requestId: 1,
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.SUBSCRIBE_NAMESPACE_ERROR,
+        requestId: 1,
+        errorCode: 500,
+        reason: 'Server error',
+      },
+    },
+    {
+      kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
+      msg: {
+        kind: shaka.msf.Utils.MessageType.UNSUBSCRIBE_NAMESPACE,
         namespace: ['ns'],
       },
     },


### PR DESCRIPTION
## Summary

Add `manifest.msf.subscribeFilterType` config option to control the `filter_type` field in MoQ SUBSCRIBE messages.

## Problem

The hardcoded `NEXT_GROUP_START` filter type causes cold-start failures on MoQ relay networks with gossip-based routing. When a player connects to an edge relay that doesn't have the stream cached, the relay pulls it via gossip from the origin — but with `NEXT_GROUP_START`, the relay waits for the next group boundary before forwarding data. This often exceeds the subscribe timeout, causing playback failure.

The `LATEST_OBJECT` filter type tells the relay to start sending from the most recent available data immediately, which works reliably even on cold edge relays.

## Usage

```javascript
player.configure({
  manifest: {
    msf: {
      namespaces: ['my-stream'],
      subscribeFilterType: 'latest_object',  // default
    },
  },
});
```

Values: `'latest_object'` (default) or `'next_group'`

## Files

| File | Change |
|------|--------|
| `externs/shaka/player.js` | Add `subscribeFilterType` to `MsfManifestConfiguration` typedef |
| `lib/util/player_configuration.js` | Default value `'latest_object'` |
| `lib/msf/msf_parser.js` | Resolve config string to `FilterType` enum, pass to transport |
| `lib/msf/msf_transport.js` | Accept filter type param, pass to TracksManager |
| `lib/msf/msf_tracks_manager.js` | Use configured filter type in SUBSCRIBE messages |

## Test plan

- [x] Tested with `latest_object` on MoQ relay network with gossip routing — cold-start works
- [x] Tested with `next_group` — same behavior as before this change
- [x] Builds with Closure Compiler

Related to #9872

Author: erik@vivoh.com