### PR TITLE
feat(Demo): Use monospace in extra config text areas

### DIFF
--- a/demo/custom.js
+++ b/demo/custom.js
@@ -745,6 +745,7 @@ shakaDemo.Custom = class {
     container.setDefaultRowClass('wide-input');
 
     const extraSetup = (input, container) => {
+      input.classList.add('extra-config-textarea');
       input.setAttribute('rows', 10);
 
       if (assetInProgress.extraConfig) {
@@ -800,6 +801,7 @@ shakaDemo.Custom = class {
     container.setDefaultRowClass('wide-input');
 
     const extraSetup = (input, container) => {
+      input.classList.add('extra-config-textarea');
       input.setAttribute('rows', 10);
 
       if (assetInProgress.extraUiConfig) {

--- a/demo/demo.less
+++ b/demo/demo.less
@@ -626,3 +626,7 @@ footer .mdl-mega-footer__link-list {
   margin: 4px 0;
   text-align: right;
 }
+
+.extra-config-textarea {
+  font-family: monospace;
+}


### PR DESCRIPTION
Improves readability when writing custom JSON configs.

| Before | After |
|-------|--------|
|<img width="448" height="456" alt="obraz" src="https://github.com/user-attachments/assets/8882aee0-8e58-4cd1-945d-aa6d0cf01cd2" />|<img width="448" height="449" alt="obraz" src="https://github.com/user-attachments/assets/c25fca0e-a5ae-4452-9095-08271e0cc04f" />|