### PR TITLE
fix(UI): Fix blurry seek bar marks

### DIFF
--- a/ui/seek_bar.js
+++ b/ui/seek_bar.js
@@ -461,8 +461,7 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
 
     const seekRange = this.player.seekRange();
     const seekRangeSize = seekRange.end - seekRange.start;
-    const gradient = ['to right'];
-    let pointsAsFractions = [];
+    const rects = [];
     const adBreakColor = this.config_.seekBarColors.adBreaks;
     let postRollAd = false;
     for (const point of this.adCuePoints_) {
@@ -486,42 +485,29 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
           endFrac = (endDist / seekRangeSize) || 0;
         }
 
-        pointsAsFractions.push({
-          start: startFrac,
-          end: endFrac,
+        rects.push({
+          position: (startFrac * 100) + '%',
+          width: ((endFrac - startFrac) * 100) + '%',
         });
       }
     }
 
-    pointsAsFractions = pointsAsFractions.sort((a, b) => {
-      return a.start - b.start;
-    });
-
-    for (const point of pointsAsFractions) {
-      gradient.push(this.makeColor_('transparent', point.start));
-      gradient.push(this.makeColor_(adBreakColor, point.start));
-      gradient.push(this.makeColor_(adBreakColor, point.end));
-      gradient.push(this.makeColor_('transparent', point.end));
-    }
-
     if (postRollAd) {
-      gradient.push(this.makeColor_('transparent', 0.99));
-      gradient.push(this.makeColor_(adBreakColor, 0.99));
+      rects.push({position: '99%', width: '1%'});
     }
     this.adMarkerContainer_.style.background =
-            'linear-gradient(' + gradient.join(',') + ')';
+            this.buildLayeredBackground_(rects, adBreakColor);
   }
 
   /**
    * @private
    */
   markChapters_() {
-    const gradient = ['to right'];
-    const chapterColor = this.config_.seekBarColors.chapters;
+    const color = this.config_.seekBarColors.chapters;
 
     const chapters = this.controls.getChapters();
 
-    if (!chapters.length || !chapterColor || chapterColor === 'transparent') {
+    if (!chapters.length || !color || color === 'transparent') {
       this.chapterMarkerContainer_.style.background = 'transparent';
       this.chaptersTimer_?.stop();
       return;
@@ -560,19 +546,13 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
       return;
     }
 
-    const sortedPoints = Array.from(points).sort((a, b) => a - b);
-    for (const point of sortedPoints) {
-      const start = ((point - seekRange.start) / seekRangeSize) * 100 + '%';
-      const end = `calc(${start} + 2px)`;
-
-      gradient.push(`transparent ${start}`);
-      gradient.push(`${chapterColor} ${start}`);
-      gradient.push(`${chapterColor} ${end}`);
-      gradient.push(`transparent ${end}`);
-    }
+    const rects = Array.from(points).map((point) => ({
+      position: ((point - seekRange.start) / seekRangeSize) * 100 + '%',
+      width: '2px',
+    }));
 
     this.chapterMarkerContainer_.style.background =
-        'linear-gradient(' + gradient.join(',') + ')';
+            this.buildLayeredBackground_(rects, color);
   }
 
 
@@ -584,6 +564,21 @@ shaka.ui.SeekBar = class extends shaka.ui.RangeElement {
    */
   makeColor_(color, fraction) {
     return color + ' ' + (fraction * 100) + '%';
+  }
+
+  /**
+   * @param {!Array<{ position: string, width: string }>} rects
+   * @param {string} color
+   * @private
+   */
+  buildLayeredBackground_(rects, color) {
+    if (!rects.length || !color || color === 'transparent') {
+      return 'transparent';
+    }
+    return rects
+        .map(({position, width}) =>
+          `linear-gradient(${color}) ${position} / ${width} 100% no-repeat`)
+        .join(',');
   }
 
 


### PR DESCRIPTION
On long videos with lots of chapters Chromium based browser were showing the chapter markers as blury lines instead of clearly defined lines. This solves that problem by taking advantage of the fact that CSS supports multiple backgrounds and creates a separate one for each chapter. It also applies the same change to the ad markers.