### PR TITLE
perf(Mp4Generator): assemble segment data in a single allocation

### DIFF
--- a/lib/util/mp4_generator.js
+++ b/lib/util/mp4_generator.js
@@ -8,6 +8,7 @@ goog.provide('shaka.util.Mp4Generator');
 
 goog.require('goog.asserts');
 goog.require('shaka.device.DeviceFactory');
+goog.require('shaka.util.BufferUtils');
 goog.require('shaka.util.Lazy');
 goog.require('shaka.util.ManifestParserUtils');
 goog.require('shaka.util.Uint8ArrayUtils');
@@ -673,11 +674,38 @@ shaka.util.Mp4Generator = class {
    * @return {!Uint8Array}
    */
   segmentData() {
-    const segmentDataArray = [];
+    const Mp4Generator = shaka.util.Mp4Generator;
+    const boxHeaderSize = Mp4Generator.BOX_HEADER_SIZE_;
+    // Assemble whole segment into one allocation
+    const streams = [];
+    // Running sum of bytes needed for the final segment buffer.
+    let total = 0;
     for (const streamInfo of this.streamInfos_) {
-      segmentDataArray.push(this.moof_(streamInfo), this.mdat_(streamInfo));
+      const moof = this.moof_(streamInfo);
+      const samples = streamInfo.data ? streamInfo.data.samples : [];
+      // Sum of sample byte lengths for this stream's mdat payload.
+      let mdatPayload = 0;
+      for (const sample of samples) {
+        mdatPayload += sample.data.byteLength;
+      }
+      const mdatSize = boxHeaderSize + mdatPayload;
+      streams.push({moof, samples, mdatSize});
+      total += moof.byteLength + mdatSize;
     }
-    const result = shaka.util.Uint8ArrayUtils.concat(...segmentDataArray);
+    const result = shaka.util.BufferUtils.toUint8(new ArrayBuffer(total));
+    // Current byte position in the output buffer.
+    let offset = 0;
+    for (const {moof, samples, mdatSize} of streams) {
+      result.set(moof, offset);
+      offset += moof.byteLength;
+      this.writeUint32_(result, mdatSize, offset);
+      result.set(Mp4Generator.MDAT_TYPE_.value(), offset + 4);
+      offset += boxHeaderSize;
+      for (const sample of samples) {
+        result.set(sample.data, offset);
+        offset += sample.data.byteLength;
+      }
+    }
     return result;
   }
 
@@ -850,20 +878,6 @@ shaka.util.Mp4Generator = class {
   }
 
   /**
-   * Generate a MDAT box
-   *
-   * @param {shaka.util.Mp4Generator.StreamInfo} streamInfo
-   * @return {!Uint8Array}
-   * @private
-   */
-  mdat_(streamInfo) {
-    const Mp4Generator = shaka.util.Mp4Generator;
-    const samples = streamInfo.data ? streamInfo.data.samples : [];
-    const allData = samples.map((sample) => sample.data);
-    return Mp4Generator.box('mdat', ...allData);
-  }
-
-  /**
    * @param {!Uint8Array} bytes
    * @param {number} value
    * @param {number} offset
@@ -1001,6 +1015,13 @@ shaka.util.Mp4Generator.BOX_TYPES_ = new Map();
  * @const {number}
  */
 shaka.util.Mp4Generator.BOX_HEADER_SIZE_ = 8;
+
+/**
+ * 'mdat' box-type bytes (ASCII).
+ * @private {!shaka.util.Lazy<!Uint8Array>}
+ */
+shaka.util.Mp4Generator.MDAT_TYPE_ =
+    new shaka.util.Lazy(() => new Uint8Array([0x6d, 0x64, 0x61, 0x74]));
 
 /**
  * Template MVHD (version 1, 112 bytes).


### PR DESCRIPTION
This PR reduces allocation pressure in MP4 segment generation by writing mdat data directly into the final segment buffer - this avoids one full media-payload copy per segment