### PR TITLE
perf(segments): use binary search for segment lookup in more hot paths

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -13,6 +13,7 @@ goog.require('shaka.log');
 goog.require('shaka.media.InitSegmentReference');
 goog.require('shaka.media.SegmentIndex');
 goog.require('shaka.media.SegmentReference');
+goog.require('shaka.util.ArrayUtils');
 goog.require('shaka.util.Error');
 goog.require('shaka.util.IReleasable');
 goog.require('shaka.util.ManifestParserUtils');
@@ -866,20 +867,15 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
       return;
     }
     shaka.log.debug(`${this.representationId_} Evicting at ${time}`);
-    let numToEvict = 0;
     const timeline = this.templateInfo_.timeline;
+    if (!timeline) {
+      return;
+    }
 
-    for (let i = 0; i < timeline.length; i += 1) {
-      const range = timeline[i];
-      const end = range.end + this.periodStart_;
-      const start = range.start + this.periodStart_;
-
-      if (end <= time) {
-        shaka.log.debug(`Evicting ${start} - ${end}`);
-        numToEvict += 1;
-      } else {
-        break;
-      }
+    let numToEvict = 0;
+    while (numToEvict < timeline.length &&
+        timeline[numToEvict].end + this.periodStart_ <= time) {
+      numToEvict++;
     }
 
     if (numToEvict > 0) {
@@ -1067,26 +1063,32 @@ shaka.dash.TimelineSegmentIndex = class extends shaka.media.SegmentIndex {
 
     const lastIndex = timeline.length - 1;
 
-    for (let i = 0; i < timeline.length; i++) {
-      const range = timeline[i];
-      const start = range.start + this.periodStart_;
-      // A rounding error can cause /time/ to equal e.endTime or fall in between
-      // the references by a fraction of a second. To account for this, we use
-      // the start of the next segment as /end/, unless this is the last
-      // reference, in which case we use the period end as the /end/
-      let end;
+    // Find the last range whose start <= time.
+    const i = shaka.util.ArrayUtils.binarySearch(
+        timeline, (r) => r.start + this.periodStart_ <= time) - 1;
 
-      if (i < lastIndex) {
-        end = timeline[i + 1].start + this.periodStart_;
-      } else if (this.periodEnd_ === Infinity) {
-        end = range.end + this.periodStart_;
-      } else {
-        end = this.periodEnd_;
-      }
+    if (i < 0) {
+      return null;
+    }
 
-      if ((time >= start) && (time < end)) {
-        return i + this.numEvicted_;
-      }
+    const range = timeline[i];
+    const start = range.start + this.periodStart_;
+    // A rounding error can cause /time/ to equal e.endTime or fall in between
+    // the references by a fraction of a second. To account for this, we use
+    // the start of the next segment as /end/, unless this is the last
+    // reference, in which case we use the period end as the /end/
+    let end;
+
+    if (i < lastIndex) {
+      end = timeline[i + 1].start + this.periodStart_;
+    } else if (this.periodEnd_ === Infinity) {
+      end = range.end + this.periodStart_;
+    } else {
+      end = this.periodEnd_;
+    }
+
+    if ((time >= start) && (time < end)) {
+      return i + this.numEvicted_;
     }
 
     return null;

--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -145,28 +145,30 @@ shaka.media.SegmentIndex = class {
    * @export
    */
   find(time) {
-    // For live streams, searching from the end is faster.  For VOD, it balances
-    // out either way.  In both cases, references.length is small enough that
-    // the difference isn't huge.
     const lastReferenceIndex = this.references.length - 1;
-    for (let i = lastReferenceIndex; i >= 0; --i) {
-      const r = this.references[i];
-      const start = r.startTime;
-      // A rounding error can cause /time/ to equal e.endTime or fall in between
-      // the references by a fraction of a second. To account for this, we use
-      // the start of the next segment as /end/, unless this is the last
-      // reference, in which case we use its end time as /end/.
-      const end = i < lastReferenceIndex ?
-        this.references[i + 1].startTime : r.endTime;
-      // Note that a segment ends immediately before the end time.
-      if ((time >= start) && (time < end)) {
-        return i + this.numEvicted_;
-      }
+    if (lastReferenceIndex < 0) {
+      return null;
     }
-    if (this.references.length && time < this.references[0].startTime) {
+    if (time < this.references[0].startTime) {
       return this.numEvicted_;
     }
-
+    // Find the last reference whose startTime <= time.
+    const i = shaka.util.ArrayUtils.binarySearch(
+        this.references, (r) => r.startTime <= time) - 1;
+    if (i < 0) {
+      return null;
+    }
+    const r = this.references[i];
+    // A rounding error can cause /time/ to equal e.endTime or fall in between
+    // the references by a fraction of a second. To account for this, we use
+    // the start of the next segment as /end/, unless this is the last
+    // reference, in which case we use its end time as /end/.
+    const end = i < lastReferenceIndex ?
+        this.references[i + 1].startTime : r.endTime;
+    // Note that a segment ends immediately before the end time.
+    if ((time >= r.startTime) && (time < end)) {
+      return i + this.numEvicted_;
+    }
     return null;
   }
 
@@ -274,12 +276,10 @@ shaka.media.SegmentIndex = class {
     // invalid refs are always at the front — scan until the first valid one.
     const existingStart =
         this.references.length > 0 ? this.references[0].startTime : -Infinity;
+    const threshold = Math.max(windowStart, existingStart);
     let firstValid = 0;
-    while (firstValid < references.length) {
-      const r = references[firstValid];
-      if (r.endTime > windowStart && r.endTime > existingStart) {
-        break;
-      }
+    while (firstValid < references.length &&
+        references[firstValid].endTime <= threshold) {
       firstValid++;
     }
     if (firstValid > 0) {


### PR DESCRIPTION
This PR replaces more linear scans with binary search in more segment lookup methods - optimization is aimed at long DVR livestreams on low-end TV devices