### PR TITLE
fix: force gap jump when stalled at the end of a buffer

### DIFF
--- a/lib/media/gap_jumping_controller.js
+++ b/lib/media/gap_jumping_controller.js
@@ -227,8 +227,24 @@ shaka.media.GapJumpingController = class {
     const buffered = this.video_.buffered;
     const gapDetectionThreshold = this.config_.gapDetectionThreshold;
 
-    const gapIndex = shaka.media.TimeRangesUtils.getGapIndex(
+    let gapIndex = shaka.media.TimeRangesUtils.getGapIndex(
         buffered, currentTime, gapDetectionThreshold);
+
+    // If we are not technically in a gap according to getGapIndex,
+    // but we are stuck at the very edge of a range and there's a gap ahead:
+    if (gapIndex == null &&
+        this.stallDetector_ && !this.stallDetector_.poll()) {
+      const info = shaka.media.TimeRangesUtils.getBufferedInfo(buffered);
+      for (let i = 0; i < info.length - 1; i++) {
+        // If we are stuck within a very small margin (0.1s) of the end of a
+        // range and the next range is far away, we consider it a gap.
+        if (Math.abs(currentTime - info[i].end) < 0.1 &&
+            info[i+1].start > info[i].end) {
+          gapIndex = i + 1;
+          break;
+        }
+      }
+    }
 
     // The current time is unbuffered or is too far from a gap.
     if (gapIndex == null) {


### PR DESCRIPTION
Ensures the GapJumpingController identifies gaps even if the playhead hasn't technically exited the previous buffered range