### PR TITLE
fix: Limit recursion depth in TXml to prevent stack overflow DoS

### DIFF
--- a/lib/util/tXml.js
+++ b/lib/util/tXml.js
@@ -119,6 +119,7 @@ shaka.util.TXml = class {
    */
   static parse(S, includeParent) {
     let pos = 0;
+    let depth = 0;
 
     const openBracket = '<';
     const openBracketCC = '<'.charCodeAt(0);
@@ -201,7 +202,12 @@ shaka.util.TXml = class {
             pos++;
             continue;
           }
+          if (depth > 512) {
+            throw new Error('XML is too deeply nested');
+          }
+          depth++;
           const node = parseNode(preserveSpace);
+          depth--;
           children.push(node);
           if (typeof node === 'string') {
             return children;

--- a/test/util/tXml_unit.js
+++ b/test/util/tXml_unit.js
@@ -209,6 +209,22 @@ describe('tXml', () => {
       const doc = TXml.parseXmlString(xmlString, 'Document');
       expect(doc).toBeNull();
     });
+
+    it('throws on deeply nested XML', () => {
+      // Build XML that is nested 600 levels deep, exceeding the 512 limit.
+      const depth = 600;
+      let xmlString = '<?xml version="1.0"?>';
+      for (let i = 0; i < depth; i++) {
+        xmlString += '<N>';
+      }
+      xmlString += 'deep';
+      for (let i = 0; i < depth; i++) {
+        xmlString += '</N>';
+      }
+      const expected = new Error('XML is too deeply nested');
+      expect(() => TXml.parseXmlString(xmlString, 'N'))
+          .toThrow(expected);
+    });
   });
 
   it('parseDate', () => {


### PR DESCRIPTION
## Description
Fixes a Denial of Service (DoS) vulnerability in the `shaka.util.TXml.parse` component. 

When processing deeply nested XML manifests (e.g. 10,000 layers deep), the unbounded recursion between `parseNode` and `parseChildren` can exhaust the JavaScript call stack, leading to an uncaught `RangeError: Maximum call stack size exceeded` exception and potential browser tab crashes.

This PR introduces a maximum recursion depth limit of 512. If the nesting depth exceeds this limit, an explicit Error (`XML is too deeply nested`) is thrown, gracefully halting the parser rather than risking a hard crash.

## Testing
- Verified against the simulated PoC with a deeply nested `MPD` document.
- It safely catches the error instead of crashing the player process.
