### PR TITLE
perf(HLS): skip rebuilding known refs on live playlist refresh

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -594,7 +594,8 @@ shaka.hls.HlsParser = class {
     const wasRedirected = response.uri !== response.originalUri;
     const {segments, totalCount, bandwidth} = this.createSegments_(
         playlist, mediaSequenceToStartTime, mediaVariables,
-        streamInfo.getUris, streamInfo.type, /* isNewStream= */ wasRedirected);
+        streamInfo.getUris, streamInfo.type, /* isNewStream= */ wasRedirected,
+        stream.segmentIndex);
     if (bandwidth) {
       stream.bandwidth = bandwidth;
     }
@@ -3247,7 +3248,7 @@ shaka.hls.HlsParser = class {
 
     const {segments, bandwidth} = this.createSegments_(
         playlist, mediaSequenceToStartTime, variables, getUris, type,
-        /* isNewStream= */ true);
+        /* isNewStream= */ true, /* existingSegmentIndex= */ null);
 
     if (!mimeType && type == shaka.util.ManifestParserUtils.ContentType.TEXT) {
       mimeType = await this.guessMimeType_(type, codecs, segments);
@@ -3426,6 +3427,31 @@ shaka.hls.HlsParser = class {
       nextMediaSequence,
       nextPart,
     };
+  }
+
+  /**
+   * Find the existing SegmentReference for a media sequence number.
+   *
+   * @param {?shaka.media.SegmentIndex} segmentIndex
+   * @param {!Map<number, number>} mediaSequenceToStartTime
+   * @param {number} mediaSequence
+   * @return {?shaka.media.SegmentReference}
+   * @private
+   */
+  getReferenceForMediaSequence_(
+      segmentIndex, mediaSequenceToStartTime, mediaSequence) {
+    if (!segmentIndex || !mediaSequenceToStartTime.has(mediaSequence)) {
+      return null;
+    }
+
+    const startTime = mediaSequenceToStartTime.get(mediaSequence);
+    const position = segmentIndex.find(startTime);
+    if (position == null) {
+      return null;
+    }
+
+    const reference = segmentIndex.get(position);
+    return reference && reference.startTime == startTime ? reference : null;
   }
 
 
