### PR TITLE
fix: avoid pts rollover correction for fmp4/cmaf streams

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Esteban Dosztal <edosztal@gmail.com>
 Elchin Hasanov <elcin.hasanov@gmail.com>
 Fadomire <fadomire@gmail.com>
 Fernando Neira <slocomber@gmail.com>
+Fredrik Höglin <fredrik.hoglin@teliacompany.com>
 Gabor Balogh <grabomobil23@gmail.com>
 Gerardo Meola <meola.gerardo@gmail.com>
 Gil Gonen <gil.gonen@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -61,6 +61,7 @@ Elchin Hasanov <elcin.hasanov@gmail.com>
 Fadomire <fadomire@gmail.com>
 Fernando Neira <slocomber@gmail.com>
 François Beaufort <fbeaufort@google.com>
+Fredrik Höglin <fredrik.hoglin@teliacompany.com>
 Gabor Balogh <grabomobil23@gmail.com>
 Gary Katsevman <git@gkatsev.com>
 Gerardo Meola <meola.gerardo@gmail.com>

--- a/externs/shaka/text.js
+++ b/externs/shaka/text.js
@@ -61,7 +61,8 @@ shaka.extern.TextParser = class {
  *   periodStart: number,
  *   segmentStart: number,
  *   segmentEnd: number,
- *   vttOffset: number
+ *   vttOffset: number,
+ *   isMpegTs: boolean,
  * }}
  *
  * @property {number} periodStart
@@ -73,6 +74,10 @@ shaka.extern.TextParser = class {
  * @property {number} vttOffset
  *     The start time relative to either segment or period start depending
  *     on <code>segmentRelativeVttTiming</code> configuration.
+ * @property {boolean} isMpegTs
+ *     True if the media container type is MPEG-TS (not fMP4)
+ *     needed to know if we should use rollover wrapping when
+ *     calculating offset for webvtt cues in hls streams
  *
  * @exportDoc
  */

--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1286,6 +1286,8 @@ shaka.media.MediaSourceEngine = class {
         if (isBestSourceBufferForTimestamps && this.textEngine_) {
           this.textEngine_.setTimestampOffset(
               timestampOffset, reference.discontinuitySequence);
+          this.textEngine_.setContainerIsMpegTs(
+              (mimeType || '').includes('mp2t'));
         }
       }
       if (metadata.length) {

--- a/lib/offline/storage.js
+++ b/lib/offline/storage.js
@@ -1386,6 +1386,7 @@ shaka.offline.Storage = class {
       segmentStart: 0,
       segmentEnd: manifest.presentationTimeline.getDuration(),
       vttOffset: 0,
+      isMpegTs: false,
     };
     const data = shaka.util.BufferUtils.toUint8(buffer);
     const cues = TextParser.parseMedia(data, time, uri, /* images= */ []);

--- a/lib/player.js
+++ b/lib/player.js
@@ -5784,6 +5784,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         segmentStart: 0,
         segmentEnd: this.video_.duration,
         vttOffset: 0,
+        isMpegTs: false,
       };
       /** @type {!Array<shaka.text.Cue>} */
       const allCues = [];
@@ -7029,6 +7030,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         segmentStart: 0,
         segmentEnd: duration,
         vttOffset: 0,
+        isMpegTs: false,
       };
       const data = shaka.util.BufferUtils.toUint8(buffer);
       const cues = TextParser.parseMedia(data, time, uri, /* images= */ []);
@@ -7186,6 +7188,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         segmentStart: 0,
         segmentEnd: duration,
         vttOffset: 0,
+        isMpegTs: false,
       };
       const data = shaka.util.BufferUtils.toUint8(buffer);
       const cues = textParser.parseMedia(data, time, uri, /* images= */ []);
@@ -7377,6 +7380,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         segmentStart: 0,
         segmentEnd: this.video_.duration,
         vttOffset: 0,
