### PR TITLE
fix(text): include regionAnchorX/Y in region cache key

### DIFF
--- a/lib/text/ui_text_displayer.js
+++ b/lib/text/ui_text_displayer.js
@@ -695,7 +695,8 @@ shaka.text.UITextDisplayer = class {
         region.viewportAnchorUnits == percentageUnit ? '%' : 'px';
     const uniqueRegionId = `${region.id}_${
       region.width}x${region.height}${heightUnit}-${
-      region.viewportAnchorX}x${region.viewportAnchorY}${viewportAnchorUnit}`;
+      region.viewportAnchorX}x${region.viewportAnchorY}${viewportAnchorUnit}-${
+      region.regionAnchorX}x${region.regionAnchorY}`;
 
     return uniqueRegionId;
   }


### PR DESCRIPTION
Region elements were cached by an ID that omitted regionAnchorX and regionAnchorY, causing regions that shared the same viewport anchor but differed in region anchor to reuse a previously cached DOM element positioned incorrectly. Include both region anchor values in the generated ID so each unique anchor combination gets its own element.

Issue: https://github.com/shaka-project/shaka-player/issues/2583