### PR TITLE
fix: Clamp playback rate to 16x and improve playhead movement behavior

### DIFF
--- a/lib/media/play_rate_controller.js
+++ b/lib/media/play_rate_controller.js
@@ -114,7 +114,9 @@ shaka.media.PlayRateController = class {
 
     shaka.log.v1('Changing effective playback rate to', rate);
 
-    if (rate >= 0) {
+    // Technically the spec does not impose a maximum limit, but there is no
+    // browser that is capable of handling more than 16.
+    if (rate >= 0 && rate <= 16) {
       try {
         this.applyRate_(rate);
         return;

--- a/lib/player.js
+++ b/lib/player.js
@@ -2750,7 +2750,29 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       getRate: () => mediaElement.playbackRate,
       getDefaultRate: () => mediaElement.defaultPlaybackRate,
       setRate: (rate) => { mediaElement.playbackRate = rate; },
-      movePlayhead: (delta) => { mediaElement.currentTime += delta; },
+      movePlayhead: (delta) => {
+        const currentTime = mediaElement.currentTime;
+        // This simulates the native behavior of playbackrate; it only
+        // advances when there is something in the buffer that can be rendered.
+        if (!shaka.media.TimeRangesUtils.isBuffered(
+            mediaElement.buffered, currentTime) ||
+            mediaElement.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA) {
+          return;
+        }
+        const newTime = currentTime + delta;
+        const seekRange = this.seekRange();
+        if (newTime < seekRange.start) {
+          if (currentTime !== seekRange.start) {
+            mediaElement.currentTime = seekRange.start;
+          }
+        } else if (newTime > seekRange.end) {
+          if (currentTime !== seekRange.end) {
+            mediaElement.currentTime = seekRange.end;
+          }
+        } else {
+          mediaElement.currentTime = newTime;
+        }
+      },
       isPaused: () => mediaElement.paused,
     });
   }
@@ -7762,6 +7784,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     //
     // https://github.com/shaka-project/shaka-player/issues/951
     if (newRate == 0) {
+      const currentPlaybackRate = this.getPlaybackRate();
+      if (currentPlaybackRate !== 0 && currentPlaybackRate !== 1) {
+        const event = shaka.Player.makeEvent_(
+            shaka.util.FakeEvent.EventName.RateChange);
+        this.dispatchEvent(event);
+      }
       return;
     }
 


### PR DESCRIPTION
Technically the spec does not impose a maximum limit, but browsers do not reliably support playback rates above 16x. For rates greater than 16x, we fall back to the trick-play mechanism used for negative playback rates.