### PR TITLE
fix: Do not fallback to an arbitrary role with no strict role match

### DIFF
--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1912,7 +1912,9 @@ shaka.util.StreamUtils = class {
       if (roleMatches.length) {
         return roleMatches;
       } else {
-        shaka.log.warning('No exact match for the text role could be found.');
+        // If we have no closest preferred role, we didn't match any
+        // tracks. There's nothing left to do.
+        return [];
       }
     } else {
       // Prefer text streams with no roles, if they exist.


### PR DESCRIPTION
https://github.com/shaka-project/shaka-player/pull/9542 introduced a set of preferences. However, we fallback to an arbitrary role if there's no strict role match. This is clearly visible with tracks that do not require an initial selection (such as text, text can be left "not selected", thus no text tracks shown during initialization).

Read https://github.com/shaka-project/shaka-player/issues/9993 for more context.

While I think it's fair to say that if we have no strict role match, we shouldn't try and select one at all. A follow up should be:

- We drop `currentTextLanguage_`, `currentTextRole_` and `currentTextForced_`.
- Initial track selection matches each preference "per type" and comes up with the right initial track.
  - Each property in a single preference is an AND, each preference is an OR.
- We should also drop `setTextTrackVisibility_`, which we made internal going from 4 to 5. Text tracks are an explicit action, a valid selection makes the text track visible. Not selecting a text track (value = `null`) does not. The concept where we split text track selection and text track visibility has been dropped a while ago but we still have traces in our codebase.

With the work done on multiple preferences, we're probably going to have an easier time cleaning this up internally.