### PR TITLE
feat(UITextDisplayer): add suspendRenderingWhenHidden config

### DIFF
--- a/demo/config.js
+++ b/demo/config.js
@@ -432,7 +432,9 @@ shakaDemo.Config = class {
             positionAreaOptionNames)
         .addNumberInput_('Subtitle delay (seconds)',
             'textDisplayer.subtitleDelay',
-            /* canBeDecimal= */ true);
+            /* canBeDecimal= */ true)
+        .addBoolInput_('Suspend rendering when hidden',
+            'textDisplayer.suspendRenderingWhenHidden');
   }
 
   /** @private */

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2954,6 +2954,7 @@ shaka.extern.OfflineConfiguration;
  *   fontScaleFactor: number,
  *   positionArea: shaka.config.PositionArea,
  *   subtitleDelay: number,
+ *   suspendRenderingWhenHidden: boolean,
  * }}
  *
  * @description
@@ -2979,6 +2980,16 @@ shaka.extern.OfflineConfiguration;
  *   (appear later than video); negative values advance them.
  *   <br>
  *   Defaults to <code>0</code>.
+ * @property {boolean} suspendRenderingWhenHidden
+ *   If <code>true</code>, the UI text displayer suspends caption rendering
+ *   when the video container is off-screen or the page is hidden, using
+ *   <code>IntersectionObserver</code> and <code>document.visibilityState</code>.
+ *   If <code>false</code>, captions render unconditionally on every captions
+ *   update period.
+ *   <br>
+ *   Defaults to <code>true</code>, except on TV devices where it defaults to
+ *   <code>false</code> because some TV browsers misreport
+ *   <code>IntersectionObserver</code> visibility for the player container.
  * @exportDoc
  */
 shaka.extern.TextDisplayerConfiguration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2987,9 +2987,8 @@ shaka.extern.OfflineConfiguration;
  *   If <code>false</code>, captions render unconditionally on every captions
  *   update period.
  *   <br>
- *   Defaults to <code>true</code>, except on TV devices where it defaults to
- *   <code>false</code> because some TV browsers misreport
- *   <code>IntersectionObserver</code> visibility for the player container.
+ *   Defaults to <code>true</code> except on Tizen, WebOS, Hisense,
+ *   Vizio whose default value is <code>false</code>.
  * @exportDoc
  */
 shaka.extern.TextDisplayerConfiguration;

--- a/externs/shaka/player.js
+++ b/externs/shaka/player.js
@@ -2983,7 +2983,8 @@ shaka.extern.OfflineConfiguration;
  * @property {boolean} suspendRenderingWhenHidden
  *   If <code>true</code>, the UI text displayer suspends caption rendering
  *   when the video container is off-screen or the page is hidden, using
- *   <code>IntersectionObserver</code> and <code>document.visibilityState</code>.
+ *   <code>IntersectionObserver</code> and
+ *   <code>document.visibilityState</code>.
  *   If <code>false</code>, captions render unconditionally on every captions
  *   update period.
  *   <br>

--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -253,6 +253,9 @@ shaka.device.AbstractDevice = class {
       config.ads.skipPlayDetection = true;
       config.ads.supportsMultipleMediaElements = false;
     }
+    if (deviceType === shaka.device.IDevice.DeviceType.TV) {
+      config.textDisplayer.suspendRenderingWhenHidden = false;
+    }
     return config;
   }
 

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -401,7 +401,10 @@ shaka.text.UITextDisplayer = class {
       isFullscreenActive = video.webkitDisplayingFullscreen;
     }
     const pageVisible = document.visibilityState === 'visible';
-    const actuallyVisible = isPiPActive || isFullscreenActive ||
+    const suspendWhenHidden =
+        this.config_?.suspendRenderingWhenHidden !== false;
+    const actuallyVisible = !suspendWhenHidden || isPiPActive ||
+        isFullscreenActive ||
         (pageVisible && this.isContainerActuallyVisible_);
     if (actuallyVisible) {
       if (this.renderSuspended_) {

--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -401,8 +401,7 @@ shaka.text.UITextDisplayer = class {
       isFullscreenActive = video.webkitDisplayingFullscreen;
     }
     const pageVisible = document.visibilityState === 'visible';
-    const suspendWhenHidden =
-        this.config_?.suspendRenderingWhenHidden !== false;
+    const suspendWhenHidden = this.config_?.suspendRenderingWhenHidden ?? true;
     const actuallyVisible = !suspendWhenHidden || isPiPActive ||
         isFullscreenActive ||
         (pageVisible && this.isContainerActuallyVisible_);

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -15,7 +15,6 @@ goog.require('shaka.config.MsfVersion');
 goog.require('shaka.config.PositionArea');
 goog.require('shaka.config.RepeatMode');
 goog.require('shaka.device.DeviceFactory');
-goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.FairPlay');
 goog.require('shaka.log');
@@ -402,14 +401,12 @@ shaka.util.PlayerConfiguration = class {
       interstitialPreloadAheadTime: 10,
     };
 
-    const isTV = device.getDeviceType() ===
-        shaka.device.IDevice.DeviceType.TV;
     const textDisplayer = {
       captionsUpdatePeriod: 0.25,
       fontScaleFactor: 1,
       positionArea: shaka.config.PositionArea.DEFAULT,
       subtitleDelay: 0,
-      suspendRenderingWhenHidden: !isTV,
+      suspendRenderingWhenHidden: true,
     };
 
     const queue = {

--- a/lib/util/player_configuration.js
+++ b/lib/util/player_configuration.js
@@ -15,6 +15,7 @@ goog.require('shaka.config.MsfVersion');
 goog.require('shaka.config.PositionArea');
 goog.require('shaka.config.RepeatMode');
 goog.require('shaka.device.DeviceFactory');
+goog.require('shaka.device.IDevice');
 goog.require('shaka.drm.DrmUtils');
 goog.require('shaka.drm.FairPlay');
 goog.require('shaka.log');
@@ -401,11 +402,14 @@ shaka.util.PlayerConfiguration = class {
       interstitialPreloadAheadTime: 10,
     };
 
+    const isTV = device.getDeviceType() ===
+        shaka.device.IDevice.DeviceType.TV;
     const textDisplayer = {
       captionsUpdatePeriod: 0.25,
       fontScaleFactor: 1,
       positionArea: shaka.config.PositionArea.DEFAULT,
       subtitleDelay: 0,
+      suspendRenderingWhenHidden: !isTV,
     };
 
     const queue = {


### PR DESCRIPTION
Closes #10042

Adds a `textDisplayer.suspendRenderingWhenHidden` config flag that gates the IntersectionObserver-based render suspension introduced in #9545.

- Defaults to `true` (existing behavior preserved for browsers/desktop).
- Defaults to `false` on TV devices (detected via `shaka.device.DeviceFactory.getDevice().getDeviceType() === DeviceType.TV`).

Some TV browsers (e.g. older Tizen WebKit) misreport `IntersectionObserver` visibility for transformed/absolute-positioned player containers, leading to permanently suspended caption rendering. Disabling suspension on TVs sidesteps the platform bug at the cost of running one DOM update per `captionsUpdatePeriod` (default 0.25s) while the player is off-screen.

Externs updated at `externs/shaka/player.js`. When the flag is `false`, `applyVisibility_` short-circuits to "always visible" so the IO observer can never suspend rendering.