### PR TITLE
fix: Avoid race condition in concurrent getAllThumbnails calls

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -5465,19 +5465,23 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   async getAllThumbnails(trackId) {
-    const imageStream = await this.getBestImageStream_(trackId);
-    if (!imageStream) {
-      return null;
+    // Mark this stream as in use BEFORE awaiting, so a concurrent caller
+    // parked on the same createSegmentIndex promise will also have incremented
+    // inUse by the time either reaches its finally block. Incrementing after
+    // the await lets the first caller's sync finally close the segmentIndex
+    // out from under the second caller's iteration.
+    let pendingState = this.imageStreamPendingState_.get(trackId);
+    if (!pendingState) {
+      pendingState = {createPromise: null, inUse: 0};
+      this.imageStreamPendingState_.set(trackId, pendingState);
     }
-    // Mark this stream as in use so a concurrent getAllThumbnails call won't
-    // close the segmentIndex out from under us, and so getBestImageStream_
-    // won't see a stale (already-populated) segmentIndex that is about to be
-    // cleared.
-    const pendingState = this.imageStreamPendingState_.get(trackId);
-    if (pendingState) {
-      pendingState.inUse++;
-    }
+    pendingState.inUse++;
+    let imageStream;
     try {
+      imageStream = await this.getBestImageStream_(trackId);
+      if (!imageStream) {
+        return null;
+      }
       const thumbnails = [];
       imageStream.segmentIndex.forEachTopLevelReference((reference) => {
         const dimensions = this.parseTilesLayout_(
@@ -5502,15 +5506,12 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       });
       return thumbnails;
     } finally {
-      let canClose = true;
-      if (pendingState) {
-        pendingState.inUse--;
-        canClose = pendingState.inUse <= 0;
-        if (canClose) {
-          this.imageStreamPendingState_.delete(trackId);
-        }
+      pendingState.inUse--;
+      const canClose = pendingState.inUse <= 0;
+      if (canClose) {
+        this.imageStreamPendingState_.delete(trackId);
       }
-      if (canClose && imageStream.closeSegmentIndex) {
+      if (canClose && imageStream && imageStream.closeSegmentIndex) {
         imageStream.closeSegmentIndex();
       }
     }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5465,12 +5465,13 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   async getAllThumbnails(trackId) {
+    // TrackId can start from 0, so we use -1 as the key for the default
+    const trackIdKey = (trackId != null && trackId >= 0) ? trackId : -1;
     // Mark this stream as in use BEFORE awaiting, so a concurrent caller
     // parked on the same createSegmentIndex promise will also have incremented
     // inUse by the time either reaches its finally block. Incrementing after
     // the await lets the first caller's sync finally close the segmentIndex
     // out from under the second caller's iteration.
-    const trackIdKey = trackId || 0;
     let pendingState = this.imageStreamPendingState_.get(trackIdKey);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};
@@ -5621,7 +5622,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     //      transiently populated.
     //   2. A concurrent getAllThumbnails closeSegmentIndex won't race with
     //      this caller and leave imageStream.segmentIndex == null.
-    const trackIdKey = trackId || 0;
+    const trackIdKey = (trackId != null && trackId >= 0) ? trackId : -1;
     let pendingState = this.imageStreamPendingState_.get(trackIdKey);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};

--- a/lib/player.js
+++ b/lib/player.js
@@ -895,7 +895,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
      * concurrent getAllThumbnails calls (so the segmentIndex is not closed
      * out from under another in-flight call).
      *
-     * @private {!Map<string, {createPromise: ?Promise, inUse: number}>}
+     * @private {!Map<number, {createPromise: ?Promise, inUse: number}>}
      */
     this.imageStreamPendingState_ = new Map();
 
@@ -5470,15 +5470,15 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // inUse by the time either reaches its finally block. Incrementing after
     // the await lets the first caller's sync finally close the segmentIndex
     // out from under the second caller's iteration.
-    let pendingState = this.imageStreamPendingState_.get(trackId);
+    let pendingState = this.imageStreamPendingState_.get(trackId || 0);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackId, pendingState);
+      this.imageStreamPendingState_.set(trackId || 0, pendingState);
     }
     pendingState.inUse++;
     let imageStream;
     try {
-      imageStream = await this.getBestImageStream_(trackId);
+      imageStream = await this.getBestImageStream_(trackId || 0);
       if (!imageStream) {
         return null;
       }
@@ -5509,7 +5509,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       pendingState.inUse--;
       const canClose = pendingState.inUse <= 0;
       if (canClose) {
-        this.imageStreamPendingState_.delete(trackId);
+        this.imageStreamPendingState_.delete(trackId || 0);
       }
       if (canClose && imageStream && imageStream.closeSegmentIndex) {
         imageStream.closeSegmentIndex();
@@ -5620,10 +5620,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     //      transiently populated.
     //   2. A concurrent getAllThumbnails closeSegmentIndex won't race with
     //      this caller and leave imageStream.segmentIndex == null.
-    let pendingState = this.imageStreamPendingState_.get(trackId);
+    let pendingState = this.imageStreamPendingState_.get(trackId || 0);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackId, pendingState);
+      this.imageStreamPendingState_.set(trackId || 0, pendingState);
     }
     if (!imageStream.segmentIndex) {
       if (!pendingState.createPromise) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -5470,15 +5470,16 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     // inUse by the time either reaches its finally block. Incrementing after
     // the await lets the first caller's sync finally close the segmentIndex
     // out from under the second caller's iteration.
-    let pendingState = this.imageStreamPendingState_.get(trackId || 0);
+    const trackIdKey = trackId || 0;
+    let pendingState = this.imageStreamPendingState_.get(trackIdKey);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackId || 0, pendingState);
+      this.imageStreamPendingState_.set(trackIdKey, pendingState);
     }
     pendingState.inUse++;
     let imageStream;
     try {
-      imageStream = await this.getBestImageStream_(trackId || 0);
+      imageStream = await this.getBestImageStream_(trackId);
       if (!imageStream) {
         return null;
       }
@@ -5509,7 +5510,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       pendingState.inUse--;
       const canClose = pendingState.inUse <= 0;
       if (canClose) {
-        this.imageStreamPendingState_.delete(trackId || 0);
+        this.imageStreamPendingState_.delete(trackIdKey);
       }
       if (canClose && imageStream && imageStream.closeSegmentIndex) {
         imageStream.closeSegmentIndex();
@@ -5620,10 +5621,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     //      transiently populated.
     //   2. A concurrent getAllThumbnails closeSegmentIndex won't race with
     //      this caller and leave imageStream.segmentIndex == null.
-    let pendingState = this.imageStreamPendingState_.get(trackId || 0);
+    const trackIdKey = trackId || 0;
+    let pendingState = this.imageStreamPendingState_.get(trackIdKey);
     if (!pendingState) {
       pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackId || 0, pendingState);
+      this.imageStreamPendingState_.set(trackIdKey, pendingState);
     }
     if (!imageStream.segmentIndex) {
       if (!pendingState.createPromise) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -5507,7 +5507,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         pendingState.inUse--;
         canClose = pendingState.inUse <= 0;
         if (canClose) {
-          this.imageStreamPendingState_.delete(imageStream);
+          this.imageStreamPendingState_.delete(trackId);
         }
       }
       if (canClose && imageStream.closeSegmentIndex) {

--- a/lib/player.js
+++ b/lib/player.js
@@ -888,6 +888,17 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {!Map<shaka.extern.Stream, shaka.util.Timer>} */
     this.deferredCloseSegmentIndex_ = new Map();
 
+    /**
+     * Tracks pending state for image streams used by the thumbnail APIs.
+     * For each image stream, stores an in-flight createSegmentIndex promise
+     * (so concurrent callers share the same call) and a reference count of
+     * concurrent getAllThumbnails calls (so the segmentIndex is not closed
+     * out from under another in-flight call).
+     *
+     * @private {!Map<string, {createPromise: ?Promise, inUse: number}>}
+     */
+    this.imageStreamPendingState_ = new Map();
+
     /** @private {!Array<shaka.extern.Stream>} */
     this.externalSrcEqualsChapterStreams_ = [];
 
@@ -1739,6 +1750,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         timer.stop();
       }
       this.deferredCloseSegmentIndex_.clear();
+
+      this.imageStreamPendingState_.clear();
 
       this.externalSrcEqualsChapterStreams_ = [];
 
@@ -5456,32 +5469,51 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
-    const thumbnails = [];
-    imageStream.segmentIndex.forEachTopLevelReference((reference) => {
-      const dimensions = this.parseTilesLayout_(
-          reference.getTilesLayout() || imageStream.tilesLayout);
-      if (dimensions) {
-        const numThumbnails = dimensions.rows * dimensions.columns;
-        const duration = reference.trueEndTime - reference.startTime;
-        const thumbDuration = duration / numThumbnails;
-        for (let i = 0; i < numThumbnails; i++) {
-          const sampleTime = reference.startTime + i * thumbDuration;
-          const thumbnail = this.getThumbnailByReference_(reference,
-              /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
-              dimensions);
-          // If the thumbnail is missing, all future thumbnails in this
-          // reference are missing as well.
-          if (!thumbnail) {
-            break;
+    // Mark this stream as in use so a concurrent getAllThumbnails call won't
+    // close the segmentIndex out from under us, and so getBestImageStream_
+    // won't see a stale (already-populated) segmentIndex that is about to be
+    // cleared.
+    const pendingState = this.imageStreamPendingState_.get(trackId);
+    if (pendingState) {
+      pendingState.inUse++;
+    }
+    try {
+      const thumbnails = [];
+      imageStream.segmentIndex.forEachTopLevelReference((reference) => {
+        const dimensions = this.parseTilesLayout_(
+            reference.getTilesLayout() || imageStream.tilesLayout);
+        if (dimensions) {
+          const numThumbnails = dimensions.rows * dimensions.columns;
+          const duration = reference.trueEndTime - reference.startTime;
+          const thumbDuration = duration / numThumbnails;
+          for (let i = 0; i < numThumbnails; i++) {
+            const sampleTime = reference.startTime + i * thumbDuration;
+            const thumbnail = this.getThumbnailByReference_(reference,
+                /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
+                dimensions);
+            // If the thumbnail is missing, all future thumbnails in this
+            // reference are missing as well.
+            if (!thumbnail) {
+              break;
+            }
+            thumbnails.push(thumbnail);
           }
-          thumbnails.push(thumbnail);
+        }
+      });
+      return thumbnails;
+    } finally {
+      let canClose = true;
+      if (pendingState) {
+        pendingState.inUse--;
+        canClose = pendingState.inUse <= 0;
+        if (canClose) {
+          this.imageStreamPendingState_.delete(imageStream);
         }
       }
-    });
-    if (imageStream.closeSegmentIndex) {
-      imageStream.closeSegmentIndex();
+      if (canClose && imageStream.closeSegmentIndex) {
+        imageStream.closeSegmentIndex();
+      }
     }
-    return thumbnails;
   }
 
   /**
@@ -5581,8 +5613,25 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
+    // Coordinate concurrent callers via a per-stream pending state, so that:
+    //   1. Concurrent createSegmentIndex calls share the same in-flight
+    //      promise instead of being skipped because segmentIndex is
+    //      transiently populated.
+    //   2. A concurrent getAllThumbnails closeSegmentIndex won't race with
+    //      this caller and leave imageStream.segmentIndex == null.
+    let pendingState = this.imageStreamPendingState_.get(trackId);
+    if (!pendingState) {
+      pendingState = {createPromise: null, inUse: 0};
+      this.imageStreamPendingState_.set(trackId, pendingState);
+    }
     if (!imageStream.segmentIndex) {
-      await imageStream.createSegmentIndex();
+      if (!pendingState.createPromise) {
+        pendingState.createPromise = Promise.resolve(
+            imageStream.createSegmentIndex()).then(() => {
+          pendingState.createPromise = null;
+        });
+      }
+      await pendingState.createPromise;
     }
     return imageStream;
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5456,20 +5456,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
-    // Defer closeSegmentIndex via a debounced timer, mirroring getThumbnails.
-    // This prevents a concurrent getAllThumbnails/getThumbnails caller on the
-    // same imageStream from closing the segmentIndex out from under us.
-    if (imageStream.closeSegmentIndex) {
-      if (!this.deferredCloseSegmentIndex_.has(imageStream)) {
-        const timer = new shaka.util.Timer(() => {
-          imageStream.closeSegmentIndex();
-          this.deferredCloseSegmentIndex_.delete(imageStream);
-        });
-        this.deferredCloseSegmentIndex_.set(imageStream, timer);
-      }
-      this.deferredCloseSegmentIndex_.get(imageStream)
-          .tickAfter(/* seconds= */ 5);
-    }
     const thumbnails = [];
     imageStream.segmentIndex.forEachTopLevelReference((reference) => {
       const dimensions = this.parseTilesLayout_(
@@ -5537,18 +5523,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
-    if (imageStream.closeSegmentIndex) {
-      if (!this.deferredCloseSegmentIndex_.has(imageStream)) {
-        const timer = new shaka.util.Timer(() => {
-          imageStream.closeSegmentIndex();
-          this.deferredCloseSegmentIndex_.delete(imageStream);
-        });
-        this.deferredCloseSegmentIndex_.set(imageStream, timer);
-      }
-      const closeSegmentIndexTimer =
-          this.deferredCloseSegmentIndex_.get(imageStream);
-      closeSegmentIndexTimer.tickAfter(/* seconds= */ 5);
-    }
     const referencePosition = imageStream.segmentIndex.find(time);
     if (referencePosition == null) {
       return null;
@@ -5594,6 +5568,21 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
     if (!imageStream.segmentIndex) {
       await imageStream.createSegmentIndex();
+    }
+    // Defer closeSegmentIndex via a debounced timer so concurrent
+    // getThumbnails/getAllThumbnails callers on the same imageStream don't
+    // close the segmentIndex out from under each other. Each call resets
+    // the 5-second timer.
+    if (imageStream.closeSegmentIndex) {
+      if (!this.deferredCloseSegmentIndex_.has(imageStream)) {
+        const timer = new shaka.util.Timer(() => {
+          imageStream.closeSegmentIndex();
+          this.deferredCloseSegmentIndex_.delete(imageStream);
+        });
+        this.deferredCloseSegmentIndex_.set(imageStream, timer);
+      }
+      this.deferredCloseSegmentIndex_.get(imageStream)
+          .tickAfter(/* seconds= */ 5);
     }
     return imageStream;
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -888,17 +888,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     /** @private {!Map<shaka.extern.Stream, shaka.util.Timer>} */
     this.deferredCloseSegmentIndex_ = new Map();
 
-    /**
-     * Tracks pending state for image streams used by the thumbnail APIs.
-     * For each image stream, stores an in-flight createSegmentIndex promise
-     * (so concurrent callers share the same call) and a reference count of
-     * concurrent getAllThumbnails calls (so the segmentIndex is not closed
-     * out from under another in-flight call).
-     *
-     * @private {!Map<number, {createPromise: ?Promise, inUse: number}>}
-     */
-    this.imageStreamPendingState_ = new Map();
-
     /** @private {!Array<shaka.extern.Stream>} */
     this.externalSrcEqualsChapterStreams_ = [];
 
@@ -1750,8 +1739,6 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
         timer.stop();
       }
       this.deferredCloseSegmentIndex_.clear();
-
-      this.imageStreamPendingState_.clear();
 
       this.externalSrcEqualsChapterStreams_ = [];
 
@@ -5465,55 +5452,47 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
    * @export
    */
   async getAllThumbnails(trackId) {
-    // TrackId can start from 0, so we use -1 as the key for the default
-    const trackIdKey = (trackId != null && trackId >= 0) ? trackId : -1;
-    // Mark this stream as in use BEFORE awaiting, so a concurrent caller
-    // parked on the same createSegmentIndex promise will also have incremented
-    // inUse by the time either reaches its finally block. Incrementing after
-    // the await lets the first caller's sync finally close the segmentIndex
-    // out from under the second caller's iteration.
-    let pendingState = this.imageStreamPendingState_.get(trackIdKey);
-    if (!pendingState) {
-      pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackIdKey, pendingState);
+    const imageStream = await this.getBestImageStream_(trackId);
+    if (!imageStream) {
+      return null;
     }
-    pendingState.inUse++;
-    let imageStream;
-    try {
-      imageStream = await this.getBestImageStream_(trackId);
-      if (!imageStream) {
-        return null;
+    // Defer closeSegmentIndex via a debounced timer, mirroring getThumbnails.
+    // This prevents a concurrent getAllThumbnails/getThumbnails caller on the
+    // same imageStream from closing the segmentIndex out from under us.
+    if (imageStream.closeSegmentIndex) {
+      if (!this.deferredCloseSegmentIndex_.has(imageStream)) {
+        const timer = new shaka.util.Timer(() => {
+          imageStream.closeSegmentIndex();
+          this.deferredCloseSegmentIndex_.delete(imageStream);
+        });
+        this.deferredCloseSegmentIndex_.set(imageStream, timer);
       }
-      const thumbnails = [];
-      imageStream.segmentIndex.forEachTopLevelReference((reference) => {
-        const dimensions = this.parseTilesLayout_(
-            reference.getTilesLayout() || imageStream.tilesLayout);
-        if (dimensions) {
-          const numThumbnails = dimensions.rows * dimensions.columns;
-          const duration = reference.trueEndTime - reference.startTime;
-          const thumbDuration = duration / numThumbnails;
-          for (let i = 0; i < numThumbnails; i++) {
-            const sampleTime = reference.startTime + i * thumbDuration;
-            const thumbnail = this.getThumbnailByReference_(reference,
-                /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
-                dimensions);
-            // If the thumbnail is missing, all future thumbnails in this
-            // reference are missing as well.
-            if (!thumbnail) {
-              break;
-            }
-            thumbnails.push(thumbnail);
+      this.deferredCloseSegmentIndex_.get(imageStream)
+          .tickAfter(/* seconds= */ 5);
+    }
+    const thumbnails = [];
+    imageStream.segmentIndex.forEachTopLevelReference((reference) => {
+      const dimensions = this.parseTilesLayout_(
+          reference.getTilesLayout() || imageStream.tilesLayout);
+      if (dimensions) {
+        const numThumbnails = dimensions.rows * dimensions.columns;
+        const duration = reference.trueEndTime - reference.startTime;
+        const thumbDuration = duration / numThumbnails;
+        for (let i = 0; i < numThumbnails; i++) {
+          const sampleTime = reference.startTime + i * thumbDuration;
+          const thumbnail = this.getThumbnailByReference_(reference,
+              /** @type {shaka.extern.Stream} */ (imageStream), sampleTime,
+              dimensions);
+          // If the thumbnail is missing, all future thumbnails in this
+          // reference are missing as well.
+          if (!thumbnail) {
+            break;
           }
+          thumbnails.push(thumbnail);
         }
-      });
-      return thumbnails;
-    } finally {
-      pendingState.inUse--;
-      if (pendingState.inUse <= 0) {
-        this.imageStreamPendingState_.delete(trackIdKey);
-        imageStream?.closeSegmentIndex?.();
       }
-    }
+    });
+    return thumbnails;
   }
 
   /**
@@ -5613,27 +5592,8 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (!imageStream) {
       return null;
     }
-    // Coordinate concurrent callers via a per-stream pending state, so that:
-    //   1. Concurrent createSegmentIndex calls share the same in-flight
-    //      promise instead of being skipped because segmentIndex is
-    //      transiently populated.
-    //   2. A concurrent getAllThumbnails closeSegmentIndex won't race with
-    //      this caller and leave imageStream.segmentIndex == null.
-    const trackIdKey = (trackId != null && trackId >= 0) ? trackId : -1;
-    let pendingState = this.imageStreamPendingState_.get(trackIdKey);
-    if (!pendingState) {
-      pendingState = {createPromise: null, inUse: 0};
-      this.imageStreamPendingState_.set(trackIdKey, pendingState);
-    }
     if (!imageStream.segmentIndex) {
-      if (!pendingState.createPromise) {
-        pendingState.createPromise = imageStream
-            .createSegmentIndex()
-            .finally(() => {
-              pendingState.createPromise = null;
-            });
-      }
-      await pendingState.createPromise;
+      await imageStream.createSegmentIndex();
     }
     return imageStream;
   }

--- a/lib/player.js
+++ b/lib/player.js
@@ -5576,6 +5576,10 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     if (imageStream.closeSegmentIndex) {
       if (!this.deferredCloseSegmentIndex_.has(imageStream)) {
         const timer = new shaka.util.Timer(() => {
+          // Closure may have been destroyed since the timer was created.
+          if (!imageStream) {
+            return;
+          }
           imageStream.closeSegmentIndex();
           this.deferredCloseSegmentIndex_.delete(imageStream);
         });

--- a/lib/player.js
+++ b/lib/player.js
@@ -5509,12 +5509,9 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       return thumbnails;
     } finally {
       pendingState.inUse--;
-      const canClose = pendingState.inUse <= 0;
-      if (canClose) {
+      if (pendingState.inUse <= 0) {
         this.imageStreamPendingState_.delete(trackIdKey);
-      }
-      if (canClose && imageStream && imageStream.closeSegmentIndex) {
-        imageStream.closeSegmentIndex();
+        imageStream?.closeSegmentIndex?.();
       }
     }
   }
@@ -5630,10 +5627,11 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
     }
     if (!imageStream.segmentIndex) {
       if (!pendingState.createPromise) {
-        pendingState.createPromise = Promise.resolve(
-            imageStream.createSegmentIndex()).then(() => {
-          pendingState.createPromise = null;
-        });
+        pendingState.createPromise = imageStream
+            .createSegmentIndex()
+            .finally(() => {
+              pendingState.createPromise = null;
+            });
       }
       await pendingState.createPromise;
     }

--- a/test/player_integration.js
+++ b/test/player_integration.js
@@ -1178,6 +1178,39 @@ describe('Player', () => {
           const allThumbnails = await player.getAllThumbnails();
           expect(allThumbnails.length).toBe(3);
         });
+
+    it('handles concurrent getAllThumbnails calls', async () => {
+      await player.load('test:sintel_no_text_compiled');
+      const locationUri = new goog.Uri(location.href);
+      const partialUri =
+          new goog.Uri('/base/test/test/assets/thumbnails-sprites.vtt');
+      const absoluteUri = locationUri.resolve(partialUri);
+      const newTrack =
+          await player.addThumbnailsTrack(absoluteUri.toString());
+
+      // Two concurrent calls on the same track must share the
+      // createSegmentIndex call and both receive the full set without the
+      // first caller closing the segmentIndex out from under the second.
+      const [thumbnails1, thumbnails2] = await Promise.all([
+        player.getAllThumbnails(newTrack.id),
+        player.getAllThumbnails(newTrack.id),
+      ]);
+      expect(thumbnails1.length).toBe(3);
+      expect(thumbnails2.length).toBe(3);
+
+      // A subsequent call must still succeed after the concurrent pair
+      // tore down the shared pendingState.
+      const thumbnails3 = await player.getAllThumbnails(newTrack.id);
+      expect(thumbnails3.length).toBe(3);
+
+      // Default trackId must also coordinate with itself.
+      const [defaultThumbs1, defaultThumbs2] = await Promise.all([
+        player.getAllThumbnails(),
+        player.getAllThumbnails(),
+      ]);
+      expect(defaultThumbs1.length).toBe(3);
+      expect(defaultThumbs2.length).toBe(3);
+    });
   });  // describe('addThumbnailsTrack')
 
   it('preload', async () => {

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -5136,6 +5136,66 @@ describe('Player', () => {
           height: 50,
         }));
       });
+
+      it('coordinates concurrent calls on the same track', async () => {
+        const uris = () => ['thumbnail'];
+        const ref = new shaka.media.SegmentReference(
+            0, 60, uris, 0, null, null, 0, 0, Infinity, [],
+        );
+        const index = new shaka.media.SegmentIndex([ref]);
+
+        manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+          manifest.addVariant(0, (variant) => {
+            variant.addVideo(1);
+          });
+          manifest.addImageStream(5, (stream) => {
+            stream.originalId = 'thumbnail';
+            stream.width = 200;
+            stream.height = 150;
+            stream.mimeType = 'image/jpeg';
+            stream.tilesLayout = '2x3';
+          });
+        });
+
+        const imageStream = manifest.imageStreams[0];
+        imageStream.segmentIndex = null;
+
+        /** @type {function()} */
+        let resolveCreate;
+        const createSpy = jasmine.createSpy('createSegmentIndex')
+            .and.callFake(() => new Promise((resolve) => {
+              resolveCreate = () => {
+                imageStream.segmentIndex = index;
+                resolve();
+              };
+            }));
+        const closeSpy = jasmine.createSpy('closeSegmentIndex')
+            .and.callFake(() => {
+              imageStream.segmentIndex = null;
+            });
+        imageStream.createSegmentIndex = shaka.test.Util.spyFunc(createSpy);
+        imageStream.closeSegmentIndex = shaka.test.Util.spyFunc(closeSpy);
+
+        await player.load(fakeManifestUri, 0, fakeMimeType);
+
+        // Start two concurrent callers before createSegmentIndex resolves.
+        const p1 = player.getAllThumbnails(5);
+        const p2 = player.getAllThumbnails(5);
+
+        // Both callers must share the same in-flight createSegmentIndex call.
+        expect(createSpy).toHaveBeenCalledTimes(1);
+
+        resolveCreate();
+
+        const [thumbs1, thumbs2] = await Promise.all([p1, p2]);
+
+        expect(thumbs1.length).toBe(6);
+        expect(thumbs2.length).toBe(6);
+        expect(createSpy).toHaveBeenCalledTimes(1);
+        // closeSegmentIndex runs once — after the last caller finishes, not
+        // once per caller.
+        expect(closeSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/test/player_unit.js
+++ b/test/player_unit.js
@@ -5137,65 +5137,59 @@ describe('Player', () => {
         }));
       });
 
-      it('coordinates concurrent calls on the same track', async () => {
-        const uris = () => ['thumbnail'];
-        const ref = new shaka.media.SegmentReference(
-            0, 60, uris, 0, null, null, 0, 0, Infinity, [],
-        );
-        const index = new shaka.media.SegmentIndex([ref]);
+      it('handles concurrent calls without closing the segmentIndex early',
+          async () => {
+            const uris = () => ['thumbnail'];
+            const ref = new shaka.media.SegmentReference(
+                0, 60, uris, 0, null, null, 0, 0, Infinity, [],
+            );
+            const index = new shaka.media.SegmentIndex([ref]);
 
-        manifest = shaka.test.ManifestGenerator.generate((manifest) => {
-          manifest.addVariant(0, (variant) => {
-            variant.addVideo(1);
-          });
-          manifest.addImageStream(5, (stream) => {
-            stream.originalId = 'thumbnail';
-            stream.width = 200;
-            stream.height = 150;
-            stream.mimeType = 'image/jpeg';
-            stream.tilesLayout = '2x3';
-          });
-        });
-
-        const imageStream = manifest.imageStreams[0];
-        imageStream.segmentIndex = null;
-
-        /** @type {function()} */
-        let resolveCreate;
-        const createSpy = jasmine.createSpy('createSegmentIndex')
-            .and.callFake(() => new Promise((resolve) => {
-              resolveCreate = () => {
-                imageStream.segmentIndex = index;
-                resolve();
-              };
-            }));
-        const closeSpy = jasmine.createSpy('closeSegmentIndex')
-            .and.callFake(() => {
-              imageStream.segmentIndex = null;
+            manifest = shaka.test.ManifestGenerator.generate((manifest) => {
+              manifest.addVariant(0, (variant) => {
+                variant.addVideo(1);
+              });
+              manifest.addImageStream(5, (stream) => {
+                stream.originalId = 'thumbnail';
+                stream.width = 200;
+                stream.height = 150;
+                stream.mimeType = 'image/jpeg';
+                stream.tilesLayout = '2x3';
+                stream.segmentIndex = index;
+              });
             });
-        imageStream.createSegmentIndex = shaka.test.Util.spyFunc(createSpy);
-        imageStream.closeSegmentIndex = shaka.test.Util.spyFunc(closeSpy);
 
-        await player.load(fakeManifestUri, 0, fakeMimeType);
+            const imageStream = manifest.imageStreams[0];
+            const closeSpy = jasmine.createSpy('closeSegmentIndex')
+                .and.callFake(() => {
+                  imageStream.segmentIndex = null;
+                });
+            imageStream.closeSegmentIndex =
+                shaka.test.Util.spyFunc(closeSpy);
 
-        // Start two concurrent callers before createSegmentIndex resolves.
-        const p1 = player.getAllThumbnails(5);
-        const p2 = player.getAllThumbnails(5);
+            await player.load(fakeManifestUri, 0, fakeMimeType);
 
-        // Both callers must share the same in-flight createSegmentIndex call.
-        expect(createSpy).toHaveBeenCalledTimes(1);
+            jasmine.clock().install();
+            try {
+              // Two concurrent callers must both see the full set; the
+              // deferred close timer must not fire synchronously between
+              // them.
+              const [thumbs1, thumbs2] = await Promise.all([
+                player.getAllThumbnails(5),
+                player.getAllThumbnails(5),
+              ]);
+              expect(thumbs1.length).toBe(6);
+              expect(thumbs2.length).toBe(6);
+              expect(closeSpy).not.toHaveBeenCalled();
 
-        resolveCreate();
-
-        const [thumbs1, thumbs2] = await Promise.all([p1, p2]);
-
-        expect(thumbs1.length).toBe(6);
-        expect(thumbs2.length).toBe(6);
-        expect(createSpy).toHaveBeenCalledTimes(1);
-        // closeSegmentIndex runs once — after the last caller finishes, not
-        // once per caller.
-        expect(closeSpy).toHaveBeenCalledTimes(1);
-      });
+              // Once the 5-second deferred-close timer elapses,
+              // closeSegmentIndex fires exactly once.
+              await shaka.test.Util.fakeEventLoop(6);
+              expect(closeSpy).toHaveBeenCalledTimes(1);
+            } finally {
+              jasmine.clock().uninstall();
+            }
+          });
     });
   });
 


### PR DESCRIPTION
## What

Fixes a race condition observed in production when **`player.getAllThumbnails()`** is called concurrently for the same image stream.

This issue only affects HLS manifests that include **EXT-X-IMAGE-STREAM-INF** (DASH may be the same), because segmentIndex lifecycle management is only available in this case.

## Repro

1. Two `getAllThumbnails()` calls start back-to-back for the same image stream.
2. Call **1st** enters `getBestImageStream_`, sees `segmentIndex == null`, awaits `createSegmentIndex()`.
3. Call **2nd** enters `getBestImageStream_`, sees `segmentIndex` already populated by call **1st**, **skips** `createSegmentIndex` — but still yields at the async boundary.
4. Call **1st** finishes iterating, runs `closeSegmentIndex()` at the end, nulling `segmentIndex`.
5. Call **2nd** resumes and crashes on `imageStream.segmentIndex.forEachTopLevelReference` (TypeError: cannot read properties of null).

<img width="1188" height="1403" alt="image" src="https://github.com/user-attachments/assets/f1d2af6b-28ce-474f-85d9-edc9a8f85463" />

## Fix

Use the existing `deferredCloseSegmentIndex_`  to `getAllThumbnails`

- Don't close immediately. Schedule the close on a per-stream debounced timer. 
- Every thumbnail call resets the timer 5 seconds into the future. 
- As long as calls keep arriving, the segmentIndex stays alive; 
- Once the stream is idle for 5s, the timer fires and closes it exactly once.

`getThumbnails()` already uses the deferred-close timer mechanism.

## Risk

* Low. Only `getAllThumbnails` close behaviour changes (now deferred until the last concurrent caller finishes). No public API change.
* Can block the concurrent calls in the app's life-cycle: eg, adding a pending flag in the app rendering;
* If thumbnails come as VTT from an extra API request, it doesn't affect any segmentIndex lifecycle.