### PR TITLE
docs: Clean up upgrade doc

### DIFF
--- a/docs/tutorials/upgrade.md
+++ b/docs/tutorials/upgrade.md
@@ -138,7 +138,6 @@ application:
     - `preferredVariantRole` has been renamed to `preferredAudioRole` (deprecated in v4.16.0)
     - `autoShowText` has been removed.
     - `removeLatencyFromFirstPacketTime` has been removed.
-    - `removeLatencyFromFirstPacketTime` has been removed.
     - `streaming.speechToText` moved to `accessibility.speechToText`
 
   - UI Configuration changes:
@@ -180,40 +179,39 @@ application:
     - `airplay` button has been removed; use the `remote` button instead
 
 
-## v5.1
+## v6.0
 
   - Configuration changes:
     - Individual preference config fields have been replaced by structured
-      preference arrays. The old fields still work with a deprecation warning
-      but will be removed in the next major version.
-    - `preferredAudioLanguage`, `preferredAudioRole`, `preferredAudioLabel`,
-      `preferredAudioChannelCount`, and `preferSpatialAudio` have been replaced
-      by `preferredAudio`, an array of `shaka.extern.AudioPreference` objects.
-    - `preferredAudioCodecs` has been replaced by `preferredAudio` with the
-      `codec` field in each entry.
-    - `preferredTextLanguage` and `preferredTextRole` have been replaced by
-      `preferredText`, an array of `shaka.extern.TextPreference` objects.
-    - `preferredTextFormats` has been replaced by `preferredText` with the
-      `format` field in each entry.
-    - `preferForcedSubs` has been replaced by the `forced` field in
-      `preferredText` entries (e.g.
-      `player.configure('preferredText', [{language: 'en', forced: true}])`).
-    - `preferredVideoLabel`, `preferredVideoRole`, `preferredVideoHdrLevel`,
-      and `preferredVideoLayout` have been replaced by `preferredVideo`, an
-      array of `shaka.extern.VideoPreference` objects.
-    - `preferredVideoCodecs` has been replaced by `preferredVideo` with the
-      `codec` field in each entry.
-    - The new structured arrays allow specifying multiple preference sets in
-      priority order. For example:
-      ```js
-      // Old way (deprecated, still works with a warning):
-      player.configure('preferredAudioLanguage', 'ko');
-      player.configure('preferredAudioChannelCount', 6);
+      preference arrays.  (Deprecated in v5.1)
+      - `preferredAudioLanguage`, `preferredAudioRole`, `preferredAudioLabel`,
+        `preferredAudioChannelCount`, and `preferSpatialAudio` have been replaced
+        by `preferredAudio`, an array of `shaka.extern.AudioPreference` objects.
+      - `preferredAudioCodecs` has been replaced by `preferredAudio` with the
+        `codec` field in each entry.
+      - `preferredTextLanguage` and `preferredTextRole` have been replaced by
+        `preferredText`, an array of `shaka.extern.TextPreference` objects.
+      - `preferredTextFormats` has been replaced by `preferredText` with the
+        `format` field in each entry.
+      - `preferForcedSubs` has been replaced by the `forced` field in
+        `preferredText` entries (e.g.
+        `player.configure('preferredText', [{language: 'en', forced: true}])`).
+      - `preferredVideoLabel`, `preferredVideoRole`, `preferredVideoHdrLevel`,
+        and `preferredVideoLayout` have been replaced by `preferredVideo`, an
+        array of `shaka.extern.VideoPreference` objects.
+      - `preferredVideoCodecs` has been replaced by `preferredVideo` with the
+        `codec` field in each entry.
+      - The new structured arrays allow specifying multiple preference sets in
+        priority order. For example:
+        ```js
+        // Old way (deprecated, still works with a warning):
+        player.configure('preferredAudioLanguage', 'ko');
+        player.configure('preferredAudioChannelCount', 6);
 
-      // New way:
-      player.configure('preferredAudio', [
-        {language: 'ko', channelCount: 6},
-        {language: 'ko'},
-        {language: 'en'},
-      ]);
-      ```
+        // New way:
+        player.configure('preferredAudio', [
+          {language: 'ko', channelCount: 6},
+          {language: 'ko'},
+          {language: 'en'},
+        ]);
+        ```


### PR DESCRIPTION
 - Remove duplicate entry in the 5.0 list
 - Rename the 5.1 list as 6.0 (named for the version in which something is removed, with a note about the deprecation version)
 - Reindent the set of related config changes

Noticed while preparing CAF for 5.0 compatibility