### PR TITLE
perf: replace shift lpop with binary search

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -357,16 +357,13 @@ shaka.media.SegmentIndex = class {
       }
     }
 
-    while (this.references.length) {
-      const firstReference = this.references[0];
-      if (firstReference.endTime <= windowStart) {
-        this.references.shift();
-        if (!isNew) {
-          this.numEvicted_++;
-        }
-      } else {
-        break;
+    const lo = shaka.util.ArrayUtils.binarySearch(
+        this.references, (r) => r.endTime <= windowStart);
+    if (lo > 0) {
+      if (!isNew) {
+        this.numEvicted_ += lo;
       }
+      this.references = this.references.slice(lo);
     }
 
     if (this.references.length == 0) {


### PR DESCRIPTION
This PR replaces the repeated shift loop in `fit` method with an already present binary search, reducing loop complexity - helps TV devices and reuses existing optimization code