### PR TITLE
perf(HLS): skip merging known segments on live playlist updates

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -589,9 +589,12 @@ shaka.hls.HlsParser = class {
       this.playerInterface_.newDrmInfo(stream);
     }
 
-    const {segments, bandwidth} = this.createSegments_(
+    // On redirect the segment base URIs change, so all existing refs need to
+    // be replaced with the freshly built ones that carry the redirected URI.
+    const wasRedirected = response.uri !== response.originalUri;
+    const {segments, totalCount, bandwidth} = this.createSegments_(
         playlist, mediaSequenceToStartTime, mediaVariables,
-        streamInfo.getUris, streamInfo.type);
+        streamInfo.getUris, streamInfo.type, /* isNewStream= */ wasRedirected);
     if (bandwidth) {
       stream.bandwidth = bandwidth;
     }
@@ -604,9 +607,12 @@ shaka.hls.HlsParser = class {
       }
     }
 
-    stream.segmentIndex.mergeAndEvict(
-        segments, this.presentationTimeline_.getSegmentAvailabilityStart());
     if (segments.length) {
+      stream.segmentIndex.mergeAndEvict(
+          segments,
+          this.presentationTimeline_.getSegmentAvailabilityStart());
+    }
+    if (totalCount) {
       const mediaSequenceNumber = shaka.hls.Utils.getFirstTagWithNameAsNumber(
           playlist.tags, 'EXT-X-MEDIA-SEQUENCE', 0);
       const skipTag = shaka.hls.Utils.getFirstTagWithName(
@@ -614,7 +620,8 @@ shaka.hls.HlsParser = class {
       const skippedSegments =
           skipTag ? Number(skipTag.getAttributeValue('SKIPPED-SEGMENTS')) : 0;
       const {nextMediaSequence, nextPart} =
-          this.getNextMediaSequenceAndPart_(mediaSequenceNumber, segments);
+          this.getNextMediaSequenceAndPart_(mediaSequenceNumber, segments,
+              totalCount);
       streamInfo.nextMediaSequence = nextMediaSequence + skippedSegments;
       streamInfo.nextPart = nextPart;
       const playlistStartTime = mediaSequenceToStartTime.get(
@@ -625,10 +632,9 @@ shaka.hls.HlsParser = class {
     if (oldSegment) {
       streamInfo.minTimestamp = oldSegment.startTime;
 
-      const newestSegment = segments[segments.length - 1];
-      goog.asserts.assert(newestSegment, 'Should have segments!');
-
-      streamInfo.maxTimestamp = newestSegment.endTime;
+      if (segments.length) {
+        streamInfo.maxTimestamp = segments[segments.length - 1].endTime;
+      }
     }
 
     // Once the last segment has been added to the playlist,
@@ -3238,7 +3244,8 @@ shaka.hls.HlsParser = class {
         this.mediaSequenceToStartTimeByType_.get(type) : new Map();
 
     const {segments, bandwidth} = this.createSegments_(
-        playlist, mediaSequenceToStartTime, variables, getUris, type);
+        playlist, mediaSequenceToStartTime, variables, getUris, type,
+        /* isNewStream= */ true);
 
     if (!mimeType && type == shaka.util.ManifestParserUtils.ContentType.TEXT) {
       mimeType = await this.guessMimeType_(type, codecs, segments);
@@ -3382,8 +3389,9 @@ shaka.hls.HlsParser = class {
    * @return {{nextMediaSequence: number, nextPart:number}}}
    * @private
    */
-  getNextMediaSequenceAndPart_(mediaSequenceNumber, segments) {
-    const currentMediaSequence = mediaSequenceNumber + segments.length - 1;
+  getNextMediaSequenceAndPart_(mediaSequenceNumber, segments,
+      totalCount = segments.length) {
+    const currentMediaSequence = mediaSequenceNumber + totalCount - 1;
     let nextMediaSequence = currentMediaSequence;
     let nextPart = -1;
     if (!segments.length) {
@@ -4536,12 +4544,15 @@ shaka.hls.HlsParser = class {
    * @param {!Map<string, string>} variables
    * @param {function(): !Array<string>} getUris
    * @param {string} type
+   * @param {boolean} isNewStream When true, segments contains all parsed refs.
+   *   When false (live update), segments contains only newly seen refs.
    * @return {{segments: !Array<!shaka.media.SegmentReference>,
+   *          totalCount: number,
    *          bandwidth: (number|undefined)}}
    * @private
    */
   createSegments_(playlist, mediaSequenceToStartTime, variables,
-      getUris, type) {
+      getUris, type, isNewStream) {
     /** @type {Array<!shaka.hls.Segment>} */
     const hlsSegments = playlist.segments;
     goog.asserts.assert(hlsSegments.length, 'Playlist should have segments!');
@@ -4581,6 +4592,9 @@ shaka.hls.HlsParser = class {
 
     /** @type {!Array<!shaka.media.SegmentReference>} */
     const references = [];
+
+    /** @type {!Array<!shaka.media.SegmentReference>} */
+    const newReferences = [];
 
     let previousReference = null;
 
@@ -4651,6 +4665,8 @@ shaka.hls.HlsParser = class {
         }
       }
 
+      const isNewSegment =
+          isNewStream || !mediaSequenceToStartTime.has(position);
       mediaSequenceToStartTime.set(position, startTime);
 
 
@@ -4711,6 +4727,9 @@ shaka.hls.HlsParser = class {
           // method.
         } else {
           references.push(reference);
+          if (isNewSegment) {
+            newReferences.push(reference);
+          }
         }
       }
     }
@@ -4813,7 +4832,8 @@ shaka.hls.HlsParser = class {
     }
 
     return {
-      segments: references,
+      segments: isNewStream ? references : newReferences,
+      totalCount: references.length,
       bandwidth,
     };
   }


### PR DESCRIPTION
This PR reduces redundant work on every live HLS playlist poll by avoiding a full segment array re-merge when no new segments have arrived - hls.js does this in a similar fashion in mergeDetails: https://github.com/video-dev/hls.js/blob/master/src/utils/level-helper.ts