### PR TITLE
chore(Demo): demo assetBase64 prototype pollution to DOM XSS

### DIFF
--- a/demo/common/asset.js
+++ b/demo/common/asset.js
@@ -13,6 +13,15 @@ goog.provide('ShakaDemoAssetInfo');
 
 
 /**
+ * @param {string} key
+ * @return {boolean}
+ */
+function shakaDemoIsBlockedKey_(key) {
+  return key == '__proto__' || key == 'constructor' || key == 'prototype';
+}
+
+
+/**
  * An object that contains information about an asset.
  */
 const ShakaDemoAssetInfo = class {
@@ -488,7 +497,10 @@ const ShakaDemoAssetInfo = class {
     // Construct a generic object with the values of this object, but with the
     // proper formatting.
     const raw = {};
-    for (const key in this) {
+    for (const key of Object.keys(this)) {
+      if (shakaDemoIsBlockedKey_(key)) {
+        continue;
+      }
       if (key.startsWith('preload') || key.startsWith('store') ||
           key.endsWith('Callback')) {
         // These values shouldn't be saved, as they are dynamic.
@@ -501,6 +513,9 @@ const ShakaDemoAssetInfo = class {
         const replacement = {};
         replacement['__type__'] = 'map';
         for (const entry of value.entries()) {
+          if (shakaDemoIsBlockedKey_(entry[0])) {
+            continue;
+          }
           replacement[entry[0]] = entry[1];
         }
         raw[key] = replacement;
@@ -545,7 +560,10 @@ const ShakaDemoAssetInfo = class {
       {drm: {advanced: {}}, manifest: {dash: {}, hls: {}}, streaming: {}});
 
     if (this.extraConfig) {
-      for (const key in this.extraConfig) {
+      for (const key of Object.keys(this.extraConfig)) {
+        if (shakaDemoIsBlockedKey_(key)) {
+          continue;
+        }
         config[key] = this.extraConfig[key];
       }
     }
@@ -620,13 +638,16 @@ const ShakaDemoAssetInfo = class {
   static fromJSON(raw) {
     // This handles the special case for Maps in toJSON.
     const parsed = {};
-    for (const key in raw) {
+    for (const key of Object.keys(raw)) {
+      if (shakaDemoIsBlockedKey_(key)) {
+        continue;
+      }
       const value = raw[key];
       if (value && typeof value == 'object' && value['__type__'] == 'map') {
         const replacement = new Map();
-        for (const key in value) {
-          if (key != '__type__') {
-            replacement.set(key, value[key]);
+        for (const mapKey of Object.keys(value)) {
+          if (mapKey != '__type__' && !shakaDemoIsBlockedKey_(mapKey)) {
+            replacement.set(mapKey, value[mapKey]);
           }
         }
         parsed[key] = replacement;
@@ -635,7 +656,9 @@ const ShakaDemoAssetInfo = class {
       }
     }
     const asset = ShakaDemoAssetInfo.makeBlankAsset();
-    Object.assign(asset, parsed);
+    for (const key of Object.keys(parsed)) {
+      /** @type {!Object} */(asset)[key] = parsed[key];
+    }
     return asset;
   }
 

--- a/lib/util/config_utils.js
+++ b/lib/util/config_utils.js
@@ -31,6 +31,7 @@ shaka.util.ConfigUtils = class {
 
     // If true, override the template.
     const overrideTemplate = path in overrides;
+    const blockedKeys = new Set(['__proto__', 'constructor', 'prototype']);
 
     // If true, treat the source as a generic object to be copied without
     // descending more deeply.
@@ -48,12 +49,15 @@ shaka.util.ConfigUtils = class {
 
     let isValid = true;
 
-    for (const k in source) {
+    for (const k of Object.keys(source)) {
       const subPath = path + '.' + k;
       const subTemplate = overrideTemplate ? overrides[path] : template[k];
 
       // The order of these checks is important.
-      if (!ignoreKeys && !(k in template)) {
+      if (blockedKeys.has(k)) {
+        shaka.log.alwaysError('Invalid config, dangerous key ' + subPath);
+        isValid = false;
+      } else if (!ignoreKeys && !(k in template)) {
         shaka.log.alwaysError('Invalid config, unrecognized key ' + subPath);
         isValid = false;
       } else if (source[k] === undefined) {

--- a/test/demo/demo_unit.js
+++ b/test/demo/demo_unit.js
@@ -4,7 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+goog.require('ShakaDemoAssetInfo');
+goog.require('shakaAssets');
+
 describe('Demo', () => {
+  /**
+   * @return {!ShakaDemoAssetInfo}
+   */
+  const makeBlankAsset = () => {
+    return new ShakaDemoAssetInfo(
+        /* name= */ '',
+        /* iconUri= */ '',
+        /* manifestUri= */ '',
+        /* source= */ shakaAssets.Source.CUSTOM);
+  };
+
   beforeEach(() => {
     // Make mock versions of misc third-party libraries.
     window['tippy'] = () => {};
@@ -34,6 +48,41 @@ describe('Demo', () => {
   });
 
   describe('config', () => {
+    it('does not copy dangerous extra config keys into player config', () => {
+      const asset = makeBlankAsset();
+      asset.extraConfig = /** @type {!Object} */(JSON.parse(
+          '{"__proto__":{"testPolluted":"YES"}}'));
+      const cleanProto = Object.getPrototypeOf({});
+
+      const config = asset.getConfiguration();
+
+      expect(/** @type {!Object} */(config)['testPolluted']).toBe(undefined);
+      expect(Object.getPrototypeOf(config)).toBe(cleanProto);
+    });
+
+    it('does not serialize inherited asset properties into JSON', () => {
+      const asset = makeBlankAsset();
+      const inheritedProto = Object.create(Object.getPrototypeOf(asset));
+      /** @type {!Object} */(inheritedProto)['testPolluted'] = 'YES';
+      Object.setPrototypeOf(asset, inheritedProto);
+
+      const raw = asset.toJSON();
+
+      expect(Object.hasOwn(raw, 'testPolluted')).toBe(false);
+    });
+
+    it('does not accept dangerous keys when parsing saved assets', () => {
+      const assetProto = Object.getPrototypeOf(makeBlankAsset());
+      const raw = /** @type {!Object} */(JSON.parse(
+          '{"name":"n","shortName":"s","iconUri":"","manifestUri":' +
+          '"" ,"source":0,"__proto__":{"testPolluted":"YES"}}'));
+
+      const asset = ShakaDemoAssetInfo.fromJSON(raw);
+
+      expect(/** @type {!Object} */(asset)['testPolluted']).toBe(undefined);
+      expect(Object.getPrototypeOf(asset)).toBe(assetProto);
+    });
+
     it('does not have entries for invalid config options', () => {
       const exceptions = new Set()
           .add('preferredAudio')

--- a/test/util/config_utils_unit.js
+++ b/test/util/config_utils_unit.js
@@ -1,0 +1,48 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe('ConfigUtils', () => {
+  it('rejects dangerous keys while merging generic objects', () => {
+    const destination = shaka.util.PlayerConfiguration.createDefault();
+    const updates = {
+      drm: {
+        advanced: JSON.parse(
+            '{"__proto__":{"testPolluted":"YES"},' +
+            '"com.widevine.alpha":{"videoRobustness":["SW_SECURE_DECODE"]}}'),
+      },
+    };
+
+    const valid = shaka.util.PlayerConfiguration.mergeConfigObjects(
+        destination, updates,
+        shaka.util.PlayerConfiguration.createDefault());
+
+    expect(valid).toBe(false);
+    expect(/** @type {!Object} */(destination.drm.advanced)['testPolluted'])
+        .toBe(undefined);
+    expect(Object.getPrototypeOf(/** @type {!Object} */(destination.drm.advanced)))
+        .toBe(Object.getPrototypeOf({}));
+    expect(destination.drm.advanced['com.widevine.alpha'].videoRobustness)
+        .toEqual(['SW_SECURE_DECODE']);
+  });
+
+  it('does not traverse inherited magic keys during config merges', () => {
+    const inheritedProto = Object.create(null);
+    Object.defineProperty(inheritedProto, '__proto__', {
+      enumerable: true,
+      value: {testPolluted: 'YES'},
+    });
+
+    const updates = Object.create(inheritedProto);
+    const destination = shaka.util.PlayerConfiguration.createDefault();
+
+    const valid = shaka.util.PlayerConfiguration.mergeConfigObjects(
+        destination, updates,
+        shaka.util.PlayerConfiguration.createDefault());
+
+    expect(valid).toBe(true);
+    expect(/** @type {!Object} */({})['testPolluted']).toBe(undefined);
+  });
+});

--- a/test/util/config_utils_unit.js
+++ b/test/util/config_utils_unit.js
@@ -22,8 +22,10 @@ describe('ConfigUtils', () => {
     expect(valid).toBe(false);
     expect(/** @type {!Object} */(destination.drm.advanced)['testPolluted'])
         .toBe(undefined);
-    expect(Object.getPrototypeOf(/** @type {!Object} */(destination.drm.advanced)))
-        .toBe(Object.getPrototypeOf({}));
+    expect(
+        Object.getPrototypeOf(/** @type {!Object} */(destination.drm.advanced)))
+        .toBe(
+            Object.getPrototypeOf({}));
     expect(destination.drm.advanced['com.widevine.alpha'].videoRobustness)
         .toEqual(['SW_SECURE_DECODE']);
   });


### PR DESCRIPTION
## Summary

This PR fixes a demo asset parsing and configuration merge vulnerability where a
malicious `assetBase64` payload could abuse `__proto__`, `constructor`, or
`prototype` keys to pollute object prototypes and later reach DOM XSS gadgets in
Shaka Player Demo.

## Vulnerability details

The vulnerable path was:

1. `demo/main.js` reads attacker-controlled `assetBase64` from the URL hash.
2. `demo/common/asset.js` copies `extraConfig` into a player config object with
   `for..in`, which allows dangerous magic keys to be applied.
3. `lib/util/config_utils.js` merges config objects with another `for..in`
   traversal and no explicit rejection of `__proto__`, `constructor`, or
   `prototype`.
4. The resulting prototype pollution can be turned into DOM XSS when later demo
   UI rebuild paths consume inherited properties.

## Fix approach

This change hardens both the demo entry point and the shared merge utility:

- `demo/common/asset.js`
  - filter dangerous keys when copying `extraConfig`
  - restrict `toJSON()` and `fromJSON()` to own properties only
  - prevent dangerous keys from being serialized into or restored from saved demo
    assets
- `lib/util/config_utils.js`
  - switch config merging from `for..in` to `Object.keys()`
  - explicitly reject `__proto__`, `constructor`, and `prototype`

## Regression coverage

Added tests that verify:

- dangerous `extraConfig` keys do not alter the generated player config
- inherited demo asset properties are not serialized into JSON
- dangerous keys are ignored when parsing saved assets back into demo objects
- inherited magic keys are not traversed during config merges

## Verification

- `python3 build/test.py --quick --filter 'Demo|ConfigUtils' --browsers ChromeHeadless`
- `python3 build/check.py`