+        isMpegTs: false,
       };
       const data = shaka.util.BufferUtils.toUint8(buffer);
       const cues = obj.parseMedia(

--- a/lib/text/text_engine.js
+++ b/lib/text/text_engine.js
@@ -40,6 +40,9 @@ shaka.text.TextEngine = class {
     this.segmentRelativeVttTiming_ = false;
 
     /** @private {boolean} */
+    this.containerIsMpegTs_ = false;
+
+    /** @private {boolean} */
     this.external_ = false;
 
     /** @private {Map<number, number>} */
@@ -220,6 +223,7 @@ shaka.text.TextEngine = class {
       segmentStart: startTime,
       segmentEnd: endTime,
       vttOffset: vttOffset,
+      isMpegTs: this.containerIsMpegTs_,
     };
 
     // Parse the buffer and add the new cues.
@@ -357,6 +361,17 @@ shaka.text.TextEngine = class {
       this.appendBuffer(buffer, startTime, endTime, uri, disco);
     }
     this.deferredAppends_.set(discontinuity, []);
+  }
+
+  /**
+   * Sets whether the video container is MPEG-TS. This controls whether the
+   * VTT parser applies its 33-bit PTS rollover correction logic, which must
+   * only run for MPEG-TS streams (not fMP4/CMAF).
+   *
+   * @param {boolean} isMpegTs
+   */
+  setContainerIsMpegTs(isMpegTs) {
+    this.containerIsMpegTs_ = isMpegTs;
   }
 
   /**

--- a/lib/text/vtt_text_parser.js
+++ b/lib/text/vtt_text_parser.js
@@ -147,10 +147,12 @@ shaka.text.VttTextParser = class {
 
     const rolloverSeconds =
         shaka.text.VttTextParser.TS_ROLLOVER_ / mpegTimescale;
-    let segmentStart = time.segmentStart - time.periodStart;
-    while (segmentStart >= rolloverSeconds) {
-      segmentStart -= rolloverSeconds;
-      mpegTime += shaka.text.VttTextParser.TS_ROLLOVER_;
+    if (time.isMpegTs) {
+      let segmentStart = time.segmentStart - time.periodStart;
+      while (segmentStart >= rolloverSeconds) {
+        segmentStart -= rolloverSeconds;
+        mpegTime += shaka.text.VttTextParser.TS_ROLLOVER_;
+      }
     }
 
     return time.periodStart + mpegTime / mpegTimescale - cueTime;

--- a/test/text/cue_integration.js
+++ b/test/text/cue_integration.js
@@ -19,7 +19,13 @@ describe('Cue', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         'Test',
-        {periodStart: 7, segmentStart: 10, segmentEnd: 60, vttOffset: 7});
+        {
+          periodStart: 7,
+          segmentStart: 10,
+          segmentEnd: 60,
+          vttOffset: 7,
+          isMpegTs: false,
+        });
     expect(cues.length).toBe(1);
     expect(cues[0].startTime).toBe(27);
     expect(cues[0].endTime).toBe(47);
@@ -34,7 +40,13 @@ describe('Cue', () => {
         'ID1\n' +
         '00:00:20.000 --> 00:00:40.000 align:middle size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     expect(cues.length).toBe(1);
   });
 

--- a/test/text/mp4_ttml_parser_unit.js
+++ b/test/text/mp4_ttml_parser_unit.js
@@ -59,8 +59,13 @@ describe('Mp4TtmlParser', () => {
   it('handles media segments with multiple mdats', () => {
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(ttmlInitSegment);
-    const time =
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 60,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const ret = parser.parseMedia(ttmlSegmentMultipleMDAT, time, null);
     // Bodies.
     expect(ret.length).toBe(2);
@@ -75,8 +80,13 @@ describe('Mp4TtmlParser', () => {
   it('handles media segments with multiple sample', () => {
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(ttmlInitSegment);
-    const time =
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 60,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const ret = parser.parseMedia(ttmlSegmentMultipleSample, time, null);
     // Bodies.
     expect(ret.length).toBe(2);
@@ -89,10 +99,20 @@ describe('Mp4TtmlParser', () => {
   });
 
   it('accounts for offset', () => {
-    const time1 =
-        {periodStart: 0, segmentStart: 0, segmentEnd: 70, vttOffset: 0};
-    const time2 =
-        {periodStart: 7, segmentStart: 0, segmentEnd: 70, vttOffset: 7};
+    const time1 = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 70,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
+    const time2 = {
+      periodStart: 7,
+      segmentStart: 0,
+      segmentEnd: 70,
+      vttOffset: 7,
+      isMpegTs: false,
+    };
 
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(ttmlInitSegment);
@@ -197,8 +217,13 @@ describe('Mp4TtmlParser', () => {
     ];
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(ttmlInitSegment);
-    const time =
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 60,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(ttmlSegment, time, null);
     shaka.test.TtmlUtils.verifyHelper(
         cues, result, {startTime: 23, endTime: 53.5});
@@ -207,8 +232,13 @@ describe('Mp4TtmlParser', () => {
   it('handles IMSC1 (CMAF) image subtitle', () => {
     const parser = new shaka.text.Mp4TtmlParser();
     parser.parseInit(imscImageInitSegment);
-    const time =
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 60,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const ret = parser.parseMedia(imscImageSegment, time, null);
     // Bodies.
     expect(ret.length).toBe(1);

--- a/test/text/mp4_vtt_parser_unit.js
+++ b/test/text/mp4_vtt_parser_unit.js
@@ -65,7 +65,13 @@ describe('Mp4VttParser', () => {
 
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(vttSegment, time);
     verifyHelper(cues, result);
   });
@@ -93,7 +99,13 @@ describe('Mp4VttParser', () => {
 
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(vttSegmentMultiPayload, time);
     verifyHelper(cues, result);
   });
@@ -121,7 +133,13 @@ describe('Mp4VttParser', () => {
 
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(vttSegSettings, time);
     verifyHelper(cues, result);
   });
@@ -143,7 +161,13 @@ describe('Mp4VttParser', () => {
 
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(vttSegNoDuration, time);
     verifyHelper(cues, result);
   });
@@ -165,8 +189,13 @@ describe('Mp4VttParser', () => {
 
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time =
-        {periodStart: 10, segmentStart: 0, segmentEnd: 0, vttOffset: 10};
+    const time = {
+      periodStart: 10,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 10,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(vttSegment, time);
     verifyHelper(cues, result);
   });
@@ -174,7 +203,13 @@ describe('Mp4VttParser', () => {
   it('handles empty media segments', () => {
     const parser = new shaka.text.Mp4VttParser();
     parser.parseInit(vttInitSegment);
-    const time = {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0};
+    const time = {
+      periodStart: 0,
+      segmentStart: 0,
+      segmentEnd: 0,
+      vttOffset: 0,
+      isMpegTs: false,
+    };
     const result = parser.parseMedia(new Uint8Array(0), time);
     verifyHelper([], result);
   });

--- a/test/text/srt_text_parser_unit.js
+++ b/test/text/srt_text_parser_unit.js
@@ -10,7 +10,13 @@ describe('SrtTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],
         '',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles a blank line at the end of the file', () => {
@@ -21,7 +27,13 @@ describe('SrtTextParser', () => {
         '1\n' +
         '00:00:20,000 --> 00:00:40,000\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles no blank line at the end of the file', () => {
@@ -32,7 +44,13 @@ describe('SrtTextParser', () => {
         '1\n' +
         '00:00:20,000 --> 00:00:40,000\n' +
         'Test\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles no newline after the final text payload', () => {
@@ -43,7 +61,13 @@ describe('SrtTextParser', () => {
         '1\n' +
         '00:00:20,000 --> 00:00:40,000\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports multiple cues', () => {
@@ -58,7 +82,13 @@ describe('SrtTextParser', () => {
         '2\n' +
         '00:00:40,000 --> 00:00:50,000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports payload stylized', () => {
@@ -179,7 +209,13 @@ describe('SrtTextParser', () => {
         '8\n' +
         '00:01:20,000 --> 00:01:30,000\n' +
         '{\\pos(960,540)}Positioned cue',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   /**

--- a/test/text/text_engine_unit.js
+++ b/test/text/text_engine_unit.js
@@ -104,7 +104,13 @@ describe('TextEngine', () => {
       await textEngine.appendBuffer(dummyData, 0, 3);
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -121,7 +127,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 3, segmentEnd: 5, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 3,
+          segmentEnd: 5,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -172,7 +184,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         'subs.vtt',
         [],
       ]);
@@ -195,7 +213,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         'subs.vtt',
         [],
       ]);
@@ -225,7 +249,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         'subs.vtt',
         [],
       ]);
@@ -255,7 +285,13 @@ describe('TextEngine', () => {
 
           expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
             dummyData,
-            {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+            {
+              periodStart: 0,
+              segmentStart: 0,
+              segmentEnd: 3,
+              vttOffset: 0,
+              isMpegTs: false,
+            },
             'subs.vtt',
             [],
           ]);
@@ -278,7 +314,13 @@ describe('TextEngine', () => {
 
           expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
             dummyData,
-            {periodStart: 0, segmentStart: 3, segmentEnd: 5, vttOffset: 0},
+            {
+              periodStart: 0,
+              segmentStart: 3,
+              segmentEnd: 5,
+              vttOffset: 0,
+              isMpegTs: false,
+            },
             'subs2.vtt',
             [],
           ]);
@@ -294,7 +336,13 @@ describe('TextEngine', () => {
 
           expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
             dummyData,
-            {periodStart: 0, segmentStart: 5, segmentEnd: 7, vttOffset: 0},
+            {
+              periodStart: 0,
+              segmentStart: 5,
+              segmentEnd: 7,
+              vttOffset: 0,
+              isMpegTs: false,
+            },
             'subs3.vtt',
             [],
           ]);
@@ -449,7 +497,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -465,7 +519,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 4, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
+        {
+          periodStart: 4,
+          segmentStart: 4,
+          segmentEnd: 7,
+          vttOffset: 4,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -494,7 +554,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         'subs.vtt',
         [],
       ]);
@@ -509,7 +575,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 4, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
+        {
+          periodStart: 4,
+          segmentStart: 4,
+          segmentEnd: 7,
+          vttOffset: 4,
+          isMpegTs: false,
+        },
         'subs2.vtt',
         [],
       ]);
@@ -540,7 +612,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -551,7 +629,13 @@ describe('TextEngine', () => {
       // vttOffset should equal segmentStart instead of periodStart
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 8, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
+        {
+          periodStart: 8,
+          segmentStart: 4,
+          segmentEnd: 7,
+          vttOffset: 4,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -576,7 +660,13 @@ describe('TextEngine', () => {
 
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 0, segmentEnd: 3, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 3,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);
@@ -587,7 +677,13 @@ describe('TextEngine', () => {
       // periodStart should equal 0 instead of timestampOffset
       expect(mockParseMedia).toHaveBeenCalledOnceMoreWith([
         dummyData,
-        {periodStart: 0, segmentStart: 4, segmentEnd: 7, vttOffset: 4},
+        {
+          periodStart: 0,
+          segmentStart: 4,
+          segmentEnd: 7,
+          vttOffset: 4,
+          isMpegTs: false,
+        },
         undefined,
         [],
       ]);

--- a/test/text/ttml_text_parser_unit.js
+++ b/test/text/ttml_text_parser_unit.js
@@ -13,14 +13,26 @@ describe('TtmlTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],
         '<tt></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
   it('supports empty text string', () => {
     verifyHelper([],
         '',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
@@ -28,7 +40,13 @@ describe('TtmlTextParser', () => {
     verifyHelper(
         [],
         '<tt><body><div>  \r\n </div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
@@ -55,7 +73,13 @@ describe('TtmlTextParser', () => {
           },
         ],
         '<tt xml:space="default">' + ttBody + '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.03, endTime: 62.05});
     // When xml:space="preserve", take them into account.
     verifyHelper(
@@ -81,7 +105,13 @@ describe('TtmlTextParser', () => {
           },
         ],
         '<tt xml:space="preserve">' + ttBody + '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.03, endTime: 62.05});
     // The default value for xml:space is "default".
     verifyHelper(
@@ -97,7 +127,13 @@ describe('TtmlTextParser', () => {
           },
         ],
         '<tt>' + ttBody + '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.03, endTime: 62.05});
 
     // Any other value is rejected as an error.
@@ -128,7 +164,13 @@ describe('TtmlTextParser', () => {
           },
         ],
         '<tt>' + ttBody + '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.03, endTime: 62.05});
   });
 
@@ -198,7 +240,13 @@ describe('TtmlTextParser', () => {
         '<span>First cue</span><br /><span>Second cue</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -234,7 +282,13 @@ describe('TtmlTextParser', () => {
         'First cue<br />Second cue' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -293,7 +347,13 @@ describe('TtmlTextParser', () => {
         '</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -312,7 +372,13 @@ describe('TtmlTextParser', () => {
         '<div><p begin="01:02.05" end="01:02:03.200">' +
         '<span>Test</span></p></div>' +
         '</body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -342,7 +408,13 @@ describe('TtmlTextParser', () => {
         '<p><div begin="01:02.05" end="01:02:03.200" ' +
         'smpte:backgroundImage="#img_0"></div></p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -354,7 +426,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -366,7 +444,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02" end="01:02:03.2">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62, endTime: 3723.2});
   });
 
@@ -378,7 +462,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 7, segmentStart: 60, segmentEnd: 3740, vttOffset: 0},
+        {
+          periodStart: 7,
+          segmentStart: 60,
+          segmentEnd: 3740,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 69.05, endTime: 3730.2});
   });
 
@@ -401,7 +491,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" end="01:02:03.200"><span>Nested cue</span></p>' +
         '</div></body></tt>',
-        {periodStart: 7, segmentStart: 60, segmentEnd: 3740, vttOffset: 0},
+        {
+          periodStart: 7,
+          segmentStart: 60,
+          segmentEnd: 3740,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 69.05, endTime: 3730.2});
   });
 
@@ -413,7 +509,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="59.45m30ms" end="1.5h2.3s">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 3560, segmentEnd: 5410, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 3560,
+          segmentEnd: 5410,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 3567.03, endTime: 5402.3});
   });
 
@@ -427,7 +529,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:10:15:15" end="00:11:02:30">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 610, segmentEnd: 670, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 610,
+          segmentEnd: 670,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 615.5, endTime: 663});
   });
 
@@ -441,7 +549,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:10:15:15" end="00:11:02:30">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 610, segmentEnd: 670, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 610,
+          segmentEnd: 670,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 615.5, endTime: 663});
   });
 
@@ -459,7 +573,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:10:15:15.1" end="00:11:02:29.2">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 610, segmentEnd: 670, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 610,
+          segmentEnd: 670,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: Util.closeTo(615.5 + 1 / 60), endTime: 663});
   });
 
@@ -473,7 +593,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="75f" end="300.3f">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 20, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 20,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 2.5, endTime: Util.closeTo(10.01)});
   });
 
@@ -487,7 +613,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="50t" end="60.2t">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 5, endTime: Util.closeTo(6.02)});
   });
 
@@ -499,7 +631,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" dur="5s">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 67.05});
   });
 
@@ -509,7 +647,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<!-- text-based TTML -->' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
@@ -529,7 +673,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -551,7 +701,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -573,7 +729,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -598,7 +760,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -623,7 +791,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -644,7 +818,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -673,7 +853,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             viewportAnchorX: 50,
@@ -701,7 +887,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             viewportAnchorX: 50,
@@ -730,7 +922,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -766,7 +964,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -802,7 +1006,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -839,7 +1049,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -876,7 +1092,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -914,7 +1136,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -951,7 +1179,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -980,7 +1214,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             viewportAnchorX: 50,
@@ -1008,7 +1248,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             viewportAnchorX: 50,
@@ -1038,7 +1284,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {
           region: {
             id: 'subtitleArea',
@@ -1070,7 +1322,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
 
@@ -1091,7 +1349,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
 
@@ -1112,7 +1376,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
 
@@ -1133,7 +1403,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
 
@@ -1154,7 +1430,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1179,7 +1461,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1197,7 +1485,13 @@ describe('TtmlTextParser', () => {
         '<div></div>' +
         '</body>' +
         '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
 
     verifyHelper(
@@ -1212,7 +1506,13 @@ describe('TtmlTextParser', () => {
         '</div>' +
         '</body>' +
         '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
 
     verifyHelper(
@@ -1225,7 +1525,13 @@ describe('TtmlTextParser', () => {
         '<div></div>' +
         '</body>' +
         '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
@@ -1242,7 +1548,13 @@ describe('TtmlTextParser', () => {
         '</div>' +
         '</body>' +
         '</tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -1265,7 +1577,13 @@ describe('TtmlTextParser', () => {
         '<body><div smpte:backgroundImage="#img_0">' +
         '<p begin="01:02.05" end="01:02:03.200"></p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2},
         {
           startTime: 62.05,
@@ -1294,7 +1612,13 @@ describe('TtmlTextParser', () => {
         '<body><div smpte:backgroundImage="img_0.png">' +
         '<p begin="01:02.05" end="01:02:03.200"></p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2},
         {
           startTime: 62.05,
@@ -1317,7 +1641,13 @@ describe('TtmlTextParser', () => {
         '<body><div begin="00:00.00" end="01:02.05" '+
         'smpte:backgroundImage="#img_0"></div>' +
         '</body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 70, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 70,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 0, endTime: 62.05},
         {
           startTime: 0,
@@ -1348,7 +1678,13 @@ describe('TtmlTextParser', () => {
         '<p begin="01:02.05" end="01:02:03.200" ' +
         'smpte:backgroundImage="#img_0" />' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -1375,7 +1711,13 @@ describe('TtmlTextParser', () => {
         '<p begin="01:02.05" end="01:02:03.200" tts:ruby="container">' +
         '<span tts:ruby="base">Line1</span><span tts:ruby="text">Line2' +
         '</span></p></div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -1404,7 +1746,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" end="01:02:03.200">Line1<br/>Line2</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
 
     verifyHelper(
@@ -1438,7 +1786,13 @@ describe('TtmlTextParser', () => {
         '<span>Line1<br/>Line2</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -1466,7 +1820,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1492,7 +1852,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1540,7 +1906,13 @@ describe('TtmlTextParser', () => {
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '<p begin="00:02.00" end="00:04.00" style="s2">Test 2</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 4, region: {id: 'subtitleArea'}},
         {startTime: 1, endTime: 4});
   });
@@ -1565,7 +1937,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1587,7 +1965,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1617,7 +2001,13 @@ describe('TtmlTextParser', () => {
         '<p tts:textAlign="center" begin="00:01.00" end="00:02.00">' +
         '<span style="style_1">alpha value</span></p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1654,7 +2044,13 @@ describe('TtmlTextParser', () => {
         '<span style="s1">Test</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1674,7 +2070,13 @@ describe('TtmlTextParser', () => {
         '<span style="s1">Test</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         // The body must have these properties:
         {backgroundColor: 'transparent'},
         // The div must have these properties:
@@ -1697,7 +2099,13 @@ describe('TtmlTextParser', () => {
         '<span>Test</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         // The body must have these properties:
         {backgroundColor: 'black'},
         // The div must have these properties:
@@ -1724,7 +2132,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1752,7 +2166,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200" style="s2">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1777,7 +2197,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1805,7 +2231,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1834,7 +2266,13 @@ describe('TtmlTextParser', () => {
         '<body><div>' +
         '<p begin="00:01.00" end="00:02.00" style="s1">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 2});
   });
 
@@ -1859,7 +2297,13 @@ describe('TtmlTextParser', () => {
         '<body region="subtitleArea"><div>' +
         '<p begin="01:02.05" end="01:02:03.200" style="s2">Test</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2, region: {id: 'subtitleArea'}},
         {startTime: 62.05, endTime: 3723.2});
   });
@@ -1874,7 +2318,13 @@ describe('TtmlTextParser', () => {
         '<p begin="00:01.00" end="00:02.00">First cue</p>' +
         '<p begin="00:03.00" end="00:04.00">Second cue</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 4});
   });
 
@@ -1898,7 +2348,13 @@ describe('TtmlTextParser', () => {
         '<tt><body><div>' +
         '<p begin="01:02.05" end="01:02:03.200"><span>äöü</span></p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 60, segmentEnd: 3730, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 60,
+          segmentEnd: 3730,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 62.05, endTime: 3723.2});
   });
 
@@ -1915,7 +2371,13 @@ describe('TtmlTextParser', () => {
         '<p begin="3s" end="4s">First cue</p>' +
         '<p begin="4s" end="5s">Second cue</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 10,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         // Capped to segment end time.
         {startTime: 1, endTime: 10},
         {startTime: 3, endTime: 10});
@@ -1941,7 +2403,13 @@ describe('TtmlTextParser', () => {
         '<span begin="5s" end="6s">Second cue</span>' +
         '</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 20, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 20,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         // Capped to segment end time.
         {startTime: 1, endTime: 20},
         {startTime: 3, endTime: 20});
@@ -1958,7 +2426,13 @@ describe('TtmlTextParser', () => {
         '<p begin="3s" end="4s">First cue</p>' +
         '<p begin="4s">Second cue</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 30, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 30,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 1, endTime: 30},
         {startTime: 3, endTime: 30});
   });
@@ -1974,7 +2448,13 @@ describe('TtmlTextParser', () => {
         '<p begin="1s">First cue</p>' +
         '<p begin="2s">Second cue</p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 9000, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 9000,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         // Capped to segment end time.
         {startTime: 1, endTime: 9000});
   });
@@ -2046,7 +2526,13 @@ describe('TtmlTextParser', () => {
         '    <span style="spanStyle">Test with spanStyle</span>' +
         '  </p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 60,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 0, endTime: 60});
   });
 
@@ -2078,7 +2564,13 @@ describe('TtmlTextParser', () => {
         '<body><div><p begin="00:00" end="01:00" region="r1">' +
         '<span>Hello!</span>' +
         '</p></div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 60,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 0, endTime: 60},
     );
   });
@@ -2140,7 +2632,13 @@ describe('TtmlTextParser', () => {
         '    A<br/>B' +
         '  </p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 60, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 60,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {startTime: 0, endTime: 60});
   });
 
@@ -2156,7 +2654,13 @@ describe('TtmlTextParser', () => {
         '    <span style="s1">Emo look.<br/>I mean listen.</span>' +
         '  </p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 160, segmentEnd: 170, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 160,
+          segmentEnd: 170,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
 
     verifyHelper(
@@ -2169,7 +2673,13 @@ describe('TtmlTextParser', () => {
         '    <span style="s1">Emo look.<br/>I mean listen.</span>' +
         '  </p>' +
         '</div></body></tt>',
-        {periodStart: 0, segmentStart: 170, segmentEnd: 180, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 170,
+          segmentEnd: 180,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         {});
   });
 
@@ -2211,7 +2721,13 @@ describe('TtmlTextParser', () => {
     expect(() => {
       new shaka.text.TtmlTextParser().parseMedia(
           shaka.util.BufferUtils.toUint8(data),
-          {periodStart: 0, segmentStart: 0, segmentEnd: 10, vttOffset: 0},
+          {
+            periodStart: 0,
+            segmentStart: 0,
+            segmentEnd: 10,
+            vttOffset: 0,
+            isMpegTs: false,
+          },
           'foo://bar', /* images= */ []);
     }).toThrow(error);
   }

