### PR TITLE
perf(transmuxer): Reduce per-frame object allocations for h265, ac-3 and ec-3

### DIFF
--- a/lib/transmuxer/ac3.js
+++ b/lib/transmuxer/ac3.js
@@ -14,29 +14,25 @@ shaka.transmuxer.Ac3 = class {
   /**
    * @param {!Uint8Array} data
    * @param {!number} offset
-   * @return {?{
-   *   sampleRate: number,
-   *   channelCount: number,
-   *   audioConfig: !Uint8Array,
-   *   frameLength: number,
-   * }}
+   * @param {!shaka.transmuxer.Ac3.Ac3Frame} frame
+   * @return {boolean}
    */
-  static parseFrame(data, offset) {
+  static parseFrame(data, offset, frame) {
     if (offset + 8 > data.length) {
       // not enough bytes left
-      return null;
+      return false;
     }
 
     if (data[offset] !== 0x0b || data[offset + 1] !== 0x77) {
       // invalid magic
-      return null;
+      return false;
     }
 
     // get sample rate
     const samplingRateCode = data[offset + 4] >> 6;
     if (samplingRateCode >= 3) {
       // invalid sampling rate
-      return null;
+      return false;
     }
 
     const samplingRateMap = [48000, 44100, 32000];
@@ -57,7 +53,7 @@ shaka.transmuxer.Ac3 = class {
 
     const frameLength = frameSizeMap[frameSizeCode * 3 + samplingRateCode] * 2;
     if (offset + frameLength > data.length) {
-      return null;
+      return false;
     }
 
     // get channel count
@@ -94,12 +90,16 @@ shaka.transmuxer.Ac3 = class {
       (frameSizeCode << 4) & 0xe0,
     ]);
 
-    return {
-      sampleRate: samplingRateMap[samplingRateCode],
-      channelCount: channelsMap[channelMode] + lowFrequencyEffectsChannelOn,
-      audioConfig: config,
-      frameLength: frameLength,
-    };
+    // All properties of the `frame` object need to be written
+    // when true is returned, as the object is reused by the caller
+    // for multiple calls to this method.
+    frame.sampleRate = samplingRateMap[samplingRateCode];
+    frame.channelCount =
+      channelsMap[channelMode] + lowFrequencyEffectsChannelOn;
+    frame.audioConfig = config;
+    frame.frameLength = frameLength;
+
+    return true;
   }
 
   /**
@@ -144,3 +144,18 @@ shaka.transmuxer.Ac3 = class {
  * @const {number}
  */
 shaka.transmuxer.Ac3.AC3_SAMPLES_PER_FRAME = 1536;
+
+/**
+ * @typedef {{
+ *   sampleRate: number,
+ *   channelCount: number,
+ *   audioConfig: !Uint8Array,
+ *   frameLength: number,
+ * }}
+ *
+ * @property {number} sampleRate
+ * @property {number} channelCount
+ * @property {!Uint8Array} audioConfig
+ * @property {number} frameLength
+ */
+shaka.transmuxer.Ac3.Ac3Frame;

--- a/lib/transmuxer/ac3_transmuxer.js
+++ b/lib/transmuxer/ac3_transmuxer.js
@@ -146,9 +146,17 @@ shaka.transmuxer.Ac3Transmuxer = class {
     /** @type {!Array<shaka.util.Mp4Generator.Mp4Sample>} */
     const samples = [];
 
+    /** @type {!shaka.transmuxer.Ac3.Ac3Frame} */
+    const frame = {
+      sampleRate: 0,
+      channelCount: 0,
+      audioConfig: new Uint8Array(0),
+      frameLength: 0,
+    };
+
     while (offset < uint8ArrayData.length) {
-      const frame = Ac3.parseFrame(uint8ArrayData, offset);
-      if (!frame) {
+      const didParseFrame = Ac3.parseFrame(uint8ArrayData, offset, frame);
+      if (!didParseFrame) {
         return Promise.reject(new shaka.util.Error(
             shaka.util.Error.Severity.CRITICAL,
             shaka.util.Error.Category.MEDIA,

--- a/lib/transmuxer/ec3.js
+++ b/lib/transmuxer/ec3.js
@@ -16,21 +16,17 @@ shaka.transmuxer.Ec3 = class {
   /**
    * @param {!Uint8Array} data
    * @param {!number} offset
-   * @return {?{
-   *   sampleRate: number,
-   *   channelCount: number,
-   *   audioConfig: !Uint8Array,
-   *   frameLength: number,
-   * }}
+   * @param {!shaka.transmuxer.Ec3.Ec3Frame} frame
+   * @return {boolean}
    */
-  static parseFrame(data, offset) {
+  static parseFrame(data, offset, frame) {
     if (offset + 8 > data.length) {
       // not enough bytes left
-      return null;
+      return false;
     }
 
     if (!shaka.transmuxer.Ec3.probe(data, offset)) {
-      return null;
+      return false;
     }
 
     const gb = new shaka.util.ExpGolomb(data.subarray(offset + 2));
@@ -56,7 +52,7 @@ shaka.transmuxer.Ec3 = class {
     const bitStreamIdentification = gb.readBits(5);
 
     if (offset + frameLength > data.byteLength) {
-      return null;
+      return false;
     }
 
     const channelsMap = [2, 1, 2, 3, 3, 4, 4, 5];
@@ -77,12 +73,16 @@ shaka.transmuxer.Ec3 = class {
       (0 << 5) | (0 << 1) | (0 << 0),
     ]);
 
-    return {
-      sampleRate,
-      channelCount: channelsMap[channelMode] + lowFrequencyEffectsChannelOn,
-      audioConfig: config,
-      frameLength,
-    };
+    // All properties of the `frame` object need to be written
+    // when true is returned, as the object is reused by the caller
+    // for multiple calls to this method.
+    frame.sampleRate = sampleRate;
+    frame.channelCount =
+      channelsMap[channelMode] + lowFrequencyEffectsChannelOn;
+    frame.audioConfig = config;
+    frame.frameLength = frameLength;
+
+    return true;
   }
 
   /**
@@ -105,3 +105,18 @@ shaka.transmuxer.Ec3 = class {
  * @const {number}
  */
 shaka.transmuxer.Ec3.EC3_SAMPLES_PER_FRAME = 1536;
+
+/**
+ * @typedef {{
+ *   sampleRate: number,
+ *   channelCount: number,
+ *   audioConfig: !Uint8Array,
+ *   frameLength: number,
+ * }}
+ *
+ * @property {number} sampleRate
+ * @property {number} channelCount
+ * @property {!Uint8Array} audioConfig
+ * @property {number} frameLength
+ */
+shaka.transmuxer.Ec3.Ec3Frame;

--- a/lib/transmuxer/ec3_transmuxer.js
+++ b/lib/transmuxer/ec3_transmuxer.js
@@ -140,9 +140,17 @@ shaka.transmuxer.Ec3Transmuxer = class {
     /** @type {!Array<shaka.util.Mp4Generator.Mp4Sample>} */
     const samples = [];
 
+    /** @type {!shaka.transmuxer.Ec3.Ec3Frame} */
+    const frame = {
+      sampleRate: 0,
+      channelCount: 0,
+      audioConfig: new Uint8Array(0),
+      frameLength: 0,
+    };
+
     while (offset < uint8ArrayData.length) {
-      const frame = Ec3.parseFrame(uint8ArrayData, offset);
-      if (!frame) {
+      const didParseFrame = Ec3.parseFrame(uint8ArrayData, offset, frame);
+      if (!didParseFrame) {
         return Promise.reject(new shaka.util.Error(
             shaka.util.Error.Severity.CRITICAL,
             shaka.util.Error.Category.MEDIA,

--- a/lib/transmuxer/h265.js
+++ b/lib/transmuxer/h265.js
@@ -609,9 +609,10 @@ shaka.transmuxer.H265 = class {
 
   /**
    * @param {!Array<shaka.extern.VideoNalu>} nalus
-   * @return {?{data: !Uint8Array, isKeyframe: boolean}}
+   * @param {!shaka.transmuxer.H265.H265Frame} frame
+   * @return {boolean}
    */
-  static parseFrame(nalus) {
+  static parseFrame(nalus, frame) {
     const H265 = shaka.transmuxer.H265;
     let isKeyframe = false;
     const nalusData = [];
@@ -633,11 +634,7 @@ shaka.transmuxer.H265 = class {
           isKeyframe = true;
           break;
         case H265.NALU_TYPE_VPS_:
-          push = true;
-          break;
         case H265.NALU_TYPE_SPS_:
-          push = true;
-          break;
         case H265.NALU_TYPE_PPS_:
           push = true;
           break;
@@ -660,18 +657,21 @@ shaka.transmuxer.H265 = class {
         naluLength[1] = (size >> 16) & 0xff;
         naluLength[2] = (size >> 8) & 0xff;
         naluLength[3] = size & 0xff;
-        nalusData.push(naluLength);
-        nalusData.push(nalu.fullData);
+        nalusData.push(naluLength, nalu.fullData);
       }
     }
     if (!nalusData.length) {
-      return null;
+      return false;
     }
     const data = shaka.util.Uint8ArrayUtils.concat(...nalusData);
-    return {
-      data,
-      isKeyframe,
-    };
+
+    // All properties of the `frame` object need to be written
+    // when true is returned, as the object is reused by the caller
+    // for multiple calls to this method.
+    frame.data = data;
+    frame.isKeyframe = isKeyframe;
+
+    return true;
   }
 };
 
@@ -893,3 +893,14 @@ shaka.transmuxer.H265.PPSConfiguration;
  * @property {boolean} frameRateFixed
  */
 shaka.transmuxer.H265.DecoderConfigurationRecordType;
+
+/**
+ * @typedef {{
+ *   data: !Uint8Array,
+ *   isKeyframe: boolean
+ * }}
+ *
+ * @property {!Uint8Array} data
+ * @property {boolean} isKeyframe
+ */
+shaka.transmuxer.H265.H265Frame;

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -440,8 +440,13 @@ shaka.transmuxer.LocTransmuxer = class {
     const sampleDuration =
         Math.floor((reference.endTime - reference.startTime) * timescale);
 
-    const frame = H265.parseFrame(nalus);
-    if (!frame) {
+    /** @type {!shaka.transmuxer.H265.H265Frame} */
+    const frame = {
+      data: new Uint8Array(0),
+      isKeyframe: false,
+    };
+    const didParseFrame = H265.parseFrame(nalus, frame);
+    if (!didParseFrame) {
       return null;
     }
 

--- a/lib/transmuxer/ts_transmuxer.js
+++ b/lib/transmuxer/ts_transmuxer.js
@@ -480,6 +480,14 @@ shaka.transmuxer.TsTransmuxer = class {
 
     let firstPts = null;
 
+    /** @type {!shaka.transmuxer.Ac3.Ac3Frame} */
+    const frame = {
+      sampleRate: 0,
+      channelCount: 0,
+      audioConfig: new Uint8Array(0),
+      frameLength: 0,
+    };
+
     for (const audioData of tsParser.getAudioData()) {
       const data = audioData.data;
       if (firstPts == null && audioData.pts !== null) {
@@ -487,8 +495,8 @@ shaka.transmuxer.TsTransmuxer = class {
       }
       let offset = 0;
       while (offset < data.length) {
-        const frame = Ac3.parseFrame(data, offset);
-        if (!frame) {
+        const didParseFrame = Ac3.parseFrame(data, offset, frame);
+        if (!didParseFrame) {
           offset++;
           continue;
         }
@@ -563,6 +571,14 @@ shaka.transmuxer.TsTransmuxer = class {
 
     let firstPts = null;
 
+    /** @type {!shaka.transmuxer.Ec3.Ec3Frame} */
+    const frame = {
+      sampleRate: 0,
+      channelCount: 0,
+      audioConfig: new Uint8Array(0),
+      frameLength: 0,
+    };
+
     for (const audioData of tsParser.getAudioData()) {
       const data = audioData.data;
       if (firstPts == null && audioData.pts !== null) {
@@ -570,8 +586,8 @@ shaka.transmuxer.TsTransmuxer = class {
       }
       let offset = 0;
       while (offset < data.length) {
-        const frame = Ec3.parseFrame(data, offset);
-        if (!frame) {
+        const didParseFrame = Ec3.parseFrame(data, offset, frame);
+        if (!didParseFrame) {
           offset++;
           continue;
         }
@@ -907,6 +923,13 @@ shaka.transmuxer.TsTransmuxer = class {
 
     const nalus = [];
     const videoData = tsParser.getVideoData();
+
+    /** @type {!shaka.transmuxer.H265.H265Frame} */
+    const frame = {
+      data: new Uint8Array(0),
+      isKeyframe: false,
+    };
+
     if (!videoData.length) {
       throw new shaka.util.Error(
           shaka.util.Error.Severity.CRITICAL,
@@ -918,8 +941,8 @@ shaka.transmuxer.TsTransmuxer = class {
       const pes = videoData[i];
       const dataNalus = pes.nalus;
       nalus.push(...dataNalus);
-      const frame = H265.parseFrame(dataNalus);
-      if (!frame) {
+      const didParseFrame = H265.parseFrame(dataNalus, frame);
+      if (!didParseFrame) {
         continue;
       }
       if (baseMediaDecodeTime == null && pes.dts != null) {


### PR DESCRIPTION
This improves TS h265, TS AC-3, TS EC-3, raw AC-3 and raw EC-3 as the transmuxer calls `parseFrame` for each frame in the payload passed to the `transmux` method, for LOC h265 this is marginally worse as it only calls `parseFrame` once per `transmux` call.