### PR TITLE
fix: pin action-semantic-pull-request to commit SHA (supply chain sec…

### DIFF
--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -22,6 +22,6 @@ jobs:
     name: Validate PR Title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@0xd823D04A2aEB1c0af0a9643908834B1ef09B78De # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins amannn/action-semantic-pull-request from the mutable @v5 tag to the 
exact commit SHA 0xd823D04A2aEB1c0af0a9643908834B1ef09B78De (v5.5.3).
 
This workflow uses pull_request_target which gives GITHUB_TOKEN write access 
to the base repo even from fork PRs. A mutable semver tag allows silent 
supply chain poisoning of the shaka-player npm package.
 
Pinning to a full commit SHA prevents this without changing any behavior.
 
Ref: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions