### PR TITLE
fix: Bail out on initial text preference when a user selected one manually.

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -3579,7 +3579,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // Selecting preferred text is delayed in SRC_EQUALS (on loadeddata),
     // if a user selected one before we enter here, we can bail out early
     // on initial text selection.
-    if (textTracks.some(textTrack => textTrack.active)) {
+    if (textTracks.some((textTrack) => textTrack.active)) {
       return;
     }
 
@@ -3596,7 +3596,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
           pref.role,
           pref.forced);
       if (subset.length) {
-        return this.selectTextTrack(subset[0]);
+        this.selectTextTrack(subset[0]);
+        return;
       }
     }
 
@@ -3611,11 +3612,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
             /* preferredRole= */ '',
             /* preferredForced= */ true);
         if (subset.length) {
-          return this.selectTextTrack(subset[0]);
+          this.selectTextTrack(subset[0]);
+          return;
         }
       }
     }
-    return this.selectTextTrack(null);
+    this.selectTextTrack(null);
   }
 
   /**

--- a/lib/player.js
+++ b/lib/player.js
@@ -3576,13 +3576,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
   setupPreferredTextOnSrc_() {
     const textTracks = this.getTextTracks();
 
-    if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
-      // Selecting preferred text is delayed in SRC_EQUALS (on loadeddata),
-      // if a user selected one before we enter here, we can bail out early
-      // on initial text selection.
-      if (textTracks.some(textTrack => textTrack.active)) {
-        return;
-      }
+    // Selecting preferred text is delayed in SRC_EQUALS (on loadeddata),
+    // if a user selected one before we enter here, we can bail out early
+    // on initial text selection.
+    if (textTracks.some(textTrack => textTrack.active)) {
+      return;
     }
 
     const preferredText = this.config_.preferredText;

--- a/lib/player.js
+++ b/lib/player.js
@@ -3575,6 +3575,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    */
   setupPreferredTextOnSrc_() {
     const textTracks = this.getTextTracks();
+
+    if (this.loadMode_ == shaka.Player.LoadMode.SRC_EQUALS) {
+      // Selecting preferred text is delayed in SRC_EQUALS (on loadeddata),
+      // if a user selected one before we enter here, we can bail out early
+      // on initial text selection.
+      if (textTracks.some(textTrack => textTrack.active)) {
+        return;
+      }
+    }
+
     const preferredText = this.config_.preferredText;
 
     // Try each preferred text entry in order

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1581,8 +1581,8 @@ shaka.util.StreamUtils = class {
    * @return {number} The generated ID.
    */
   static html5TrackId(html5Track) {
-    if (html5Track['__shaka_id'] == undefined) {
-      html5Track['__shaka_id'] = shaka.util.StreamUtils.nextTrackId_++;
+    if (!html5Track['__shaka_id']) {
+      html5Track['__shaka_id'] = ++shaka.util.StreamUtils.nextTrackId_;
     }
     return html5Track['__shaka_id'];
   }

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1581,7 +1581,7 @@ shaka.util.StreamUtils = class {
    * @return {number} The generated ID.
    */
   static html5TrackId(html5Track) {
-    if (!html5Track['__shaka_id']) {
+    if (html5Track['__shaka_id'] == undefined) {
       html5Track['__shaka_id'] = shaka.util.StreamUtils.nextTrackId_++;
     }
     return html5Track['__shaka_id'];

--- a/lib/util/stream_utils.js
+++ b/lib/util/stream_utils.js
@@ -1581,8 +1581,8 @@ shaka.util.StreamUtils = class {
    * @return {number} The generated ID.
    */
   static html5TrackId(html5Track) {
-    if (!html5Track['__shaka_id']) {
-      html5Track['__shaka_id'] = ++shaka.util.StreamUtils.nextTrackId_;
+    if (html5Track['__shaka_id'] == undefined) {
+      html5Track['__shaka_id'] = shaka.util.StreamUtils.nextTrackId_++;
     }
     return html5Track['__shaka_id'];
   }


### PR DESCRIPTION
```js
player.addTextTrackAsync("...", "en", "subtitles");
const textTracks = player.getTextTracks();
// Text tracks has a length of 1, but immediately selecting it would fail.
player.selectTextTrack(textTracks[0]);
```

Text track preference runs after we manually selected a text track, in `src=` we'd wait for `loadeddata` before figuring out which initial text track should be selected. The fix is to bail out when we already have a text track active when trying to select an initial text track.