### PR TITLE
fix(StreamingEngine): correct variable reference in discardReferenceByBoundary_()

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -3553,7 +3553,7 @@ shaka.media.StreamingEngine = class {
       const oldCodec = MimeUtils.getNormalizedCodec(
           MimeUtils.getCodecs(lastInitRef.mimeType));
       const newCodec = MimeUtils.getNormalizedCodec(
-          MimeUtils.getCodecs(lastInitRef.mimeType));
+          MimeUtils.getCodecs(initRef.mimeType));
       if (lastInitRef.mimeType == initRef.mimeType &&
           oldCodec == newCodec) {
         discard = false;

--- a/test/media/streaming_engine_unit.js
+++ b/test/media/streaming_engine_unit.js
@@ -4534,4 +4534,74 @@ describe('StreamingEngine', () => {
           text: [true, true, true, true],
         });
       });
+
+  describe('discardReferenceByBoundary_', () => {
+    const MIME_AVC = 'video/mp4; codecs="avc1.42E01E"';
+    const MIME_HEVC = 'video/mp4; codecs="hvc1.1.6.L93.B0"';
+    const MIME_AVC_WEBM = 'video/webm; codecs="avc1.42E01E"';
+
+    beforeEach(() => {
+      setupVod();
+      mediaSourceEngine = new shaka.test.FakeMediaSourceEngine(segmentData);
+      createStreamingEngine();
+    });
+
+    function makeInitRef(mimeType, boundaryEnd) {
+      const ref = new shaka.media.InitSegmentReference(
+          () => ['init.mp4'], 0, null);
+      ref.mimeType = mimeType;
+      ref.boundaryEnd = boundaryEnd;
+      return ref;
+    }
+
+    function makeMediaState(lastInitRef) {
+      return {
+        type: ContentType.VIDEO,
+        stream: {id: 1},
+        lastInitSegmentReference: lastInitRef,
+        seeked: false,
+      };
+    }
+
+    function makeSegmentRef(initRef) {
+      return new shaka.media.SegmentReference(
+          0, 10, () => ['seg.mp4'], 0, null, initRef, 0, 0, 10);
+    }
+
+    it('returns false when KEEP strategy and codec are identical', () => {
+      const lastInitRef = makeInitRef(MIME_AVC, 0);
+      const initRef = makeInitRef(MIME_AVC, 10);
+      const mediaState = makeMediaState(lastInitRef);
+      const segRef = makeSegmentRef(initRef);
+
+      const result = (/** @type {?} */(streamingEngine))[
+          'discardReferenceByBoundary_'](mediaState, segRef);
+
+      expect(result).toBe(false);
+    });
+
+    it('returns true when KEEP strategy and codecs differ', () => {
+      const lastInitRef = makeInitRef(MIME_AVC, 0);
+      const initRef = makeInitRef(MIME_HEVC, 10);
+      const mediaState = makeMediaState(lastInitRef);
+      const segRef = makeSegmentRef(initRef);
+
+      const result = (/** @type {?} */(streamingEngine))[
+          'discardReferenceByBoundary_'](mediaState, segRef);
+
+      expect(result).toBe(true);
+    });
+
+    it('returns true when KEEP strategy and container differs', () => {
+      const lastInitRef = makeInitRef(MIME_AVC, 0);
+      const initRef = makeInitRef(MIME_AVC_WEBM, 10);
+      const mediaState = makeMediaState(lastInitRef);
+      const segRef = makeSegmentRef(initRef);
+
+      const result = (/** @type {?} */(streamingEngine))[
+          'discardReferenceByBoundary_'](mediaState, segRef);
+
+      expect(result).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Description

fix: wrong variable reference in `discardReferenceByBoundary_()` causing VIDEO_ERROR on HLS live streams                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                               
### What this fixes                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                               
`discardReferenceByBoundary_()` in `lib/media/streaming_engine.js` has a wrong variable reference: when processing `newCodec` the code reads `lastInitRef.mimeType` instead of `initRef.mimeType`. 

This means `newCodec` is always identical to `oldCodec`, so the guard that prevents unnecessary resets  (`discard = false`) never fires when `crossBoundaryStrategy === KEEP`.
 
As a result, every HLS discontinuity of timestamps, codecs, or encoding parameters forces a MediaSource reset. 
On live streams with server-side DAI, the repeated forced resets corrupt the SourceBuffer and crash the player with VIDEO_ERROR (error code 3016).

This is a regression introduced in 5.x. Shaka 4.x did not have this issue.                                                                                                                                                                                                                               
                  
### Fix

One-line change in `lib/media/streaming_engine.js`:                                                                                                                                                                                                                                                          
   
```diff                                                                                                                                                                                                                                                                                                     
  const newCodec = MimeUtils.getNormalizedCodec(
-     MimeUtils.getCodecs(lastInitRef.mimeType));
+     MimeUtils.getCodecs(initRef.mimeType));
```                                                                                                                                                                                                                                                                                                         
   
With this fix `KEEP` correctly compares the codec of the outgoing init segment against the codec of the incoming one. When they match MediaSource is kept, and when they differ it is reset, which is the intended behavior.                                                                                          
                  
### How to reproduce                                                                                                                                                                                                                                                                                         
                  
1. Play an HLS live stream with server-side DAI that generates `EXT-X-DISCONTINUITY` tags at ad boundaries, like FAST channels.
2. Use default Shaka config, do not override `crossBoundaryStrategy`, default is `KEEP`.
3. Wait for an ad to be triggered.                                                                                                                                                                                                                                                                    
4. Player crashes with `VIDEO_ERROR` / error code 3016. No network errors. All segment fetches return 200/206.