### PR TITLE
perf(player): avoid full configuration deep-clone in time update callback

### DIFF
--- a/lib/player.js
+++ b/lib/player.js
@@ -4756,7 +4756,7 @@ shaka.Player = class extends shaka.util.FakeEventTarget {
       const bufferedLength = this.video_.buffered.length;
       const bufferedEnd =
           bufferedLength ? this.video_.buffered.end(bufferedLength - 1) : 0;
-      const bufferingGoal = this.getConfiguration().streaming.bufferingGoal;
+      const bufferingGoal = this.config_.streaming.bufferingGoal;
       const lengthToBeBuffered = Math.min(this.video_.currentTime +
           bufferingGoal, this.seekRange().end);
 


### PR DESCRIPTION
This PR replaces a full-config deep-clone in Player.getBufferFullness() with a direct read, removing a per-timeupdate allocation for playback sessions that have liveSync configured, or `vodDynamicPlaybackRate`