### PR TITLE
feat(net): Add commonAccessTokenHeaderName config

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -749,7 +749,9 @@ shakaDemo.Config = class {
         .addBoolInput_('Force HTTP', 'networking.forceHTTP')
         .addBoolInput_('Force HTTPS', 'networking.forceHTTPS')
         .addNumberInput_('Min bytes for progress events',
-            'networking.minBytesForProgressEvents');
+            'networking.minBytesForProgressEvents')
+        .addTextInput_('Common Access Token header name',
+            'networking.commonAccessTokenHeaderName');
   }
 
   /** @private */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2292,7 +2292,8 @@ shaka.extern.StreamingConfiguration;
  * @typedef {{
  *   forceHTTP: boolean,
  *   forceHTTPS: boolean,
- *   minBytesForProgressEvents: number
+ *   minBytesForProgressEvents: number,
+ *   commonAccessTokenHeaderName: string,
  * }}
  *
  * @description
@@ -2313,6 +2314,10 @@ shaka.extern.StreamingConfiguration;
  *   if possible. To avoid issues around feeding ABR with request history, this
  *   value should be greater than or equal to `abr.advanced.minBytes`.
  *   By default equals 16e3 (the same value as `abr.advanced.minBytes`).
+ * @property {string} commonAccessTokenHeaderName
+ *   CTA-WAVE Common Access Token header name.
+ *   <br>
+ *   Defaults to <code>'cta-common-access-token'</code>.
  * @exportDoc
  */
 shaka.extern.NetworkingConfiguration;

--- a/lib/net/networking_engine.js
+++ b/lib/net/networking_engine.js
@@ -532,7 +532,7 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
     const commonAccessToken =
         this.hostCommonAccessTokenMap_.get(uri.getDomain());
     if (commonAccessToken) {
-      request.headers[shaka.net.NetworkingEngine.CommonAccessTokenHeaderName_] =
+      request.headers[this.config_.commonAccessTokenHeaderName] =
           commonAccessToken;
     }
 
@@ -629,7 +629,7 @@ shaka.net.NetworkingEngine = class extends shaka.util.FakeEventTarget {
       }
       // Process headers to get the new CommonAccessToken
       const commonAccessTokenHeader = response.headers[
-          shaka.net.NetworkingEngine.CommonAccessTokenHeaderName_];
+          this.config_.commonAccessTokenHeaderName];
       if (commonAccessTokenHeader) {
         const responseHost = new goog.Uri(response.uri);
         this.hostCommonAccessTokenMap_.set(
@@ -870,14 +870,6 @@ class extends shaka.util.AbortableOperation {
     return this.bytesRemaining_.getBytes();
   }
 };
-
-/**
- * @const {string}
- * @private
- */
-shaka.net.NetworkingEngine.CommonAccessTokenHeaderName_ =
-  'common-access-token';
-
 
 /**
  * Request types.  Allows a filter to decide which requests to read/alter.

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -272,6 +272,7 @@ shaka.util.PlayerConfiguration = class {
       forceHTTP: false,
       forceHTTPS: false,
       minBytesForProgressEvents: minBytes,
+      commonAccessTokenHeaderName: 'cta-common-access-token',
     };
 
     const offline = {


### PR DESCRIPTION
Both CTA-5007-A and CTA-5007-B now specifies that the default header name should be "cta-common-access-token", but it also provides a path for using a custom header name.

Close https://github.com/shaka-project/shaka-player/issues/9948