### PR TITLE
feat(ui): add customTrackLabel callback for overriding track labels

### DIFF
--- a/test/test/util/fake_demo_main.js
+++ b/test/test/util/fake_demo_main.js
@@ -124,6 +124,7 @@ shaka.test.FakeDemoMain = class {
       },
       showUIOnPaused: true,
       showMenusOnTheRight: false,
+      customTrackLabel: (defaultLabel, track, type) => '',
     };
     this.selectedAsset = null;
 

--- a/test/test/util/test_scheme.js
+++ b/test/test/util/test_scheme.js
@@ -593,6 +593,15 @@ shaka.test.TestScheme.DATA = {
     duration: 30,
   },
 
+  'sintel_unknown_language': {
+    video: sintelVideoSegment,
+    audio: sintelAudioSegment,
+    text: vttSegment,
+    audioLanguages: ['en', 'fx'],
+    textLanguages: ['en', 'fx'],
+    duration: 30,
+  },
+
   'sintel_audio_only': {
     audio: sintelAudioSegment,
     duration: 30,

--- a/test/ui/ui_integration.js
+++ b/test/ui/ui_integration.js
@@ -357,6 +357,148 @@ describe('UI', () => {
     }
   });  // describe('language selections')
 
+  describe('customTrackLabel', () => {
+    /**
+     * Rebuilds the UI with a custom config that includes the callback,
+     * then loads the unknown language test manifest.
+     * @param {!Object} extraConfig
+     */
+    async function setupWithConfig(extraConfig) {
+      // Destroy existing UI first
+      await UiUtils.cleanupUI();
+
+      // Create fresh video and container
+      video = shaka.test.UiUtils.createVideoElement();
+      videoContainer = shaka.util.Dom.createHTMLElement('div');
+      videoContainer.appendChild(video);
+      document.body.appendChild(videoContainer);
+
+      player = new compiledShaka.Player();
+      await player.attach(video);
+
+      const config = Object.assign({
+        overflowMenuButtons: ['captions', 'language'],
+      }, extraConfig);
+
+      ui = new compiledShaka.ui.Overlay(player, videoContainer, video);
+      ui.configure(config);
+
+      const tempControls = ui.getControls();
+      goog.asserts.assert(tempControls != null, 'Controls are null!');
+      controls = tempControls;
+      eventManager = new shaka.util.EventManager();
+      waiter = new shaka.test.Waiter(eventManager);
+      eventManager.listen(player, 'error', Util.spyFunc(onErrorSpy));
+      eventManager.listen(controls, 'error', Util.spyFunc(onErrorSpy));
+
+      await player.load('test:sintel_unknown_language_compiled');
+      await waiter.failOnTimeout(false).waitForEvent(video, 'canplay');
+      expect(video.readyState).not.toBe(0);
+      await waiter.failOnTimeout(true);
+    }
+
+    /**
+     * @param {!Element} menu
+     * @return {!Array<!HTMLElement>}
+     */
+    function getTrackButtons(menu) {
+      return filterButtons(menu.childNodes,
+          ['shaka-back-to-overflow-button', 'shaka-turn-captions-off-button']);
+    }
+
+    /**
+     * @param {!Array<!HTMLElement>} buttons
+     * @param {string} label
+     * @return {?HTMLElement}
+     */
+    function findButtonWithLabel(buttons, label) {
+      for (const button of buttons) {
+        if (button.childNodes.length > 0 &&
+            button.childNodes[0].textContent === label) {
+          return button;
+        }
+      }
+      return null;
+    }
+
+    it('overrides unrecognized audio track labels', async () => {
+      await setupWithConfig({
+        customTrackLabel: (defaultLabel, track, type) => {
+          if (track.language === 'fx') {
+            return 'Sound Effects';
+          }
+          return null;
+        },
+      });
+
+      const audioMenu = shaka.util.Dom.getElementByClassName(
+          'shaka-audio-languages', videoContainer);
+      const buttons = getTrackButtons(audioMenu);
+      expect(findButtonWithLabel(buttons, 'Sound Effects')).not.toBe(null);
+      expect(findButtonWithLabel(buttons, 'English')).not.toBe(null);
+    });
+
+    it('overrides unrecognized text track labels', async () => {
+      await setupWithConfig({
+        customTrackLabel: (defaultLabel, track, type) => {
+          if (track.language === 'fx') {
+            return 'Sound Effects';
+          }
+          return null;
+        },
+      });
+
+      const textMenu = shaka.util.Dom.getElementByClassName(
+          'shaka-text-languages', videoContainer);
+      const buttons = getTrackButtons(textMenu);
+      expect(findButtonWithLabel(buttons, 'Sound Effects')).not.toBe(null);
+      expect(findButtonWithLabel(buttons, 'English')).not.toBe(null);
+    });
+
+    it('passes null for defaultLabel of unrecognized language', async () => {
+      const labelSpy = jasmine.createSpy('customTrackLabel')
+          .and.returnValue(null);
+      await setupWithConfig({customTrackLabel: labelSpy});
+
+      // Should have been called with null for 'fx' and a string for 'en'
+      const calls = labelSpy.calls.allArgs();
+      const fxCalls = calls.filter((args) => args[1].language === 'fx');
+      const enCalls = calls.filter((args) => args[1].language === 'en');
+      expect(fxCalls.length).toBeGreaterThan(0);
+      expect(enCalls.length).toBeGreaterThan(0);
+      for (const args of fxCalls) {
+        expect(args[0]).toBe(null);
+      }
+      for (const args of enCalls) {
+        expect(args[0]).not.toBe(null);
+      }
+    });
+
+    it('passes correct type argument', async () => {
+      const labelSpy = jasmine.createSpy('customTrackLabel')
+          .and.returnValue(null);
+      await setupWithConfig({customTrackLabel: labelSpy});
+
+      const calls = labelSpy.calls.allArgs();
+      const audioCalls = calls.filter((args) => args[2] === 'audio');
+      const textCalls = calls.filter((args) => args[2] === 'text');
+      expect(audioCalls.length).toBeGreaterThan(0);
+      expect(textCalls.length).toBeGreaterThan(0);
+    });
+
+    it('falls back to Unrecognized when callback returns falsy', async () => {
+      await setupWithConfig({
+        customTrackLabel: (defaultLabel, track, type) => null,
+      });
+
+      const audioMenu = shaka.util.Dom.getElementByClassName(
+          'shaka-audio-languages', videoContainer);
+      const buttons = getTrackButtons(audioMenu);
+      const fxButton = findButtonWithLabel(buttons, 'Unrecognized (fx)');
+      expect(fxButton).not.toBe(null);
+    });
+  });  // describe('customTrackLabel')
+
   describe('resolution selection', () => {
     /** @type {!Map<number, !HTMLElement>} */
     let resolutionsToButtons;

--- a/ui/externs/ui.js
+++ b/ui/externs/ui.js
@@ -260,6 +260,20 @@ shaka.extern.UIMediaSession;
 shaka.extern.UIDocumentPictureInPicture;
 
 /**
+ * A callback for customizing track labels in the UI.
+ *
+ * The callback receives the default label (or null if the language was
+ * unrecognized), the track object, and a type string ('audio' or 'text').
+ * Return a string to override the label, or a falsy value to keep the default.
+ *
+ * @typedef {function(?string,
+ *     (shaka.extern.AudioTrack|shaka.extern.TextTrack),
+ *     string): ?string}
+ * @exportDoc
+ */
+shaka.extern.UITrackLabelCallback;
+
+/**
  * @description
  * The UI's configuration options.
  *
@@ -322,6 +336,7 @@ shaka.extern.UIDocumentPictureInPicture;
  *   documentPictureInPicture: shaka.extern.UIDocumentPictureInPicture,
  *   showUIOnPaused: boolean,
  *   showMenusOnTheRight: boolean,
+ *   customTrackLabel: shaka.extern.UITrackLabelCallback,
  * }}
  *
  * @property {!Array<string>} controlPanelElements
@@ -612,6 +627,14 @@ shaka.extern.UIDocumentPictureInPicture;
  *   of where the button that opens the menu is located.
  *   <br>
  *   Defaults to <code>false</code>.
+ * @property {shaka.extern.UITrackLabelCallback} customTrackLabel
+ *   A callback for customizing track labels in the UI.  The callback receives
+ *   the default label (or <code>null</code> if the language was unrecognized),
+ *   the track object, and a type string (<code>'audio'</code> or
+ *   <code>'text'</code>).  Return a string to override the label, or a falsy
+ *   value to keep the default.
+ *   <br>
+ *   Defaults to a no-op that returns <code>''</code>.
  * @exportDoc
  */
 shaka.extern.UIConfiguration;

--- a/ui/language_utils.js
+++ b/ui/language_utils.js
@@ -185,8 +185,21 @@ shaka.ui.LanguageUtils = class {
       const span = shaka.util.Dom.createHTMLElement('span');
       button.appendChild(span);
 
-      span.textContent = shaka.ui.LanguageUtils.getLanguageName(
+      let defaultLabel = shaka.ui.LanguageUtils.getLanguageName(
           language, localization, preferIntlDisplayNames);
+      if (config.customTrackLabel) {
+        const customLabel = config.customTrackLabel(
+            defaultLabel, track, 'audio');
+        if (customLabel) {
+          defaultLabel = customLabel;
+        }
+      }
+      if (!defaultLabel) {
+        defaultLabel = localization.resolve(
+            shaka.ui.Locales.Ids.UNRECOGNIZED_LANGUAGE) +
+            ' (' + language + ')';
+      }
+      span.textContent = defaultLabel;
       let basicInfo = '';
       if (showAudioCodec && showAudioChannelCountVariants &&
           spatialAudio && (audioCodec == 'ec-3' || audioCodec == 'ac-4')) {
@@ -336,11 +349,12 @@ shaka.ui.LanguageUtils = class {
       const span = shaka.util.Dom.createHTMLElement('span');
       button.appendChild(span);
 
+      let defaultLabel;
       if (track.originalLanguage == 'speech-to-text') {
         // Necessary when there are multiple speech-to-text tracks and they
         // translate into different languages.
         if (language) {
-          span.textContent = [
+          defaultLabel = [
             shaka.ui.LanguageUtils.getLanguageName(
                 language, localization, preferIntlDisplayNames),
             ' (',
@@ -348,14 +362,27 @@ shaka.ui.LanguageUtils = class {
             ')',
           ].join('');
         } else {
-          span.textContent =
+          defaultLabel =
               localization.resolve(shaka.ui.Locales.Ids.AUTO_GENERATED);
         }
       } else {
-        span.textContent =
+        defaultLabel =
             shaka.ui.LanguageUtils.getLanguageName(
                 language, localization, preferIntlDisplayNames);
       }
+      if (config.customTrackLabel) {
+        const customLabel = config.customTrackLabel(
+            defaultLabel, track, 'text');
+        if (customLabel) {
+          defaultLabel = customLabel;
+        }
+      }
+      if (!defaultLabel) {
+        defaultLabel = localization.resolve(
+            shaka.ui.Locales.Ids.UNRECOGNIZED_LANGUAGE) +
+            ' (' + language + ')';
+      }
+      span.textContent = defaultLabel;
       let labelFormat = trackLabelFormat;
       if (labelFormat === TrackLabelFormat.LABEL_OR_LANGUAGE) {
         labelFormat = label ?
@@ -437,8 +464,9 @@ shaka.ui.LanguageUtils = class {
    * @param {string} locale
    * @param {shaka.ui.Localization} localization
    * @param {boolean} preferIntlDisplayNames
-   * @return {string} The language's name for itself in its own script, or as
-   *   close as we can get with the information we have.
+   * @return {?string} The language's name for itself in its own script, or as
+   *   close as we can get with the information we have.  Returns null if the
+   *   language is not recognized.
    */
   static getLanguageName(locale, localization, preferIntlDisplayNames) {
     if (!locale && !localization) {
@@ -499,8 +527,7 @@ shaka.ui.LanguageUtils = class {
     } else if (language in mozilla.LanguageMapping) {
       return mozilla.LanguageMapping[language] + ' (' + locale + ')';
     } else {
-      return resolve(shaka.ui.Locales.Ids.UNRECOGNIZED_LANGUAGE) +
-          ' (' + locale + ')';
+      return null;
     }
   }
 };

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -455,6 +455,7 @@ shaka.ui.Overlay = class {
       },
       showUIOnPaused: true,
       showMenusOnTheRight: false,
+      customTrackLabel: (defaultLabel, track, type) => '',
     };
 
     if (goog.DEBUG) {


### PR DESCRIPTION
## Summary
- Adds a `customTrackLabel` callback to the UI configuration that allows overriding track labels for both audio and text tracks
- The callback receives the default label (or `null` if the language was unrecognized), the track object, and a type string (`'audio'` or `'text'`)
- Returning a string overrides the label; returning falsy keeps the default behavior

Fixes #9821

## Example usage
```javascript
ui.configure({
  customTrackLabel: (defaultLabel, track, type) => {
    if (track.language === 'fx') return 'Sound Effects';
    return null; // use default
  }
});
```

## Test plan
- Added integration tests verifying label override, null for unrecognized languages, type argument, and fallback behavior
- Tests pass in both compiled and uncompiled modes

## AI Disclosure
As highlighted in the new `AGENT-ATTRIBUTION.md`, I've added Claude as a co-author of the commit as I made use of it during this PR.