### PR TITLE
fix: Fix MIME type detection for uppercase types

### DIFF
--- a/lib/media/manifest_parser.js
+++ b/lib/media/manifest_parser.js
@@ -95,7 +95,7 @@ shaka.media.ManifestParser = class {
 
     // Try using the MIME type we were given.
     if (mimeType) {
-      const factory = ManifestParser.parsersByMime.get(mimeType.toLowerCase());
+      const factory = ManifestParser.parsersByMime.get(mimeType);
       if (factory) {
         return factory;
       }
@@ -129,7 +129,7 @@ shaka.media.ManifestParser = class {
       return false;
     }
 
-    return shaka.media.ManifestParser.parsersByMime.has(mimeType.toLowerCase());
+    return shaka.media.ManifestParser.parsersByMime.has(mimeType);
   }
 };
 

--- a/lib/player.js
+++ b/lib/player.js
@@ -2253,7 +2253,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!mimeType) {
       mimeType = await this.guessMimeType_(assetUri);
     }
-    const shouldUseSrcEquals = this.shouldUseSrcEquals_(assetUri, mimeType);
+    const shouldUseSrcEquals = this.shouldUseSrcEquals_(mimeType);
     if (shouldUseSrcEquals) {
       // We cannot preload src= content.
       return null;
@@ -2558,14 +2558,14 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     const retryParams = this.config_.manifest.retryParameters;
     let mimeType = await shaka.net.NetworkingUtils.getMimeType(
         assetUri, this.networkingEngine_, retryParams);
-    if (mimeType == 'application/x-mpegurl') {
+    if (shaka.util.MimeUtils.isHlsType(mimeType)) {
       const device = shaka.device.DeviceFactory.getDevice();
       if (device.getBrowserEngine() ===
           shaka.device.IDevice.BrowserEngine.WEBKIT) {
         mimeType = 'application/vnd.apple.mpegurl';
       }
     }
-    if (mimeType == 'video/quicktime') {
+    if (mimeType.toLowerCase() == 'video/quicktime') {
       const device = shaka.device.DeviceFactory.getDevice();
       if (device.getBrowserEngine() ===
           shaka.device.IDevice.BrowserEngine.CHROMIUM) {
@@ -2579,14 +2579,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * Determines if we should use src equals, based on the mimeType (if
    * known), the URI, and platform information.
    *
-   * @param {string} assetUri
    * @param {?string=} mimeType
    * @return {boolean}
    *    |true| if the content should be loaded with src=, |false| if the content
    *    should be loaded with MediaSource.
    * @private
    */
-  shouldUseSrcEquals_(assetUri, mimeType) {
+  shouldUseSrcEquals_(mimeType) {
     const MimeUtils = shaka.util.MimeUtils;
 
     // If we are using a platform that does not support media source, we will

--- a/lib/player.js
+++ b/lib/player.js
@@ -1797,6 +1797,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @type {?shaka.media.PreloadManager} */
     let preloadManager = null;
     let assetUri = '';
+    mimeType = mimeType?.toLowerCase();
     if (assetUriOrPreloader instanceof shaka.media.PreloadManager) {
       if (assetUriOrPreloader.isDestroyed()) {
         throw new shaka.util.Error(
@@ -2205,6 +2206,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   async preload(assetUri, startTime = null, mimeType, config) {
     goog.asserts.assert(this.config_, 'Config must not be null!');
+    mimeType = mimeType?.toLowerCase();
     const preloadConfig = this.defaultConfig_();
     shaka.util.PlayerConfiguration.mergeConfigObjects(
         preloadConfig, config || this.config_, this.defaultConfig_());
@@ -2564,7 +2566,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           shaka.device.IDevice.BrowserEngine.WEBKIT) {
         mimeType = 'application/vnd.apple.mpegurl';
       }
-    } else if (mimeType.toLowerCase() == 'video/quicktime') {
+    } else if (mimeType === 'video/quicktime') {
       const device = shaka.device.DeviceFactory.getDevice();
       if (device.getBrowserEngine() ===
           shaka.device.IDevice.BrowserEngine.CHROMIUM) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -2564,8 +2564,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           shaka.device.IDevice.BrowserEngine.WEBKIT) {
         mimeType = 'application/vnd.apple.mpegurl';
       }
-    }
-    if (mimeType.toLowerCase() == 'video/quicktime') {
+    } else if (mimeType.toLowerCase() == 'video/quicktime') {
       const device = shaka.device.DeviceFactory.getDevice();
       if (device.getBrowserEngine() ===
           shaka.device.IDevice.BrowserEngine.CHROMIUM) {
@@ -2633,9 +2632,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
 
         // Native HLS can be preferred on any platform via this flag:
         return this.config_.streaming.preferNativeHls;
-      }
-
-      if (MimeUtils.isDashType(mimeType)) {
+      } else if (MimeUtils.isDashType(mimeType)) {
         // Native DASH can be preferred on any platform via this flag:
         return this.config_.streaming.preferNativeDash;
       }

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -259,6 +259,7 @@ shaka.util.MimeUtils = class {
    * @return {boolean}
    */
   static isHlsType(mimeType) {
+    mimeType = mimeType.toLowerCase();
     return mimeType === 'application/x-mpegurl' ||
         mimeType === 'application/vnd.apple.mpegurl';
   }
@@ -270,6 +271,7 @@ shaka.util.MimeUtils = class {
    * @return {boolean}
    */
   static isDashType(mimeType) {
+    mimeType = mimeType.toLowerCase();
     return mimeType === 'application/dash+xml' ||
         mimeType === 'video/vnd.mpeg.dash.mpd';
   }

--- a/lib/util/mime_utils.js
+++ b/lib/util/mime_utils.js
@@ -259,7 +259,6 @@ shaka.util.MimeUtils = class {
    * @return {boolean}
    */
   static isHlsType(mimeType) {
-    mimeType = mimeType.toLowerCase();
     return mimeType === 'application/x-mpegurl' ||
         mimeType === 'application/vnd.apple.mpegurl';
   }
@@ -271,7 +270,6 @@ shaka.util.MimeUtils = class {
    * @return {boolean}
    */
   static isDashType(mimeType) {
-    mimeType = mimeType.toLowerCase();
     return mimeType === 'application/dash+xml' ||
         mimeType === 'video/vnd.mpeg.dash.mpd';
   }

--- a/test/media/manifest_parser_unit.js
+++ b/test/media/manifest_parser_unit.js
@@ -9,8 +9,6 @@ describe('ManifestParser', () => {
 
   describe('isSupported', () => {
     const testMimeTypeLowercase = 'application/x-test-type';
-    const testMimeTypeUppercase = testMimeTypeLowercase.toUpperCase();
-    const testMimeTypeMixedCase = 'Application/X-Test-Type';
 
     let testFactory;
 
@@ -32,24 +30,8 @@ describe('ManifestParser', () => {
       ManifestParser.unregisterParserByMime(testMimeTypeLowercase);
     });
 
-    it('performs case-insensitive MIME type matching', () => {
-      // Test lowercase MIME type - original registration
-      expect(ManifestParser.isSupported(testMimeTypeLowercase)).toBe(true);
-
-      // Test uppercase MIME type
-      expect(ManifestParser.isSupported(testMimeTypeUppercase))
-          .toBe(true);
-
-      // Test mixed case MIME type
-      expect(ManifestParser.isSupported(testMimeTypeMixedCase))
-          .toBe(true);
-    });
-
     it('returns false for unregistered MIME types', () => {
-      // Verify that case-insensitive matching still correctly rejects
-      // MIME types that are not registered
       expect(ManifestParser.isSupported('application/x-unknown')).toBe(false);
-      expect(ManifestParser.isSupported('APPLICATION/X-UNKNOWN')).toBe(false);
     });
   });
 });

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -5294,6 +5294,11 @@ describe('Player', () => {
     expect(player.getAssetUri()).toBeNull();
   });
 
+  it('getMimeType case insensitive', async () => {
+    await player.load(fakeManifestUri, 0, fakeMimeType.toUpperCase());
+    expect(player.getMimeType()).toBe(fakeMimeType);
+  });
+
   /**
    * Gets the currently active variant track.
    * @return {shaka.extern.Track}


### PR DESCRIPTION
#9416 introduced case insensitive matching for ManifestParser detection. To add a feature parity, the same should be added for src= detection. 
Lack of it may cause issues with proper detection of native playback capabilities and accidental preference of MSE over src=.

Logic has been shifted - now passed MIME type is lowercased by default in `load()` and `preload()` methods. If MIME type is not present, `NetworkingUtils.getMimeType()` guarantees to return lowercase variant.