### PR TITLE
feat(UI): Add new play_pause_buffering button

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -1190,7 +1190,8 @@ shakaDemo.Config = class {
         .addUIArrayNumberInput_('Fast Forward Rates', 'fastForwardRates')
         .addUIArrayNumberInput_('Rewind Rates', 'rewindRates')
         .addUIArrayNumberInput_('Captions Font Scale Factors',
-            'captionsFontScaleFactors');
+            'captionsFontScaleFactors')
+        .addUIBoolInput_('Show buffering spinner', 'showBufferingSpinner');
   }
 
   /** @private */

--- a/docs/tutorials/ui-customization.md
+++ b/docs/tutorials/ui-customization.md
@@ -50,6 +50,7 @@ The following elements can be added to the UI bar using this configuration value
   form where "0:10" (ten seconds) is the number of seconds passed from the start of the presentation
   and "1:00" (one minute) is the presentation duration.
 * play_pause: adds a button that plays/pauses the video on click.
+* play_pause_buffering: adds a button that plays/pauses the video on click.
 * mute: adds a button that mutes/unmutes the video on click.
 * volume: adds a volume slider.
 * fullscreen: adds a button that toggles full screen mode on click.
@@ -135,6 +136,7 @@ layout for the overflow menu to be available to the user.
 
 The following elements can be added as big buttons using this configuration value:
 * play_pause: adds a button that plays/pauses the video on click.
+* play_pause_buffering: adds a button that plays/pauses the video on click.
 * mute: adds a button that mutes/unmutes the video on click.
 * fullscreen: adds a button that toggles full screen mode on click.
 * rewind: adds a button that rewinds the presentation on click; that is, it starts playing

--- a/test/test/util/fake_demo_main.js
+++ b/test/test/util/fake_demo_main.js
@@ -125,6 +125,7 @@ shaka.test.FakeDemoMain = class {
       showUIOnPaused: true,
       showMenusOnTheRight: false,
       customTrackLabel: (defaultLabel, track, type) => '',
+      showBufferingSpinner: true,
     };
     this.selectedAsset = null;
 

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1292,7 +1292,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       this.addBigButtons_();
     }
 
-    if (!this.spinnerContainer_) {
+    if (this.config_.showBufferingSpinner && !this.spinnerContainer_) {
       this.addBufferingSpinner_();
     }
 

--- a/ui/controls.js
+++ b/ui/controls.js
@@ -1292,8 +1292,15 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       this.addBigButtons_();
     }
 
