### PR TITLE
fix: include unencrypted decodingConfigs in preferredKeySystems loop

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -710,7 +710,11 @@ shaka.util.StreamUtils = class {
               const config = configs[0];
               const keySystem = config.keySystemConfiguration &&
                 config.keySystemConfiguration.keySystem;
-              return keySystem === preferredKeySystem;
+              // Also pass through unencrypted configs so that
+              // variants whose DRM info has not been lazy-loaded
+              // yet (e.g. HLS SUPPLEMENTAL-CODECS duplicates) still
+              // get a decodingInfo result in this loop.
+              return !keySystem || keySystem === preferredKeySystem;
             });
 
         // The reason we are performing this await in a loop rather than


### PR DESCRIPTION
HLS SUPPLEMENTAL-CODECS (e.g. Dolby Vision dvh1) creates duplicate variant tags with different codecs but the same media playlist URI. Due to lazy-loading, only one variant gets its drmInfos populated via createSegmentIndex(). The other variant remains with empty drmInfos and is treated as unencrypted by getDecodingConfigs_().

In the preferredKeySystems loop, the filter rejected these unencrypted configs (undefined !== preferredKeySystem), leaving the variant with no decodingInfo and causing it to be dropped.

Fix: allow unencrypted configs (!keySystem) to pass through, matching the pattern already used in the second (fallback) loop.

Propagating drmInfos in HLS parser would be more correct but is complex because stream duplication happens at the tag level with separate cache keys (URI + codecs) in createStreamInfoFromVariantTags_.