### PR TITLE
fix(MSF): Calculate reposition sooner (on segment appended)

### DIFF
--- a/lib/media/playhead.js
+++ b/lib/media/playhead.js
@@ -328,6 +328,9 @@ shaka.media.MediaSourcePlayhead = class {
     /** @private {?number} */
     this.lastCorrectiveSeek_ = null;
 
+    /** @private {boolean} */
+    this.isReady_ = false;
+
     /** @private {shaka.media.GapJumpingController} */
     this.gapController_ = new shaka.media.GapJumpingController(
         mediaElement,
@@ -351,6 +354,7 @@ shaka.media.MediaSourcePlayhead = class {
   /** @override */
   ready() {
     this.checkWindowTimer_.tickEvery(/* seconds= */ 0.25);
+    this.isReady_ = true;
   }
 
   /** @override */
@@ -455,6 +459,9 @@ shaka.media.MediaSourcePlayhead = class {
 
   /** @override */
   notifyOfBufferingChange() {
+    if (this.isReady_) {
+      this.checkWindowTimer_.tickNow().tickEvery(/* seconds= */ 0.25);
+    }
     this.gapController_.onSegmentAppended();
   }
 


### PR DESCRIPTION
This can happen when the seekrange is very small (e.g., MSF) and some segments take a long time to arrive.