### PR TITLE
fix(UI): check if ad is linear before updating mute label and icon

### DIFF
--- a/ui/mute_button.js
+++ b/ui/mute_button.js
@@ -147,7 +147,7 @@ shaka.ui.MuteButton = class extends shaka.ui.Element {
   updateLocalizedStrings_() {
     const LocIds = shaka.ui.Locales.Ids;
     let label;
-    if (this.ad) {
+    if (this.ad && this.ad.isLinear()) {
       label = this.ad.isMuted() ? LocIds.UNMUTE : LocIds.MUTE;
     } else {
       label = (this.video.muted || this.video.volume == 0) ?
@@ -167,7 +167,7 @@ shaka.ui.MuteButton = class extends shaka.ui.Element {
   updateIcon_() {
     const Icons = shaka.ui.Enums.MaterialDesignSVGIcons;
     let icon;
-    if (this.ad) {
+    if (this.ad && this.ad.isLinear()) {
       icon = this.ad.isMuted() ? Icons['UNMUTE'] : Icons['MUTE'];
     } else {
       icon = (this.video.muted || this.video.volume == 0) ?


### PR DESCRIPTION
When linear ad was muted and there is still nonlinear ad mute button is stuck with status of linear ad instead of video, this change fixes it