### PR TITLE
perf(transmuxer): Avoid repeatedly creating empty Uint8Arrays

### DIFF
--- a/lib/transmuxer/h264.js
+++ b/lib/transmuxer/h264.js
@@ -247,9 +247,11 @@ shaka.transmuxer.H264 = class {
       videoSamples.push(lastVideoSample);
     };
 
+    const EMPTY_UINT_8_ARRAY = new Uint8Array(0);
+
     const createLastVideoSample = (pes) => {
       lastVideoSample = {
-        data: new Uint8Array([]),
+        data: EMPTY_UINT_8_ARRAY,
         frame: false,
         isKeyframe: false,
         pts: pes.pts,

--- a/lib/util/ts_parser.js
+++ b/lib/util/ts_parser.js
@@ -483,21 +483,18 @@ shaka.util.TsParser = class {
     if (startPrefix !== 1) {
       return null;
     }
-    /** @type {shaka.extern.MPEG_PES} */
-    const pes = {
-      data: new Uint8Array(0),
-      // get the packet length, this will be 0 for video
-      packetLength: ((data[4] << 8) | data[5]),
-      pts: null,
-      dts: null,
-      nalus: [],
-    };
+
+    // get the packet length, this will be 0 for video
+    const packetLength = (data[4] << 8) | data[5];
 
     // if PES parsed length is not zero and greater than total received length,
     // stop parsing. PES might be truncated. minus 6 : PES header size
-    if (pes.packetLength && pes.packetLength > data.byteLength - 6) {
+    if (packetLength && packetLength > data.byteLength - 6) {
       return null;
     }
+
+    let pesPts = null;
+    let pesDts = null;
 
     // PES packets may be annotated with a PTS value, or a PTS value
     // and a DTS value. Determine what combination of values is
@@ -527,10 +524,10 @@ shaka.util.TsParser = class {
         this.referencePts_ = pts;
       }
 
-      pes.pts = this.handleRollover_(pts, this.referencePts_);
-      this.referencePts_ = pes.pts;
+      pesPts = this.handleRollover_(pts, this.referencePts_);
+      this.referencePts_ = pesPts;
 
-      pes.dts = pes.pts;
+      pesDts = pesPts;
       if (ptsDtsFlags & 0x40) {
         const dts =
           (data[14] & 0x0e) * 536870912 + // 1 << 29
@@ -543,13 +540,13 @@ shaka.util.TsParser = class {
           this.referenceDts_ = dts;
         }
 
-        if (pes.pts != pts) {
-          pes.dts = this.handleRollover_(dts, this.referenceDts_);
+        if (pesPts != pts) {
+          pesDts = this.handleRollover_(dts, this.referenceDts_);
         } else {
-          pes.dts = dts;
+          pesDts = dts;
         }
       }
-      this.referenceDts_ = pes.dts;
+      this.referenceDts_ = pesDts;
     }
 
     const pesHdrLen = data[8];
@@ -559,9 +556,13 @@ shaka.util.TsParser = class {
       return null;
     }
 
-    pes.data = data.subarray(payloadStartOffset);
-
-    return pes;
+    return {
+      data: data.subarray(payloadStartOffset),
+      packetLength: packetLength,
+      pts: pesPts,
+      dts: pesDts,
+      nalus: [],
+    };
   }
 
   /**


### PR DESCRIPTION
In `H264.getVideoSamples()` `lastVideoSample.data` is initialized with an empty `Uint8Array` which is always replaced before the sample is pushed into the `videoSamples` array, so to avoid creating a new empty placeholder `Uint8Array` for each sample, the empty `Uint8Array` can be created once and then use to initialize all `lastVideoSample` objects in that segment.

`TSParser.parsePES_` had a similar placeholder empty `Uint8Array` issue, which I was able to resolve by creating the PES object in the return statement instead of upfront, that way it can be initialized with the final data, avoiding the placeholder.

While yes empty Uint8Arrays definitely need less memory than larger ones, it is still better to not create 100+ unnecessary objects in rapid succession which then need to be cleaned up by the garbage collector later on.