### PR TITLE
fix: prevent tab crash from large SegmentTimeline repeat counts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Armand Zangue <armand.zangue@gmail.com>
 Benjamin Wallberg <me@bwallberg.com>
 Bonnier Broadcasting <*@bonnierbroadcasting.com>
 Bryan Huh <bhh1988@gmail.com>
+Carmelo Ventimiglia <car.ventimiglia@gmail.com>
 Charter Communications Inc <*@charter.com>
 Code It <*@code-it.fr>
 Cristian Atehortua <cristian25a32@gmail.com>

--- a/lib/dash/mpd_utils.js
+++ b/lib/dash/mpd_utils.js
@@ -134,6 +134,15 @@ shaka.dash.MpdUtils = class {
   static createTimeline(
       timePoints, timescale, unscaledPresentationTimeOffset,
       periodDuration, startNumber) {
+    /**
+     * Hard ceiling per S element to prevent memory exhaustion from
+     * untrusted manifests. 100 000 segments ≈ 27 h at 1 s/segment.
+     */
+    const MAX_REPEAT_PER_ELEMENT = 100000;
+    /**
+     * Hard ceiling on total timeline entries across all S elements.
+     */
+    const MAX_TIMELINE_ENTRIES = 500000;
     goog.asserts.assert(
         timescale > 0 && timescale < Infinity,
         'timescale must be a positive, finite integer');
@@ -213,7 +222,20 @@ shaka.dash.MpdUtils = class {
           repeat = Math.ceil((periodDuration * timescale - startTime) / d) - 1;
         }
       }
+      // Clamp repeat to period boundary when possible.
+      if (repeat > 0 && d > 0 && periodDuration !== Infinity) {
+        const periodMax =
+            Math.ceil((periodDuration * timescale - startTime) / d) - 1;
+        repeat = Math.min(repeat, Math.max(0, periodMax));
+      }
 
+      // Hard cap: no single S element may exceed MAX_REPEAT_PER_ELEMENT.
+      if (repeat > MAX_REPEAT_PER_ELEMENT) {
+        shaka.log.warning(
+            'SegmentTimeline S element repeat count', repeat,
+            'exceeds safe limit; clamping to', MAX_REPEAT_PER_ELEMENT);
+        repeat = MAX_REPEAT_PER_ELEMENT;
+      }
       // The end of the last segment may be before the start of the current
       // segment (a gap) or after the start of the current segment (an
       // overlap). If there is a gap/overlap then stretch/compress the end of
@@ -236,6 +258,13 @@ shaka.dash.MpdUtils = class {
       }
 
       for (let j = 0; j <= repeat; ++j) {
+        if (timeline.length >= MAX_TIMELINE_ENTRIES) {
+          shaka.log.warning(
+              'SegmentTimeline exceeded', MAX_TIMELINE_ENTRIES,
+              'entries; truncating remaining segments.');
+          return timeline;
+        }
+
         const endTime = startTime + d;
         const item = {
           start: startTime / timescale,


### PR DESCRIPTION
## Description

A DASH manifest with an excessively large `r` attribute on a `SegmentTimeline` `<S>` element causes `MpdUtils.createTimeline()` to allocate millions of `TimeRange` objects, exhausting the tab's heap and crashing it.

Negative `r` values are already clamped, but positive values pass through unbounded. This change adds three guards:

1. **Period-boundary clamp**: mirrors the existing negative-repeat math to cap positive `repeat` to what the period allows.
2. **Per-element ceiling** (`MAX_REPEAT_PER_ELEMENT = 100,000`): caps any single `<S>` element. At 1-second segments this covers ~27 hours, well above real content. Needed because the period clamp alone doesn't help when `periodDuration` is `Infinity` (live) or when the period is set large enough to match `r`.
3. **Total timeline ceiling** (`MAX_TIMELINE_ENTRIES = 500,000`): caps the full timeline array across all `<S>` elements (~5.7 days at 1s segments).

Both limits follow the same pattern as the TXml depth limit and are far above any real-world content (24h VOD at 2s segments = 43,200 entries).

## Testing

- Manifest from #9973 no longer crashes the tab
- Also tested with `periodDuration` matching `r` and with live-type manifests (`Infinity` duration)
- Existing SegmentTimeline tests pass: `python3 build/test.py --quick --filter="MpdUtils|SegmentTemplate|Timeline"`
- `python3 build/check.py` passes

Fixes #9973