### PR TITLE
fix(UI): Use consistent font throughout UI

### DIFF
--- a/ui/less/general.less
+++ b/ui/less/general.less
@@ -146,6 +146,13 @@ the control buttons panel. */
 @quality-mark-color: #fff;
 @quality-mark-hightlight-color: #f00;
 
+/* Form elements don't inherit font-family from their ancestors by default in
+ * most browsers; they fall back to the OS system font instead.  Force them to
+ * inherit so that Shaka UI containers' font-family applies consistently. */
+button, input, select, textarea {
+  font-family: inherit;
+}
+
 @media (forced-colors: active) {
   .shaka-overflow-menu,
   .shaka-settings-menu,

--- a/ui/less/overflow_menu.less
+++ b/ui/less/overflow_menu.less
@@ -180,7 +180,6 @@
   background: @quality-mark-hightlight-color;
   color: @quality-mark-color;
   border-radius: 2px;
-  font-family: @general-font-family;
   font-size: 10px;
   font-weight: bold;
   line-height: 10px;

--- a/ui/less/tooltip.less
+++ b/ui/less/tooltip.less
@@ -49,8 +49,6 @@
     &:active:after {
       content: attr(aria-label);
 
-      /* Override .material-icons-round text styling */
-      font-family: @general-font-family;
       line-height: 20px;
       white-space: nowrap;
       font-size: @general-font-size;


### PR DESCRIPTION
Force form elements (button, input, select, textarea) to inherit font-family, since browsers default them to the OS system font rather than inheriting from ancestors.  This makes the Shaka UI font apply consistently to all elements under .shaka-video-container.

Remove now-redundant explicit font-family declarations from .shaka-overflow-quality-mark and the tooltip ::after pseudo-element, which were workarounds for the same inheritance gap.

Now it is possible for an application to override the font style of the UI with a single declaration.