-    if (this.config_.showBufferingSpinner && !this.spinnerContainer_) {
-      this.addBufferingSpinner_();
+    if (this.config_.showBufferingSpinner) {
+      if (!this.spinnerContainer_) {
+        this.addBufferingSpinner_();
+      }
+    } else {
+      if (this.spinnerContainer_) {
+        this.videoContainer_.removeChild(this.spinnerContainer_);
+        this.spinnerContainer_ = null;
+      }
     }
 
     if (this.config_.seekOnTaps) {
@@ -1425,6 +1432,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
       </g>
     </svg>`;
     spinner.insertAdjacentHTML('beforeend', str);
+    this.onBufferingStateChange_();
   }
 
   /**
@@ -2229,7 +2237,7 @@ shaka.ui.Controls = class extends shaka.util.FakeEventTarget {
    * @private
    */
   onBufferingStateChange_() {
-    if (!this.enabled_) {
+    if (!this.enabled_ || !this.spinnerContainer_) {
       return;
     }
 

--- a/ui/externs/ui.js
+++ b/ui/externs/ui.js
@@ -337,6 +337,7 @@ shaka.extern.UITrackLabelCallback;
  *   showUIOnPaused: boolean,
  *   showMenusOnTheRight: boolean,
  *   customTrackLabel: shaka.extern.UITrackLabelCallback,
+ *   showBufferingSpinner: boolean,
  * }}
  *
  * @property {!Array<string>} controlPanelElements
@@ -635,6 +636,14 @@ shaka.extern.UITrackLabelCallback;
  *   value to keep the default.
  *   <br>
  *   Defaults to a no-op that returns <code>''</code>.
+ * @property {boolean} showBufferingSpinner
+ *   Whether or not to display a buffering spinner while the media is loading
+ *   or temporarily stalled due to insufficient data. When enabled, a visual
+ *   indicator is shown to inform the user that playback is waiting for more
+ *   content to be buffered.
+ *   <br>
+ *   Defaults to <code>true</code> except on mobile and smart TV whose
+ *   default value is <code>false</code>.
  * @exportDoc
  */
 shaka.extern.UIConfiguration;

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -11,6 +11,7 @@
   "BOTTOM_CENTER": "Bottom center",
   "BOTTOM_LEFT": "Bottom left",
   "BOTTOM_RIGHT": "Bottom right",
+  "BUFFERING": "Buffering",
   "CAPTIONS": "Captions",
   "CAST": "Cast...",
   "CENTER": "Center",

--- a/ui/locales/es.json
+++ b/ui/locales/es.json
@@ -11,6 +11,7 @@
   "BOTTOM_CENTER": "Abajo al centro",
   "BOTTOM_LEFT": "Abajo a la izquierda",
   "BOTTOM_RIGHT": "Abajo a la derecha",
+  "BUFFERING": "Cargando",
   "CAPTIONS": "Subtítulos",
   "CAST": "Enviar...",
   "CENTER": "Centro",

--- a/ui/locales/fr.json
+++ b/ui/locales/fr.json
@@ -11,6 +11,7 @@
   "BOTTOM_CENTER": "En bas au centre",
   "BOTTOM_LEFT": "En bas à gauche",
   "BOTTOM_RIGHT": "En bas à droite",
+  "BUFFERING": "Chargement",
   "CAPTIONS": "Sous-titres",
   "CAST": "Caster…",
   "CENTER": "Au centre",

--- a/ui/locales/source.json
+++ b/ui/locales/source.json
@@ -49,6 +49,10 @@
     "description": "Label for a button used to indicate a subtitle position.",
     "message": "Bottom right"
   },
+  "BUFFERING": {
+    "description": "Label for a button used to indicate that the video is currently buffering/loading data.",
+    "message": "Buffering"
+  },
   "CAPTIONS": {
     "description": "Label for a button used to navigate to a submenu to choose captions/subtitles in the video player.",
     "message": "Captions"

--- a/ui/play_button.js
+++ b/ui/play_button.js
@@ -27,9 +27,13 @@ shaka.ui.PlayButton = class extends shaka.ui.Element {
   /**
    * @param {!HTMLElement} parent
    * @param {!shaka.ui.Controls} controls
+   * @param {boolean=} showBuffering
    */
-  constructor(parent, controls) {
+  constructor(parent, controls, showBuffering = false) {
     super(parent, controls);
+
+    /** @private {boolean} */
+    this.showBuffering_ = showBuffering;
 
     /** @protected {!HTMLButtonElement} */
     this.button_ = shaka.util.Dom.createButton();
@@ -61,10 +65,17 @@ shaka.ui.PlayButton = class extends shaka.ui.Element {
           this.updateIcon_();
         });
 
-    this.eventManager.listen(this.player, 'loaded', () => {
-      this.updateAriaLabel_();
-      this.updateIcon_();
-    });
+    this.eventManager.listenMulti(
+        this.player,
+        [
+          'loading',
+          'loaded',
+          'unloading',
+          'buffering',
+        ], () => {
+          this.updateAriaLabel_();
+          this.updateIcon_();
+        });
 
     this.eventManager.listenMulti(
         this.adManager,
@@ -114,12 +125,26 @@ shaka.ui.PlayButton = class extends shaka.ui.Element {
   }
 
   /**
+   * @return {boolean}
+   * @private
+   */
+  isBuffering_() {
+    if (this.ad && this.ad.isLinear()) {
+      return false;
+    }
+
+    return this.player ? this.player.isBuffering() : false;
+  }
+
+  /**
    * @private
    */
   updateAriaLabel_() {
     const LocIds = shaka.ui.Locales.Ids;
     if (this.isEnded_() && this.video.duration) {
       this.button_.ariaLabel = this.localization.resolve(LocIds.REPLAY);
+    } else if (this.showBuffering_ && this.isBuffering_()) {
+      this.button_.ariaLabel = this.localization.resolve(LocIds.BUFFERING);
     } else {
       const label = this.isPaused_() ? LocIds.PLAY : LocIds.PAUSE;
       this.button_.ariaLabel = this.localization.resolve(label);
@@ -132,8 +157,25 @@ shaka.ui.PlayButton = class extends shaka.ui.Element {
    */
   updateIcon_() {
     const Icons = shaka.ui.Enums.MaterialDesignSVGIcons;
+    const svg = this.icon_.getSvgElement();
+    shaka.util.Dom.removeAllChildren(svg);
+
     if (this.isEnded_() && this.video.duration) {
       this.icon_.use(Icons['REPLAY']);
+    } else if (this.showBuffering_ && this.isBuffering_()) {
+      svg.setAttribute('viewBox', '0 0 38 38');
+      svg.style.setProperty('background-color', 'transparent');
+      svg.style.setProperty('mask-image', '');
+      svg.insertAdjacentHTML('beforeend',
+          `<g transform="translate(1 1)" stroke="currentColor"
+               stroke-width="6" fill="none" fill-rule="evenodd">
+             <circle stroke-opacity=".5" cx="18" cy="18" r="16"></circle>
+             <path d="M34 18c0-9.94-8.06-16-16-16">
+               <animateTransform attributeName="transform" type="rotate"
+                 from="0 18 18" to="360 18 18" dur="1s"
+                 repeatCount="indefinite"></animateTransform>
+             </path>
+           </g>`);
     } else {
       this.icon_.use(this.isPaused_() ? Icons['PLAY'] : Icons['PAUSE']);
     }
@@ -157,3 +199,22 @@ shaka.ui.Controls.registerElement(
 
 shaka.ui.Controls.registerBigElement(
     'play_pause', new shaka.ui.PlayButton.Factory());
+
+
+/**
+ * @implements {shaka.extern.IUIElement.Factory}
+ * @final
+ */
+shaka.ui.PlayButton.BufferingFactory = class {
+  /** @override */
+  create(rootElement, controls) {
+    return new shaka.ui.PlayButton(
+        rootElement, controls, /* showBuffering= */ true);
+  }
+};
+
+shaka.ui.Controls.registerElement(
+    'play_pause_buffering', new shaka.ui.PlayButton.BufferingFactory());
+
+shaka.ui.Controls.registerBigElement(
+    'play_pause_buffering', new shaka.ui.PlayButton.BufferingFactory());

--- a/ui/ui.js
+++ b/ui/ui.js
@@ -456,6 +456,7 @@ shaka.ui.Overlay = class {
       showUIOnPaused: true,
       showMenusOnTheRight: false,
       customTrackLabel: (defaultLabel, track, type) => '',
+      showBufferingSpinner: true,
     };
 
     if (goog.DEBUG) {
@@ -469,7 +470,7 @@ shaka.ui.Overlay = class {
     if (this.isMobile()) {
       config.bigButtons = [
         'skip_previous',
-        'play_pause',
+        'play_pause_buffering',
         'skip_next',
       ];
       config.customContextMenu = false;
@@ -505,7 +506,7 @@ shaka.ui.Overlay = class {
       ];
     } else if (this.isSmartTV()) {
       config.bigButtons = [
-        'play_pause',
+        'play_pause_buffering',
       ];
       config.customContextMenu = false;
       config.singleClickForPlayAndPause = false;
@@ -526,6 +527,10 @@ shaka.ui.Overlay = class {
           (name) => !filterElements.includes(name));
     } else {
       config.seekOnTaps = navigator.maxTouchPoints > 0;
+    }
+
+    if (config.bigButtons.some((name) => name === 'play_pause_buffering')) {
+      config.showBufferingSpinner = false;
     }
 
     const device = shaka.device.DeviceFactory.getDevice();


### PR DESCRIPTION
This new button is used on Mobile and SmartTV and eliminates the overlap between the spinner and the play/pause button.

Before in mobile: 
<img width="863" height="494" alt="imagen" src="https://github.com/user-attachments/assets/3db9f369-4d1f-49e4-b918-037b8078d7af" />

After in mobile:
<img width="863" height="494" alt="imagen" src="https://github.com/user-attachments/assets/c64390f0-6981-4750-8aad-0e4622134513" />
