### PR TITLE
perf: Remove unnecessary Uint8ArrayUtils.concat calls in Mp4Generator

### DIFF
--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -53,11 +53,10 @@ shaka.util.Mp4Generator = class {
     for (const streamInfo of this.streamInfos_) {
       trakArrays.push(this.trak_(streamInfo));
     }
-    const traks = shaka.util.Uint8ArrayUtils.concat(...trakArrays);
     const firstStreamInfo = this.streamInfos_[0];
     return Mp4Generator.box('moov',
         this.mvhd_(firstStreamInfo),
-        traks,
+        ...trakArrays,
         this.mvex_(),
         this.psshs(firstStreamInfo.stream));
   }
@@ -685,8 +684,7 @@ shaka.util.Mp4Generator = class {
     for (const streamInfo of this.streamInfos_) {
       trexArrays.push(this.trex_(streamInfo));
     }
-    const trexs = shaka.util.Uint8ArrayUtils.concat(...trexArrays);
-    return Mp4Generator.box('mvex', trexs);
+    return Mp4Generator.box('mvex', ...trexArrays);
   }
 
   /**
@@ -1037,8 +1035,7 @@ shaka.util.Mp4Generator = class {
     const Mp4Generator = shaka.util.Mp4Generator;
     const samples = streamInfo.data ? streamInfo.data.samples : [];
     const allData = samples.map((sample) => sample.data);
-    const bytes = shaka.util.Uint8ArrayUtils.concat(...allData);
-    return Mp4Generator.box('mdat', bytes);
+    return Mp4Generator.box('mdat', ...allData);
   }
 
 

--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -842,8 +842,7 @@ shaka.util.Mp4Generator = class {
   segmentData() {
     const segmentDataArray = [];
     for (const streamInfo of this.streamInfos_) {
-      segmentDataArray.push(
-          ...[this.moof_(streamInfo), this.mdat_(streamInfo)]);
+      segmentDataArray.push(this.moof_(streamInfo), this.mdat_(streamInfo));
     }
     const result = shaka.util.Uint8ArrayUtils.concat(...segmentDataArray);
     return result;


### PR DESCRIPTION
`Mp4Generator.box()` merges all arguments into one `Uint8Array`, so arrays of `Uint8Arrays` can be spread directly into the `Mp4Generator.box()` calls instead of doing the extra step of merging them into a single `Uint8Array` first. I also included a drive-by change to simplify `array.push(...[x, y])` into `array.push(x, y)` in the `segmentData` method.