### PR TITLE
perf(media): replace slice with in-place array truncation

### DIFF
--- a/lib/media/segment_index.js
+++ b/lib/media/segment_index.js
@@ -244,10 +244,7 @@ shaka.media.SegmentIndex = class {
     // Everything at or after that index is replaced by the incoming references.
     const lo = shaka.util.ArrayUtils.binarySearch(this.references,
         (r) => Math.round(r.startTime * 1000) / 1000 < firstStartTime);
-    if (lo < this.references.length) {
-      this.references = this.references.slice(0, lo);
-    }
-
+    this.references.length = lo;
     this.references.push(...references);
 
     if (goog.DEBUG) {


### PR DESCRIPTION
This PR removes slice for a simpler truncation - especially good for `merge` because we just truncate from the back. No need for allocation for none of them anyway so this is an easy win