### PR TITLE
perf(DASH): lazy segment reference creation

### DIFF
--- a/lib/dash/segment_template.js
+++ b/lib/dash/segment_template.js
@@ -536,7 +536,6 @@ shaka.dash.SegmentTemplate = class {
         range[0];
     const maxPosition = lastSegmentNumber || range[1];
 
-    const references = [];
     const createReference = (position) => {
       // These inner variables are all scoped to the inner loop, and can be used
       // safely in the callback below.
@@ -654,13 +653,11 @@ shaka.dash.SegmentTemplate = class {
       return ref;
     };
 
-    for (let position = minPosition; position <= maxPosition; ++position) {
-      const reference = createReference(position);
-      references.push(reference);
-    }
-
     /** @type {shaka.media.SegmentIndex} */
-    const segmentIndex = new shaka.media.SegmentIndex(references);
+    const segmentIndex =
+        new shaka.dash.SegmentTemplate.FixedDurationSegmentIndex_(
+            minPosition, maxPosition, startNumber, periodStart,
+            segmentDuration, createReference);
 
     // If the availability timeline currently ends before the period, we will
     // need to add references over time.
@@ -764,6 +761,160 @@ shaka.dash.SegmentTemplate = class {
       ref.boundaryEnd = context.periodInfo.start + context.periodInfo.duration;
     }
     return ref;
+  }
+};
+
+
+/**
+ * A SegmentIndex for SegmentTemplate@duration.
+ *
+ * Fixed-duration templates can describe very long VOD presentations. Creating
+ * every SegmentReference up front is expensive on older Chromium/V8 builds, so
+ * this keeps public SegmentIndex positions stable while materializing each
+ * reference on first access.
+ *
+ * @extends {shaka.media.SegmentIndex}
+ * @private
+ */
+shaka.dash.SegmentTemplate.FixedDurationSegmentIndex_ = class extends
+  shaka.media.SegmentIndex {
+  /**
+   * @param {number} minPosition
+   * @param {number} maxPosition
+   * @param {number} startNumber
+   * @param {number} periodStart
+   * @param {number} segmentDuration
+   * @param {function(number):!shaka.media.SegmentReference} createReference
+   */
+  constructor(
+      minPosition, maxPosition, startNumber, periodStart, segmentDuration,
+      createReference) {
+    const numReferences = Math.max(0, maxPosition - minPosition + 1);
+    super(new Array(numReferences));
+
+    /** @private {number} */
+    this.minPosition_ = minPosition;
+
+    /** @private {number} */
+    this.startNumber_ = startNumber;
+
+    /** @private {number} */
+    this.periodStart_ = periodStart;
+
+    /** @private {number} */
+    this.segmentDuration_ = segmentDuration;
+
+    /**
+     * @private {function(number):!shaka.media.SegmentReference}
+     */
+    this.createReference_ = createReference;
+  }
+
+  /**
+   * @override
+   */
+  find(time) {
+    const lastReferenceIndex = this.references.length - 1;
+    if (lastReferenceIndex < 0) {
+      return null;
+    }
+
+    const first = this.get(this.numEvicted_);
+    if (!first) {
+      return null;
+    }
+    if (time < first.startTime) {
+      return this.numEvicted_;
+    }
+
+    const segmentNumber =
+        Math.floor((time - this.periodStart_) / this.segmentDuration_) +
+        this.startNumber_;
+    const position = segmentNumber - this.minPosition_;
+    if (position < this.numEvicted_) {
+      return null;
+    }
+
+    const r = this.get(position);
+    if (!r) {
+      return null;
+    }
+
+    const index = position - this.numEvicted_;
+    const next = index < lastReferenceIndex ? this.get(position + 1) : null;
+    const end = next ? next.startTime : r.endTime;
+    if ((time >= r.startTime) && (time < end)) {
+      return position;
+    }
+    return null;
+  }
+
+  /**
+   * @override
+   */
+  get(position) {
+    const index = position - this.numEvicted_;
+    if (index < 0 || index >= this.references.length) {
+      return null;
+    }
+
+    let reference = this.references[index];
+    if (!reference) {
+      reference = this.createReference_(this.minPosition_ + position);
+      this.references[index] = reference;
+    }
+    return reference;
+  }
+
+  /**
+   * @override
+   */
+  earliestReference() {
+    return this.get(this.numEvicted_);
+  }
+
+  /**
+   * @override
+   */
+  forEachTopLevelReference(fn) {
+    for (let i = 0; i < this.references.length; i++) {
+      const reference = this.get(i + this.numEvicted_);
+      if (reference) {
+        fn(reference);
+      }
+    }
+  }
+
+  /**
+   * @override
+   */
+  evict(time) {
+    if (this.getIsImmutable()) {
+      return;
+    }
+
+    const lastReferenceIndex = this.references.length - 1;
+    if (lastReferenceIndex < 0) {
+      return;
+    }
+
+    const first = this.get(this.numEvicted_);
+    if (!first || first.endTime > time) {
+      return;
+    }
+
+    const lastPosition = this.numEvicted_ + lastReferenceIndex;
+    const last = this.get(lastPosition);
+    const lo = last && last.endTime <= time ? this.references.length :
+        Math.max(0, Math.min(this.references.length,
+            Math.floor((time - this.periodStart_) / this.segmentDuration_ +
+                this.startNumber_ - 1) -
+            (this.minPosition_ + this.numEvicted_) + 1));
+
+    if (lo > 0) {
+      this.numEvicted_ += lo;
+      this.references = this.references.slice(lo);
+    }
   }
 };
 


### PR DESCRIPTION
This PR extends work from #5061 to DASH SegmentTemplate@duration streams by lazily creating fixed-duration segment references instead of building the full index up front during manifest parsing