### PR TITLE
fix(demo): Re-enable lazy localization

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -473,6 +473,7 @@ shakaDemo.Main = class {
     });
 
     this.localization_ = this.controls_.getLocalization();
+    this.setupLazyLocalization_();
 
     const drawerCloseButton = document.getElementById('drawer-close-button');
     drawerCloseButton.addEventListener('click', () => {
@@ -508,6 +509,33 @@ shakaDemo.Main = class {
       this.hideElement_(drawerCloseButton);
     });
     this.hideElement_(drawerCloseButton);
+  }
+
+  /**
+   * @private
+   */
+  setupLazyLocalization_() {
+    // Load locales on-demand.
+    const UNKNOWN_LOCALES = shaka.ui.Localization.UNKNOWN_LOCALES;
+    this.localization_.addEventListener(UNKNOWN_LOCALES, (event) => {
+      for (const locale of event['locales']) {
+        this.loadUILocale_(locale);
+      }
+    });
+
+    // Load the initial locale.
+    this.loadUILocale_(this.uiLocale_);
+
+    // Also try to load the 'base' localization.  This is so that, for example,
+    // the uiLocale_ is set to 'en-US', it will try to load 'en'.
+    if (this.uiLocale_.includes('-')) {
+      this.loadUILocale_(this.uiLocale_.split('-')[0]);
+    }
+
+    // Load 'en' as a fallback option, if not already loaded.
+    if (!this.uiLocale_.startsWith('en')) {
+      this.loadUILocale_('en');
+    }
   }
 
   /** @return {boolean} */
@@ -918,6 +946,27 @@ shakaDemo.Main = class {
    */
   getNativeControlsEnabled() {
     return this.nativeControlsEnabled_;
+  }
+
+  /**
+   * @param {string} locale
+   * @return {!Promise}
+   * @private
+   */
+  async loadUILocale_(locale) {
+    if (!locale) {
+      return;
+    }
+
+    const url = '../ui/locales/' + locale + '.json';
+    try {
+      const text = await this.loadText_(url);
+      const obj = /** @type {!Object<string, string>} */(JSON.parse(text));
+      const map = new Map(Object.entries(obj));
+      this.localization_.insert(locale, map);
+    } catch (error) {
+      console.warn('Unable to load locale', locale, 'from url', url);
+    }
   }
 
   /** @param {string} locale */

--- a/test/test/util/fake_demo_main.js
+++ b/test/test/util/fake_demo_main.js
@@ -203,10 +203,6 @@ shaka.test.FakeDemoMain = class {
     });
 
     /** @type {!jasmine.Spy} */
-    this.getLocalizedString = jasmine.createSpy('getLocalizedString');
-    this.getLocalizedString.and.callFake((name) => name);
-
-    /** @type {!jasmine.Spy} */
     this.loadAsset = jasmine.createSpy('loadAsset');
     this.loadAsset.and.returnValue(Promise.resolve());
 


### PR DESCRIPTION
If you open Shaka Player with Hungarian as the UI language setting (https://shaka-project.github.io/shaka-player-release/demo/#uilang=hu) it will currently display the UI in English, because Hungarian is not one of the built-in-by-default languages for the project.  It does still work for a built-in language like German.  (Compare to https://shaka-project.github.io/shaka-player-release/demo/#uilang=de)

We used to have a feature in the demo to load localizations from the server dynamically for languages where we have translations, but don't build them in by default.

The feature to lazy-load localizations for the player UI was acccidentally dropped in e8e2807 (PR #5665) while abandoning translation of the demo itself. This PR restores that feature in a simplified implementation.  Ex: https://joeyparrish.github.io/shaka-player/demo/#uilang=hu