### PR TITLE
fix(ui): use video.currentTime for keyboard seeks when controls hidden

### DIFF
--- a/ui/controls.js
+++ b/ui/controls.js
@@ -2036,7 +2036,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
           if ((isSeekBar || isFullscreenOrControlsInWindow) &&
               !isVolumeBar) {
             event.preventDefault();
-            this.seek_(this.seekBar_.getValue() - keyboardSeekDistance);
+            this.seek_(this.video_.currentTime - keyboardSeekDistance);
           }
         }
         break;
@@ -2048,7 +2048,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
           if ((isSeekBar || isFullscreenOrControlsInWindow) &&
               !isVolumeBar) {
             event.preventDefault();
-            this.seek_(this.seekBar_.getValue() + keyboardSeekDistance);
+            this.seek_(this.video_.currentTime + keyboardSeekDistance);
           }
         }
         break;
@@ -2058,7 +2058,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         if (this.seekBar_ && keyboardLargeSeekDistance > 0) {
           if (isSeekBar || isFullscreenOrControlsInWindow) {
             event.preventDefault();
-            this.seek_(this.seekBar_.getValue() - keyboardLargeSeekDistance);
+            this.seek_(this.video_.currentTime - keyboardLargeSeekDistance);
           }
         }
         break;
@@ -2068,7 +2068,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
         if (this.seekBar_ && keyboardLargeSeekDistance > 0) {
           if (isSeekBar || isFullscreenOrControlsInWindow) {
             event.preventDefault();
-            this.seek_(this.seekBar_.getValue() + keyboardLargeSeekDistance);
+            this.seek_(this.video_.currentTime + keyboardLargeSeekDistance);
           }
         }
         break;
@@ -2346,7 +2346,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       this.video_.pause();
     }
     const frameTime = 1 / videoTrack.frameRate;
-    const newTime = this.seekBar_.getValue() + frameTime * step;
+    const newTime = this.video_.currentTime + frameTime * step;
     if (newTime >= 0 && newTime <= this.player_.seekRange().end &&
         this.video_.currentTime !== newTime) {
       this.seek_(newTime);


### PR DESCRIPTION
## Problem
When controls auto-hide, the seek bar update timer pauses and stops refreshing its value. Keyboard seek shortcuts (Arrow keys, Page Up/Down, and frame stepping) were reading this stale seek bar value instead of the actual playhead position, causing seeks to jump to the wrong time — often backwards even when pressing the forward key.

This was especially noticeable in fullscreen mode where controls auto-hide quickly.

## Fix
Replace `this.seekBar_.getValue()` with `this.video_.currentTime` in all 5 keyboard seek handlers inside `onControlsKeyDown_` and `frameByFrame_`.

## Testing
- Reproduced bug: seeked to 5:00, waited for controls to hide, pressed →, video jumped backward 
- After fix: same steps, video correctly jumps forward 
- Tested in windowed and fullscreen mode
- ESLint passes on ui/controls.js 