### PR TITLE
fix: Avoid uncaught TypeError when destroying player during DRM key status change

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -8949,6 +8949,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @private
    */
   onKeyStatus_(keyStatusMap) {
+    if (!this.streamingEngine_) {
+      return;
+    }
     goog.asserts.assert(this.streamingEngine_, 'Cannot be called in src= mode');
 
     const event = shaka.Player.makeEvent_(

--- a/lib/player.js
+++ b/lib/player.js
@@ -8952,7 +8952,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!this.streamingEngine_) {
       return;
     }
-    goog.asserts.assert(this.streamingEngine_, 'Cannot be called in src= mode');
 
     const event = shaka.Player.makeEvent_(
         shaka.util.FakeEvent.EventName.KeyStatusChanged);


### PR DESCRIPTION
Fixes #9983

## Summary

`player.destroy()` can race with a pending `keystatuseschange` callback, causing a `TypeError: Cannot read properties of null` when `onKeyStatus_()` accesses `this.streamingEngine_` after it has been nulled by `destroyStreaming_()`.

This adds a null guard at the top of `onKeyStatus_()` to bail out early if the streaming engine has already been torn down.

## Root cause

`destroyStreaming_()` and `destroyDrmEngine_()` run in parallel via `Promise.all()`. Closing the DRM session triggers `keystatuseschange` from the CDM, which is batched via `keyStatusTimer_.tickAfter()`. If the `setTimeout` callback fires after `streamingEngine_` is set to null but before `DrmEngine.destroyNow_()` calls `keyStatusTimer_.stop()`, the stale callback crashes.

The existing `goog.asserts.assert` is stripped in production builds, so there is no runtime protection.

## Impact

~13,000 error events affecting ~10,000 users over 90 days on Smart TV apps (Samsung Tizen, Hisense VIDAA, LG webOS). Slow TV CPUs widen the race window significantly.

## Test plan

- [x] Verified fix on Samsung Tizen 6.0–9.0, Hisense VIDAA (Chrome 111), LG webOS TV 25 (Chrome 120)
- [x] Reproducible on Chrome desktop with CPU 6× throttle — confirmed fix eliminates the crash
- [x] No behavioral change when `streamingEngine_` is non-null (normal path unchanged)

Co-Authored-By: Claude (Opus 4.6) <noreply@anthropic.com>