--- a/test/text/vtt_text_parser_unit.js
+++ b/test/text/vtt_text_parser_unit.js
@@ -24,13 +24,25 @@ describe('VttTextParser', () => {
   it('supports no cues', () => {
     verifyHelper([],
         'WEBVTT',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports initial comments', () => {
     verifyHelper([],
         'WEBVTT - Comments',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports comment blocks', () => {
@@ -38,7 +50,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         'NOTE\n' +
         'This is a comment block',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports comment blocks with initial comment', () => {
@@ -46,7 +64,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         'NOTE - A header comment\n' +
         'This is a comment block',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles a blank line at the end of the file', () => {
@@ -57,7 +81,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles no blank line at the end of the file', () => {
@@ -68,7 +98,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         'Test\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('handles no newline after the final text payload', () => {
@@ -79,7 +115,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports cues with no settings', () => {
@@ -95,7 +137,13 @@ describe('VttTextParser', () => {
         '2\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports cues with no ID', () => {
@@ -109,7 +157,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports comments within cues', () => {
@@ -125,7 +179,13 @@ describe('VttTextParser', () => {
         'This is a note\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports non-integer timecodes', () => {
@@ -136,7 +196,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.100 --> 00:00:40.505\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports large timecodes', () => {
@@ -147,43 +213,109 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 30:00:00.000\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('requires header', () => {
     errorHelper(shaka.util.Error.Code.INVALID_TEXT_HEADER,
         '',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     errorHelper(shaka.util.Error.Code.INVALID_TEXT_HEADER,
         '00:00:00.000 --> 00:00:00.020\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('rejects invalid time values', () => {
     verifyHelper([],
         'WEBVTT\n\n00.020    --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n0:00.020  --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n00:00.20  --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n00:100.20 --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n00:00.020 --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n00:00:00:00.020 --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n00:61.020 --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
     verifyHelper([],
         'WEBVTT\n\n61:00.020 --> 0:00.040\nTest',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports vertical setting', () => {
@@ -207,7 +339,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000 vertical:lr\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports line setting', () => {
@@ -239,7 +377,13 @@ describe('VttTextParser', () => {
         'Test3\n\n' +
         '00:00:55.000 --> 00:01:05.000 line:12.3%\n' +
         'Test4\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports line setting with optional part', () => {
@@ -261,7 +405,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000 line:-1,center\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports position setting', () => {
@@ -275,7 +425,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:25.000 --> 00:00:45.000 position:12.3%\n' +
         'Test2\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports position setting with optional part', () => {
@@ -295,7 +451,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:20.000 --> 00:00:40.000 position:45%,start\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports size setting', () => {
@@ -309,7 +471,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:25.000 --> 00:00:45.000 size:12.3%\n' +
         'Test2\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports align setting', () => {
@@ -320,7 +488,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 align:center\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports multiple settings', () => {
@@ -338,7 +512,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 align:center size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports timestamps with one-digit hour at start time', () => {
@@ -356,7 +536,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '0:00:20.000 --> 00:00:40.000 align:center size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports timestamps with one-digit hour at end time', () => {
@@ -374,7 +560,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 0:00:40.000 align:center size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports stamps with one-digit hours at start & end time', () => {
@@ -392,7 +584,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '0:00:20.000 --> 0:00:40.000 align:center size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('uses time offset from vttOffset, not periodStart or segmentStart', () => {
@@ -410,7 +608,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '0:00:10.000 --> 0:00:20.000 align:center size:56% vertical:lr\n' +
         'Test',
-        {periodStart: 60, segmentStart: 80, segmentEnd: 100, vttOffset: 40});
+        {
+          periodStart: 60,
+          segmentStart: 80,
+          segmentEnd: 100,
+          vttOffset: 40,
+          isMpegTs: false,
+        });
   });
 
   it('parses VTTRegions', () => {
@@ -440,7 +644,13 @@ describe('VttTextParser', () => {
         'viewportanchor=10%,90% scroll=up\n\n' +
         '0:00:20.000 --> 0:00:40.000 region:reg1\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('ignores and logs invalid settings', () => {
@@ -453,7 +663,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 vertical:es\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -462,7 +678,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 vertical:\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -471,7 +693,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 vertical\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -480,7 +708,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 line:-3%\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -489,7 +723,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 line:45%%\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -498,7 +738,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 align:10\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     verifyHelper(
         [
@@ -507,7 +753,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000 align:foo\n' +
         'Test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
 
     expect(logWarningSpy).toHaveBeenCalledTimes(7);
   });
@@ -526,7 +778,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000 line:-1\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 25, segmentEnd: 65, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 25,
+          segmentEnd: 65,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         /* hls= */ true);
   });
 
@@ -542,7 +800,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000 line:-1\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 25, segmentEnd: 65, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 25,
+          segmentEnd: 65,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         /* hls= */ false);
   });
 
@@ -561,7 +825,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '01:00:20.000 --> 01:00:30.000 line:-1\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 25, segmentEnd: 65, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 25,
+          segmentEnd: 65,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         /* hls= */ true);
   });
 
@@ -579,7 +849,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000 line:-1\n' +
         'Test2',
-        {periodStart: 100, segmentStart: 25, segmentEnd: 65, vttOffset: 0},
+        {
+          periodStart: 100,
+          segmentStart: 25,
+          segmentEnd: 65,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         /* hls= */ true);
   });
 
@@ -596,7 +872,13 @@ describe('VttTextParser', () => {
         'Test',
         // Non-null segmentStart takes precedence over X-TIMESTAMP-MAP.
         // This protects us from rollover in the MPEGTS field.
-        {periodStart: 0, segmentStart: 95440, segmentEnd: 95550, vttOffset: 0},
+        {
+          periodStart: 0,
+          segmentStart: 95440,
+          segmentEnd: 95550,
+          vttOffset: 0,
+          isMpegTs: false,
+        },
         /* hls= */ true);
 
     verifyHelper(
@@ -610,7 +892,8 @@ describe('VttTextParser', () => {
         'X-TIMESTAMP-MAP=MPEGTS:9745408,LOCAL:00:00:00.000\n\n' +
         '00:00:00.000 --> 00:00:02.000 line:0\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 95550, segmentEnd: 95560, vttOffset: 0},
+        {periodStart: 0, segmentStart: 95550, segmentEnd: 95560, vttOffset: 0,
+          isMpegTs: true},
         /* hls= */ true);
   });
 
@@ -632,6 +915,7 @@ describe('VttTextParser', () => {
           segmentStart: 3600,
           segmentEnd: 3610,
           vttOffset: -1234567,
+          isMpegTs: true,
         },
         /* hls= */ true);
   });
@@ -671,7 +955,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports global style blocks without blank lines', () => {
@@ -699,7 +989,13 @@ describe('VttTextParser', () => {
         'Test\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports payload stylized', () => {
@@ -850,7 +1146,13 @@ describe('VttTextParser', () => {
         '<b>Test <i>7</i></b>\n\n' +
         '00:01:30.000 --> 00:01:40.000\n' +
         '<b>Test<i>8</b>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('support escaped html payload', () => {
@@ -885,7 +1187,13 @@ describe('VttTextParser', () => {
         '&quot;Test &amp; 1&quot;&nbsp;\n\n' +
         '00:00:41.000 --> 00:00:42.000\n' +
         '<i>Test</i>&amp;',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports specific style blocks', () => {
@@ -913,7 +1221,13 @@ describe('VttTextParser', () => {
         '<b>Test</b>\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports ruby html tags', () => {
@@ -955,7 +1269,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         '<ruby>Test<rt>2</rt><rp>3</rp></ruby>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports only two digits in the timestamp', () => {
@@ -966,7 +1286,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.00 --> 00:00:40.00\n' +
         'Test',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports class with default color', () => {
@@ -1145,7 +1471,13 @@ describe('VttTextParser', () => {
         '<c.lime>less or more <     >     > <        > >in text ></c>\n\n' +
         '00:02:00.000 --> 00:02:10.000\n' +
         '<c.lime>arrow in --> text</c>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports multiline colored', () => {
@@ -1189,7 +1521,13 @@ describe('VttTextParser', () => {
         '00:00:10.000 --> 00:00:20.000\n' +
         '<c.magenta>1</c>\n' +
         '<c.magenta><i>2</i></c>\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('passes text-shadow when multiple classes included', () => {
@@ -1220,7 +1558,13 @@ describe('VttTextParser', () => {
         '}\n\n' +
         '00:00:20.000 --> 00:00:40.000\n' +
         '<c.shadow.italic>Test</c>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports karaoke style text', () => {
@@ -1246,7 +1590,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:20.00 --> 00:00:40.00\n' +
         'Test<00:00:25.00> 1',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports voice style blocks', () => {
@@ -1293,7 +1643,13 @@ describe('VttTextParser', () => {
         '<v Shaka>Test\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         '<v ShakaBis>Test</v><i>2</i>',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports default color overriding', () => {
@@ -1319,7 +1675,13 @@ describe('VttTextParser', () => {
         '::cue(.bg_blue) { font-size: 10px; background-color: yellow }\n\n' +
         '00:00:10.000 --> 00:00:20.000\n' +
         '<c.red.bg_blue>Example 1</c>\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   // https://github.com/shaka-project/shaka-player/issues/4479
@@ -1363,7 +1725,13 @@ describe('VttTextParser', () => {
         'WEBVTT\n\n' +
         '00:00:10.000 --> 00:00:20.000\n' +
         '<c.magenta>1</c><br/><c.magenta><i>2</i></c>\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('does not fail on REGION blocks', () => {
@@ -1379,7 +1747,13 @@ describe('VttTextParser', () => {
         'id:1\n\n' +
         '00:00:10.000 --> 00:00:20.000\n' +
         'test\n\n',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports an extra newline inside the cue body', () => {
@@ -1393,7 +1767,13 @@ describe('VttTextParser', () => {
         'Test\n\nExtra line\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   it('supports an extra newline before the cue body', () => {
@@ -1407,7 +1787,13 @@ describe('VttTextParser', () => {
         '\nTest\n\n' +
         '00:00:40.000 --> 00:00:50.000\n' +
         'Test2',
-        {periodStart: 0, segmentStart: 0, segmentEnd: 0, vttOffset: 0});
+        {
+          periodStart: 0,
+          segmentStart: 0,
+          segmentEnd: 0,
+          vttOffset: 0,
+          isMpegTs: false,
+        });
   });
 
   /**

--- a/test/text/web_vtt_layout_integration.js
+++ b/test/text/web_vtt_layout_integration.js
@@ -510,6 +510,7 @@ filterDescribe('WebVTT layout', shaka.test.TextLayoutTests.supported, () => {
       segmentStart: 0,
       segmentEnd: 100,
       vttOffset: 0,
+      isMpegTs: false,
     };
     const textParser = new shaka.text.VttTextParser();
     const cues = textParser.parseMedia(data, time);


### PR DESCRIPTION
For HLS CMAF streams with WebVTT subtitles with large timestamps, the rollover wrapping prevents the cues from being shown at the correct time.

By adding a check to only do the wrapping for MPEG-TS streams this problem is eliminated.

fixes #10020