### PR TITLE
fix: Correctly extract file extension from URLs with dots in query params

### DIFF
--- a/lib/net/networking_utils.js
+++ b/lib/net/networking_utils.js
@@ -65,6 +65,14 @@ shaka.net.NetworkingUtils = class {
    */
   static getExtension(uri) {
     let end = uri.length;
+    for (let i = 0; i < uri.length; i++) {
+      const c = uri.charCodeAt(i);
+      // '?' or '#'
+      if (c === 63 || c === 35) {
+        end = i;
+        break;
+      }
+    }
 
     for (let i = end - 1; i >= 0; i--) {
       const c = uri.charCodeAt(i);
@@ -78,10 +86,6 @@ shaka.net.NetworkingUtils = class {
       // '/'
       if (c === 47) {
         return '';
-      }
-      // '?' or '#'
-      if (c === 63 || c === 35) {
-        end = i;
       }
     }
 

--- a/test/net/networking_utils_unit.js
+++ b/test/net/networking_utils_unit.js
@@ -119,5 +119,41 @@ describe('NetworkingUtils', () => {
       const result = shaka.net.NetworkingUtils.getExtension(uri);
       expect(result).toBe('pdf');
     });
+
+    it('should ignore dots in query parameter values', () => {
+      const uri =
+          'https://cdn.example.com/media/en.cmft' +
+          '?host=app.example.com&signature=abc.def';
+      const result = shaka.net.NetworkingUtils.getExtension(uri);
+      expect(result).toBe('cmft');
+    });
+
+    it('should handle signed URLs with dots in query params', () => {
+      const uri =
+          'https://cdn.example.com/media/subtitle.vtt' +
+          '?algorithm=HMAC-SHA256&credential=key1234' +
+          '&signed-headers=host&signature=abcdef.1234567890' +
+          '&filename=subtitle.en.vtt';
+      const result = shaka.net.NetworkingUtils.getExtension(uri);
+      expect(result).toBe('vtt');
+    });
+
+    it('should handle query with hostname-like values', () => {
+      const uri = 'https://example.com/video.mp4?origin=cdn.example.co.uk';
+      const result = shaka.net.NetworkingUtils.getExtension(uri);
+      expect(result).toBe('mp4');
+    });
+
+    it('should handle query with dotted filename and no path extension', () => {
+      const uri = 'https://example.com/stream?file=video.mp4';
+      const result = shaka.net.NetworkingUtils.getExtension(uri);
+      expect(result).toBe('');
+    });
+
+    it('should handle fragment with dots', () => {
+      const uri = 'https://example.com/file.mp3#t=1.5';
+      const result = shaka.net.NetworkingUtils.getExtension(uri);
+      expect(result).toBe('mp3');
+    });
   });
 });


### PR DESCRIPTION
### Description

Fixes #9945 

The `getExtension` function (rewritten for performance in #9816) scans the URI right-to-left, encountering dots in query parameter values (e.g. hostnames like `app.example.com`, filenames like `en.vtt`) before finding the `?` delimiter. This causes incorrect extension detection, breaking MIME type resolution for URLs with signed parameters or other query strings containing dots.

**Fix:** Split the single right-to-left scan into two passes:
1. **Left-to-right:** find the first `?` or `#` to establish the path boundary
2. **Right-to-left:** scan backward within the path portion only, looking for `.` or `/`

This preserves the lightweight character-scanning approach from #9816 without reintroducing the `goog.Uri` dependency.

**New test cases added:**
- Dots in query parameter values (`?host=app.example.com&signature=abc.def`)
- Signed URLs with encoded paths and filenames in query strings
- Hostname-like values in query parameters (`?origin=cdn.example.co.uk`)
- No path extension with dotted query values (`/stream?file=video.mp4` → `""`)
- Dots in fragment identifiers (`#t=1.5`)