@@ -4548,13 +4574,14 @@ shaka.hls.HlsParser = class {
    * @param {string} type
    * @param {boolean} isNewStream When true, segments contains all parsed refs.
    *   When false (live update), segments contains only newly seen refs.
+   * @param {?shaka.media.SegmentIndex} existingSegmentIndex
    * @return {{segments: !Array<!shaka.media.SegmentReference>,
    *          totalCount: number,
    *          bandwidth: (number|undefined)}}
    * @private
    */
   createSegments_(playlist, mediaSequenceToStartTime, variables,
-      getUris, type, isNewStream) {
+      getUris, type, isNewStream, existingSegmentIndex) {
     /** @type {Array<!shaka.hls.Segment>} */
     const hlsSegments = playlist.segments;
     goog.asserts.assert(hlsSegments.length, 'Playlist should have segments!');
@@ -4599,9 +4626,69 @@ shaka.hls.HlsParser = class {
     const newReferences = [];
 
     let previousReference = null;
+    let syncAnchorReference = null;
 
     /** @type {!Array<{bitrate: number, duration: number}>} */
     const bitrates = [];
+
+    // Index of the first segment whose reference must be rebuilt.
+    // Start by assuming all existing references can be reused,
+    // then scan forward until we find the first segment that is missing,
+    // still partial, or no longer matches the finalized segment duration.
+    // If we cannot find a previous reference to anchor the new tail, fall back
+    // to rebuilding the whole playlist.
+    let firstReferenceToCreate = 0;
+    if (!isNewStream && existingSegmentIndex) {
+      firstReferenceToCreate = hlsSegments.length;
+      for (let i = 0; i < hlsSegments.length; i++) {
+        const segmentPosition = mediaSequenceNumber + skippedSegments + i;
+        if (!mediaSequenceToStartTime.has(segmentPosition)) {
+          firstReferenceToCreate = i;
+          break;
+        }
+        if (hlsSegments[i].partialSegments.length) {
+          firstReferenceToCreate = i;
+          break;
+        }
+        // Active partial segments are handled above - in low-latency mode, also
+        // rebuild if a segment that was previously represented by partials now
+        // has a finalized EXTINF duration that differs from the existing ref.
+        if (this.lowLatencyMode_) {
+          const extinfTag = shaka.hls.Utils.getFirstTagWithName(
+              hlsSegments[i].tags, 'EXTINF');
+          if (extinfTag) {
+            const extinfDuration =
+                shaka.hls.Utils.getExtinfDuration(extinfTag);
+            const existingRef = this.getReferenceForMediaSequence_(
+                existingSegmentIndex, mediaSequenceToStartTime,
+                segmentPosition);
+            if (existingRef &&
+                Math.abs(
+                    (existingRef.endTime - existingRef.startTime) -
+                    extinfDuration) > 0.001) {
+              firstReferenceToCreate = i;
+              break;
+            }
+          }
+        }
+      }
+
+      if (firstReferenceToCreate > 0) {
+        const previousPosition =
+            mediaSequenceNumber + skippedSegments + firstReferenceToCreate - 1;
+        previousReference = this.getReferenceForMediaSequence_(
+            existingSegmentIndex, mediaSequenceToStartTime, previousPosition);
+        if (previousReference) {
+          syncAnchorReference = previousReference;
+          shaka.log.debug('HLS live update: reusing', firstReferenceToCreate,
+              'known segment references and building only the new tail.');
+        } else {
+          shaka.log.debug('HLS live update: full playlist rebuild selected ' +
+              'for overlap recovery.');
+          firstReferenceToCreate = 0;
+        }
+      }
+    }
 
     const getMimeType = (uri) => {
       const HlsParser = shaka.hls.HlsParser;
@@ -4650,7 +4737,8 @@ shaka.hls.HlsParser = class {
       if (discontinuityTag) {
         discontinuitySequence++;
 
-        if (previousReference && previousReference.initSegmentReference) {
+        if (i >= firstReferenceToCreate &&
+            previousReference && previousReference.initSegmentReference) {
           previousReference.initSegmentReference.boundaryEnd = startTime;
         }
       }
@@ -4667,10 +4755,13 @@ shaka.hls.HlsParser = class {
         }
       }
 
+      if (i < firstReferenceToCreate) {
+        continue;
+      }
+
       const isNewSegment =
           isNewStream || !mediaSequenceToStartTime.has(position);
       mediaSequenceToStartTime.set(position, startTime);
-
 
       const reference = this.createSegmentReference_(
           currentInitSegmentRef,
@@ -4748,7 +4839,8 @@ shaka.hls.HlsParser = class {
 
     // If some segments have sync times, but not all, extrapolate the sync
     // times of the ones with none.
-    const someSyncTime = references.some((ref) => ref.syncTime != null);
+    const someSyncTime = !!syncAnchorReference?.syncTime ||
+        references.some((ref) => ref.syncTime != null);
     if (someSyncTime) {
       for (let i = 0; i < references.length; i++) {
         const reference = references[i];
@@ -4798,6 +4890,11 @@ shaka.hls.HlsParser = class {
               return other.syncTime + backwardAdd;
             }
             backwardI -= 1;
+          } else if (syncAnchorReference &&
+              syncAnchorReference.syncTime != null) {
+            return syncAnchorReference.syncTime +
+                (syncAnchorReference.endTime -
+                syncAnchorReference.startTime) + backwardAdd;
           }
           return null;
         };
@@ -4835,7 +4932,7 @@ shaka.hls.HlsParser = class {
 
     return {
       segments: isNewStream ? references : newReferences,
-      totalCount: references.length,
+      totalCount: firstReferenceToCreate + references.length,
       bandwidth,
     };
   }

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -1117,6 +1117,155 @@ describe('HlsParser live', () => {
             manifest, mediaWithAdditionalSegment, [newRef1, newRef2]);
       });
 
+      it('only creates references for the new tail on update', async () => {
+        const createSegmentReferenceSpy =
+            spyOn(parser, 'createSegmentReference_').and.callThrough();
+
+        const ref1 = makeReference(
+            'test:/main.mp4', 0, 2, /* syncTime= */ null);
+        const ref2 = makeReference(
+            'test:/main2.mp4', 2, 4, /* syncTime= */ null);
+
+        const manifest = await testInitialManifest(
+            master, mediaWithAdditionalSegment, [ref1, ref2]);
+
+        createSegmentReferenceSpy.calls.reset();
+
+        const ref3 = makeReference(
+            'test:/main3.mp4', 4, 6, /* syncTime= */ null);
+        const mediaWithAdditionalSegmentAndNewSegment = [
+          mediaWithAdditionalSegment,
+          '#EXTINF:2,\n',
+          'main3.mp4\n',
+        ].join('');
+        await testUpdate(
+            manifest, mediaWithAdditionalSegmentAndNewSegment,
+            [ref1, ref2, ref3]);
+
+        expect(createSegmentReferenceSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('falls back to rebuilding all refs on redirect updates', async () => {
+        const createSegmentReferenceSpy =
+            spyOn(parser, 'createSegmentReference_').and.callThrough();
+
+        const ref1 = makeReference(
+            'test:/main.mp4', 0, 2, /* syncTime= */ null);
+
+        let playlistFetchCount = 0;
+        fakeNetEngine.setResponseFilter((type, response) => {
+          if (response.uri == 'test:/video') {
+            playlistFetchCount++;
+            if (playlistFetchCount == 2) {
+              response.uri = 'test:/redirected/video';
+            }
+          }
+        });
+
+        const manifest = await testInitialManifest(master, media, [ref1]);
+
+        createSegmentReferenceSpy.calls.reset();
+
+        const redirectedRef1 = makeReference(
+            ['test:/redirected/main.mp4', 'test:/main.mp4'],
+            0, 2, /* syncTime= */ null);
+        const redirectedRef2 = makeReference(
+            ['test:/redirected/main2.mp4', 'test:/main2.mp4'],
+            2, 4, /* syncTime= */ null);
+        await testUpdate(
+            manifest, mediaWithAdditionalSegment,
+            [redirectedRef1, redirectedRef2]);
+
+        expect(createSegmentReferenceSpy).toHaveBeenCalledTimes(2);
+      });
+
+      it('extrapolates syncTime for new tail ref via anchor on update',
+          async () => {
+            const createSegmentReferenceSpy =
+                spyOn(parser, 'createSegmentReference_').and.callThrough();
+
+            // Corresponds to "2000-01-01T00:00:00.00Z".
+            const syncTimeBase = 946684800;
+
+            const mediaWithPdt = [
+              '#EXTM3U\n',
+              '#EXT-X-TARGETDURATION:5\n',
+              '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+              '#EXT-X-MEDIA-SEQUENCE:0\n',
+              '#EXT-X-PROGRAM-DATE-TIME:2000-01-01T00:00:00.00Z\n',
+              '#EXTINF:2,\n',
+              'main.mp4\n',
+              '#EXTINF:2,\n',
+              'main2.mp4\n',
+            ].join('');
+
+            const mediaWithPdtAndNewSegment = [
+              '#EXTM3U\n',
+              '#EXT-X-TARGETDURATION:5\n',
+              '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+              '#EXT-X-MEDIA-SEQUENCE:0\n',
+              '#EXT-X-PROGRAM-DATE-TIME:2000-01-01T00:00:00.00Z\n',
+              '#EXTINF:2,\n',
+              'main.mp4\n',
+              '#EXTINF:2,\n',
+              'main2.mp4\n',
+              '#EXTINF:2,\n',
+              'main3.mp4\n',
+            ].join('');
+
+            const ref1 = makeReference(
+                'test:/main.mp4', 0, 2, syncTimeBase);
+            const ref2 = makeReference(
+                'test:/main2.mp4', 2, 4, syncTimeBase + 2);
+            const ref3 = makeReference(
+                'test:/main3.mp4', 4, 6, syncTimeBase + 4);
+
+            const manifest = await testInitialManifest(
+                master, mediaWithPdt, [ref1, ref2]);
+
+            createSegmentReferenceSpy.calls.reset();
+
+            await testUpdate(
+                manifest, mediaWithPdtAndNewSegment, [ref1, ref2, ref3]);
+
+            // Only the new tail segment was created — the two known segments
+            // were skipped and their anchor used to extrapolate syncTime.
+            expect(createSegmentReferenceSpy).toHaveBeenCalledTimes(1);
+          });
+
+      it('falls back to full rebuild when anchor reference is unavailable',
+          async () => {
+            const createSegmentReferenceSpy =
+                spyOn(parser, 'createSegmentReference_').and.callThrough();
+
+            const ref1 = makeReference(
+                'test:/main.mp4', 0, 2, /* syncTime= */ null);
+            const ref2 = makeReference(
+                'test:/main2.mp4', 2, 4, /* syncTime= */ null);
+            const ref3 = makeReference(
+                'test:/main3.mp4', 4, 6, /* syncTime= */ null);
+
+            const manifest = await testInitialManifest(
+                master, mediaWithAdditionalSegment, [ref1, ref2]);
+
+            createSegmentReferenceSpy.calls.reset();
+            // Force anchor lookup to fail, triggering full-rebuild fallback.
+            spyOn(parser, 'getReferenceForMediaSequence_')
+                .and.returnValue(null);
+
+            const mediaWithThreeSegments = [
+              mediaWithAdditionalSegment,
+              '#EXTINF:2,\n',
+              'main3.mp4\n',
+            ].join('');
+
+            await testUpdate(
+                manifest, mediaWithThreeSegments, [ref1, ref2, ref3]);
+
+            // All 3 segments rebuilt since the anchor was unavailable.
+            expect(createSegmentReferenceSpy).toHaveBeenCalledTimes(3);
+          });
+
       it('parses start time from mp4 segments', async () => {
         const ref = makeReference(
             'test:/main.mp4', 0, 2, /* syncTime= */ null);


### PR DESCRIPTION
This PR reduces steady-state work during HLS live/DVR playlist refreshes by avoiding already known segments' re-construction. Before this, on a live playlist update, the parser would still call createSegmentReference_() for every segment, though only the newly appended tail was actually merged into the segment index.
