### PR TITLE
perf(transmuxer): Reduce allocations in the h264 transmuxer

### DIFF
--- a/lib/transmuxer/h264.js
+++ b/lib/transmuxer/h264.js
@@ -7,7 +7,6 @@
 goog.provide('shaka.transmuxer.H264');
 
 goog.require('shaka.util.ExpGolomb');
-goog.require('shaka.util.Uint8ArrayUtils');
 
 
 /**
@@ -165,31 +164,33 @@ shaka.transmuxer.H264 = class {
     const width = ((picWidthInMbsMinus1 + 1) * 16) -
         frameCropLeftOffset * 2 - frameCropRightOffset * 2;
 
-    // assemble the SPSs
-    let sps = [];
     const spsData = spsNalu.fullData;
-    sps.push((spsData.byteLength >>> 8) & 0xff);
-    sps.push(spsData.byteLength & 0xff);
-    sps = sps.concat(...spsData);
+    const spsBytes = spsData.byteLength;
 
-    // assemble the PPSs
-    let pps = [];
     const ppsData = ppsNalu.fullData;
-    pps.push((ppsData.byteLength >>> 8) & 0xff);
-    pps.push(ppsData.byteLength & 0xff);
-    pps = pps.concat(...ppsData);
+    const ppsBytes = ppsData.byteLength;
 
-    const videoConfig = new Uint8Array(
-        [
-          0x01, // version
-          sps[3], // profile
-          sps[4], // profile compat
-          sps[5], // level
-          0xfc | 3, // lengthSizeMinusOne, hard-coded to 4 bytes
-          0xe0 | 1, // 3bit reserved (111) + numOfSequenceParameterSets
-        ].concat(sps).concat([
-          1, // numOfPictureParameterSets
-        ]).concat(pps));
+    let i = 0;
+    const videoConfig = new Uint8Array(11 + spsBytes + ppsBytes);
+    videoConfig[i++] = 0x01; // version
+    videoConfig[i++] = spsData[1]; // profile
+    videoConfig[i++] = spsData[2]; // profile compat
+    videoConfig[i++] = spsData[3]; // level
+    videoConfig[i++] = 0xfc | 3; // lengthSizeMinusOne, hard-coded to 4 bytes
+
+    // SPSs
+    // 3bit reserved (111) + numOfSequenceParameterSets
+    videoConfig[i++] = 0xe0 | 1;
+    videoConfig[i++] = (spsBytes >>> 8) & 0xff;
+    videoConfig[i++] = spsBytes & 0xff;
+    videoConfig.set(spsData, i);
+    i += spsBytes;
+
+    // PPSs
+    videoConfig[i++] = 1; // numOfPictureParameterSets
+    videoConfig[i++] = (ppsBytes >>> 8) & 0xff;
+    videoConfig[i++] = ppsBytes & 0xff;
+    videoConfig.set(ppsData, i);
 
     return {
       height,
@@ -221,18 +222,28 @@ shaka.transmuxer.H264 = class {
       if (!lastVideoSample.nalus.length || !lastVideoSample.frame) {
         return;
       }
-      const nalusData = [];
+
+      let totalLength = lastVideoSample.nalus.length * 4;
+      for (const nalu of lastVideoSample.nalus) {
+        totalLength += nalu.fullData.byteLength;
+      }
+
+      const combinedData = new Uint8Array(totalLength);
+      let offset = 0;
+
       for (const nalu of lastVideoSample.nalus) {
         const size = nalu.fullData.byteLength;
-        const naluLength = new Uint8Array(4);
-        naluLength[0] = (size >> 24) & 0xff;
-        naluLength[1] = (size >> 16) & 0xff;
-        naluLength[2] = (size >> 8) & 0xff;
-        naluLength[3] = size & 0xff;
-        nalusData.push(naluLength);
-        nalusData.push(nalu.fullData);
+
+        combinedData[offset] = (size >> 24) & 0xff;
+        combinedData[offset + 1] = (size >> 16) & 0xff;
+        combinedData[offset + 2] = (size >> 8) & 0xff;
+        combinedData[offset + 3] = size & 0xff;
+
+        combinedData.set(nalu.fullData, offset + 4);
+        offset += 4 + size;
       }
-      lastVideoSample.data = shaka.util.Uint8ArrayUtils.concat(...nalusData);
+
+      lastVideoSample.data = combinedData;
       videoSamples.push(lastVideoSample);
     };
 


### PR DESCRIPTION
This pull request makes two changes to the shaka.transmuxer.H264 class. The first one is to replace the 9 temporary arrays (4 array literals, 5 Array#concat calls) in the `parseInfo` method by allocating the Uint8Array first and then filling the data directly into it, rather than assembling it in the temporary arrays first. The second change is to the `addLastVideoSample` arrow function inside the `getVideoSamples` method, instead of creating an array of `Uint8Array`s, then counting the bytes, allocating a big enough `Uint8Array` and copying everything into it, the change is similar to the first one, that it will now allocate the `Uint8Array` and fill the data directly into that.

I am probably going to get blocked by the CLA bot, but a maintainer is welcome to copy these changes into another PR and claim them as your own :).

Tested with the "Apple Advanced HLS Stream (TS) with raw AAC" asset on the demo page.