### PR TITLE
feat(UI): Add modern CSS theme support using CSS custom properties

### DIFF
--- a/build/compiler.py
+++ b/build/compiler.py
@@ -327,9 +327,58 @@ class Less(object):
     self.all_source_files = _canonicalize_source_files(all_source_files)
     self.output = output
 
+    # Derive the modern output path by inserting ".modern" before the
+    # extension: e.g. "dist/controls.css" -> "dist/controls.modern.css".
+    base, ext = os.path.splitext(output)
+    self.output_modern = base + '.modern' + ext
+
+  def _run_postcss(self, input_path, output_path, plugins, browserslist):
+    """Runs PostCSS on |input_path|, writing to |output_path|.
+
+    Sets BROWSERSLIST in os.environ for the duration of the call and restores
+    the previous value (or removes the key) afterwards.  This avoids passing
+    an 'env' kwarg that execute_get_code does not support.
+
+    Args:
+      input_path: Path to the CSS file to process.
+      output_path: Path to write the processed CSS to.
+      plugins: List of --use plugin names to pass to PostCSS.
+      browserslist: Browserslist query string.
+
+    Returns:
+      True on success; False on failure.
+    """
+    postcss = shakaBuildHelpers.get_node_binary('postcss-cli', 'postcss')
+
+    plugin_flags = []
+    for plugin in plugins:
+      plugin_flags += ['--use', plugin]
+
+    cmd_line = postcss + [input_path, '-o', output_path] + plugin_flags + ['--map']
+
+    # Temporarily override BROWSERSLIST, preserving any existing value.
+    previous = os.environ.get('BROWSERSLIST')
+    os.environ['BROWSERSLIST'] = browserslist
+    try:
+      return shakaBuildHelpers.execute_get_code(cmd_line) == 0
+    finally:
+      if previous is None:
+        os.environ.pop('BROWSERSLIST', None)
+      else:
+        os.environ['BROWSERSLIST'] = previous
+
   def compile(self, force=False):
-    """Compiles the main less file in |self.main_source_file| into the
-       |self.output| css file and applies PostCSS Autoprefixer.
+    """Compiles the main less file in |self.main_source_file| into two CSS
+       output files:
+
+       - |self.output|        — legacy build, CSS custom properties flattened
+                                via postcss-custom-properties so that it works
+                                in older browsers (chrome 38, safari 8,
+                                firefox 42).
+       - |self.output_modern| — modern build, CSS custom properties preserved,
+                                targeting the last 2 years of browsers.
+
+       Both outputs go through Autoprefixer and cssnano.
 
     Args:
       force: Generate the output even if the inputs have not changed.
@@ -337,47 +386,58 @@ class Less(object):
     Returns:
       True on success; False on failure.
     """
-    if not force and not _must_build(self.output, self.all_source_files):
+    # Rebuild if either output is stale or missing.
+    if not force and (
+        not _must_build(self.output, self.all_source_files) and
+        not _must_build(self.output_modern, self.all_source_files)):
       return True
 
+    # Step 1: compile LESS -> raw CSS (shared intermediate)
     lessc = shakaBuildHelpers.get_node_binary('less', 'lessc')
     less_options = [
-      # Output a source map of the original CSS/less files.
       '--source-map=' + self.output + '.map',
     ]
-
     cmd_line = lessc + less_options + [self.main_source_file, self.output]
 
     if shakaBuildHelpers.execute_get_code(cmd_line) != 0:
       logging.error('CSS compilation failed')
       return False
 
-    # We look for the PostCSS binary within node_modules/postcss-cli
-    postcss = shakaBuildHelpers.get_node_binary('postcss-cli', 'postcss')
-    postcss_options = [
-      self.output,
-      '-o', self.output,
-      '--use', 'autoprefixer',
-      '--use', 'cssnano',
-      '--map',
-    ]
+    # Duplicate the raw compiled CSS so each PostCSS pass has its own file.
+    shutil.copy2(self.output, self.output_modern)
 
-    # We define the specific browsers using the environment variable. These are
-    # the minimum browsers that the UI supports.
-    os.environ['BROWSERSLIST'] = 'chrome 38, safari 8, firefox 42'
-
-    if shakaBuildHelpers.execute_get_code(postcss + postcss_options) != 0:
-      logging.error('PostCSS / Autoprefixer processing failed')
+    # Step 2a: legacy build
+    #   • postcss-custom-properties  — resolve/flatten all CSS variables
+    #   • autoprefixer               — add vendor prefixes for old browsers
+    #   • cssnano                    — minify
+    if not self._run_postcss(
+        self.output, self.output,
+        ['postcss-custom-properties', 'autoprefixer', 'cssnano'],
+        'chrome 38, safari 8, firefox 42'):
+      logging.error('PostCSS legacy processing failed')
       return False
 
-    # We need to prepend the license header to the compiled CSS.
+    # Step 2b: modern build
+    #   • autoprefixer  — add vendor prefixes for recent browsers only
+    #   • cssnano       — minify
+    #   (CSS custom properties are intentionally kept as-is)
+    if not self._run_postcss(
+        self.output_modern, self.output_modern,
+        ['autoprefixer', 'cssnano'],
+        'last 2 years'):
+      logging.error('PostCSS modern processing failed')
+      return False
+
+    # Step 3: prepend the license header to both outputs
     with open(_get_source_path('build/license-header'), 'rb') as f:
       license_header = f.read()
-    with open(self.output, 'rb') as f:
-      contents = f.read()
-    with open(self.output, 'wb') as f:
-      f.write(license_header)
-      f.write(contents)
+
+    for output_path in (self.output, self.output_modern):
+      with open(output_path, 'rb') as f:
+        contents = f.read()
+      with open(output_path, 'wb') as f:
+        f.write(license_header)
+        f.write(contents)
 
     return True
 

--- a/docs/tutorials/ui-customization.md
+++ b/docs/tutorials/ui-customization.md
@@ -351,6 +351,45 @@ uiConfig['controlPanelElements'] = ['rewind', 'fast_forward', 'skip'];
 <!-- TODO: Create a doc on best a11y practices for custom buttons and link to the
   localization docs explaining how to take advantage of our localization system. -->
 
+#### Customizing the UI with CSS variables
+
+Shaka Player UI exposes styling through CSS custom properties defined on the :root.
+
+This allows applications to easily theme the player without modifying the source CSS.
+
+##### Example
+```css
+:root {
+  /* Layout */
+  --shaka-controls-w: 98%;
+
+  /* Typography */
+  --shaka-font-family: roboto, sans-serif;
+  --shaka-font-color: white;
+  --shaka-font-size: 14px;
+
+  /* Backgrounds */
+  --shaka-bg: rgba(0, 0, 0, 0.5);
+  --shaka-bg-hover: rgba(0, 0, 0, 0.75);
+
+  /* Controls */
+  --shaka-thumb-color: white;
+  --shaka-track-color: white;
+}
+```
+
+##### Using modern vs legacy builds
+
+If you are using the modern UI build, CSS custom properties are preserved and can be overridden at runtime.
+
+If you are using the legacy UI build, CSS custom properties are processed at build time for compatibility, but the variables remain in the output CSS and include fallback values for older browsers that do not support them.
+
+##### Recommendation
+
+Use:
+- controls.modern.css → when targeting modern browsers (recommended)
+- controls.css → when supporting older browsers
+
 ####  Shaka Theme Gallery
 <!-- cspell: disable-next-line -->
 Check out the set of [pre-packaged Shaka UI themes][], created by [@lucksy][]!

--- a/docs/tutorials/ui.md
+++ b/docs/tutorials/ui.md
@@ -304,3 +304,24 @@ To enable poster display in the user interface, configure your streams with one 
 - HLS: Include the `#EXT-X-SESSION-DATA` tag with the ID `com.apple.hls.poster`.
 
 Note: This same metadata is also used by the [Media Session API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API) to enhance media playback experiences across platforms.
+
+#### Modern and Legacy UI styles
+
+Shaka Player UI now provides two CSS outputs to support both modern and legacy browsers.
+
+Note: both files are generated from the same LESS source and go through Autoprefixer and cssnano, ensuring consistent visual output across builds.
+
+##### Legacy CSS (controls.css)
+- Generated from the default UI build.
+- CSS custom properties are resolved at build time using postcss-custom-properties.
+- Ensures compatibility with older browsers such as:
+  - Chrome 38
+  - Safari 8
+  - Firefox 42
+- Suitable when CSS variable support is not available.
+
+##### Modern CSS (controls.modern.css)
+- Uses the same source styles but preserves CSS custom properties.
+- Targets modern browsers (last 2 years of browser versions).
+- Does not flatten CSS variables, allowing runtime theming and overrides.
+- Recommended for all modern applications.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "open-sans-fonts": "^1.6.2",
         "postcss": "^8.5.15",
         "postcss-cli": "^11.0.1",
+        "postcss-custom-properties": "^15.0.1",
         "postcss-less": "^6.0.0",
         "pwacompat": "^2.0.17",
         "rimraf": "^3.0.2",
@@ -2234,6 +2235,96 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@csstools/cascade-layer-name-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-3.0.0.tgz",
+      "integrity": "sha512-/3iksyevwRfSJx5yH0RkcrcYXwuhMQx3Juqf40t97PeEy2/Mz2TItZ/z/216qpe4GgOyFBP8MKIwVvytzHmfIQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/utilities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-3.0.0.tgz",
+      "integrity": "sha512-etDqA/4jYvOGBM6yfKCOsEXfH96BKztZdgGmGqKi2xHnDe0ILIBraRspwgYatJH9JsCZ5HCGoCst8w18EKOAdg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
@@ -8951,6 +9042,36 @@
         "postcss": "^8.5.14"
       }
     },
+    "node_modules/postcss-custom-properties": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-15.0.1.tgz",
+      "integrity": "sha512-cuyq8sd8dLY0GLbelz1KB8IMIoDECo6RVXMeHeXY2Uw3Q05k/d1GVITdaKLsheqrHbnxlwxzSRZQQ5u+rNtbMg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/cascade-layer-name-parser": "^3.0.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/utilities": "^3.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
     "node_modules/postcss-discard-comments": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.0.tgz",
@@ -13305,6 +13426,33 @@
       "resolved": "https://registry.npmjs.org/@cspell/url/-/url-8.17.1.tgz",
       "integrity": "sha512-LMvReIndW1ckvemElfDgTt282fb2C3C/ZXfsm0pJsTV5ZmtdelCHwzmgSBmY5fDr7D66XDp8EurotSE0K6BTvw==",
       "dev": true
+    },
+    "@csstools/cascade-layer-name-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-3.0.0.tgz",
+      "integrity": "sha512-/3iksyevwRfSJx5yH0RkcrcYXwuhMQx3Juqf40t97PeEy2/Mz2TItZ/z/216qpe4GgOyFBP8MKIwVvytzHmfIQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "requires": {}
+    },
+    "@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true
+    },
+    "@csstools/utilities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-3.0.0.tgz",
+      "integrity": "sha512-etDqA/4jYvOGBM6yfKCOsEXfH96BKztZdgGmGqKi2xHnDe0ILIBraRspwgYatJH9JsCZ5HCGoCst8w18EKOAdg==",
+      "dev": true,
+      "requires": {}
     },
     "@es-joy/jsdoccomment": {
       "version": "0.49.0",
@@ -18249,6 +18397,19 @@
       "dev": true,
       "requires": {
         "browserslist": "^4.28.2",
+        "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "postcss-custom-properties": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-15.0.1.tgz",
+      "integrity": "sha512-cuyq8sd8dLY0GLbelz1KB8IMIoDECo6RVXMeHeXY2Uw3Q05k/d1GVITdaKLsheqrHbnxlwxzSRZQQ5u+rNtbMg==",
+      "dev": true,
+      "requires": {
+        "@csstools/cascade-layer-name-parser": "^3.0.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "@csstools/utilities": "^3.0.0",
         "postcss-value-parser": "^4.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "open-sans-fonts": "^1.6.2",
     "postcss": "^8.5.15",
     "postcss-cli": "^11.0.1",
+    "postcss-custom-properties": "^15.0.1",
     "postcss-less": "^6.0.0",
     "pwacompat": "^2.0.17",
     "rimraf": "^3.0.2",

--- a/ui/less/ad_controls.less
+++ b/ui/less/ad_controls.less
@@ -43,14 +43,14 @@
   padding-bottom: 1%;
 
   button, div {
-    color: @general-font-color;
+    color: var(--shaka-font-color);
     font-size: initial;
   }
 }
 
 .shaka-ad-info {
-  font-size: @general-font-size;
-  color: @general-font-color;
+  font-size: var(--shaka-font-size);
+  color: var(--shaka-font-color);
   width: auto;
   padding: 0 5px;
 
@@ -66,12 +66,13 @@
   position: relative;
 
   /* This math is determining how far the button is from the right edge.
-   * Ad panel's parent is centered and @bottom-controls-width wide, so
-   * 100% - @bottom-controls-width = margins from both sides of the container.
+   * Ad panel's parent is centered and --shaka-controls-w wide, so
+   * 100% - --shaka-controls-w = margins from both sides of the
+   * container.
    * That divided by 2 is margin on one side, so we take that, and move the
    * button from its normal position to the right by that percentage.
    */
-  right: calc((100% - @bottom-controls-width) / 2 * -1);
+  right: calc((100% - var(--shaka-controls-w)) / 2 * -1);
   display: flex;
   flex-direction: row;
   margin: 0;
@@ -80,11 +81,15 @@
 
 .shaka-skip-ad-button {
   padding: 5px 15px;
-  background: rgba(0, 0, 0, 70%);
+  background: var(--shaka-bg);
   border: none;
 
   &:disabled {
-    background: rgba(0, 0, 0, 30%);
+    opacity: 0.5;
+  }
+
+  &:not([disabled]):hover {
+    background: var(--shaka-bg-hover);
   }
 
   cursor: pointer;
@@ -92,6 +97,6 @@
 
 .shaka-skip-ad-counter {
   padding: 5px;
-  background: rgba(0, 0, 0, 70%);
+  background: var(--shaka-bg);
   margin: 0;
 }

--- a/ui/less/buttons.less
+++ b/ui/less/buttons.less
@@ -10,7 +10,7 @@
   /* Set the background and the color, otherwise it might be overwritten by
    * the css styles in demo. */
   background-color: transparent;
-  color: @general-font-color;
+  color: var(--shaka-font-color);
   cursor: default;
 }
 
@@ -19,8 +19,8 @@
  * edge. Otherwise, the button is disabled.
  */
 .shaka-current-time {
-  font-size: @general-font-size;
-  color: @general-font-color;
+  font-size: var(--shaka-font-size);
+  color: var(--shaka-font-color);
   cursor: pointer;
   width: auto;
   padding: 0 5px;
@@ -35,8 +35,8 @@
   justify-content: center;
   flex-direction: column;
 
-  font-size: @content-title-font-size;
-  color: @general-font-color;
+  font-size: var(--shaka-title-size);
+  color: var(--shaka-font-color);
   width: auto;
   padding: 0 5px;
 
@@ -88,8 +88,8 @@
   /* No border. */
   border: none;
 
-  color: @general-font-color;
-  background-color: @general-background-color;
+  color: var(--shaka-font-color);
+  background-color: var(--shaka-bg);
 
   cursor: default;
   font-size: 20px;

--- a/ui/less/containers.less
+++ b/ui/less/containers.less
@@ -17,11 +17,11 @@
 
   /* Set a special font for material design icons. */
   .shaka-ui-icon {
-    font-size: 24px;
+    font-size: var(--shaka-icon-size-sm);
   }
 
   /* Set the fonts for all other content. */
-  font-family: @general-font-family;
+  font-family: var(--shaka-font-family);
   font-weight: normal;
   -webkit-font-smoothing: antialiased;
 
@@ -37,7 +37,7 @@
 
   /* stylelint-disable max-line-length, declaration-block-no-duplicate-properties, unit-no-unknown */
   &.pip-mode {
-    background-color: @general-background-color-opaque;
+    background-color: var(--shaka-bg-solid);
     // Old browsers
     width: 100vw;
     height: 100vh;
@@ -57,7 +57,7 @@
 .fullscreen-container() {
   .fill-container();
 
-  background-color: @general-background-color-opaque;
+  background-color: var(--shaka-bg-solid);
 
   .shaka-text-container,
   .shaka-speech-to-text-container {
@@ -142,7 +142,7 @@
 /* Container for controls positioned at the top of the video container:
  * controls button panel. */
 .shaka-top-controls {
-  width: @bottom-controls-width;
+  width: var(--shaka-controls-w);
   padding: 0;
 
   position: absolute;
@@ -159,7 +159,7 @@
 /* Container for controls positioned at the bottom of the video container:
  * controls button panel and the seek bar. */
 .shaka-bottom-controls {
-  width: @bottom-controls-width;
+  width: var(--shaka-controls-w);
   padding: 0;
 
   /* Position the bottom panel in front of other controls (play button and
@@ -217,8 +217,8 @@
 
     .center-children();
 
-    color: @general-font-color;
-    background-color: @general-background-color;
+    color: var(--shaka-font-color);
+    background-color: var(--shaka-bg);
     box-shadow: 0 8px 24px rgba(0, 0, 0, 35%);
     cursor: pointer;
 
@@ -226,7 +226,7 @@
 
     &:not([disabled]):hover {
       transform: scale(1.06);
-      background-color: @general-background-color-hover;
+      background-color: var(--shaka-bg-hover);
     }
 
     &:not([disabled]):active {
@@ -321,7 +321,7 @@
 
     .center-children();
 
-    color: @general-font-color;
+    color: var(--shaka-font-color);
     background-color: rgba(0, 0, 0, 45%);
     border: 1.5px solid rgba(255, 255, 255, 25%);
     backdrop-filter: blur(6px);
@@ -352,7 +352,7 @@
     position: relative;
     z-index: 2;
     margin: 0;
-    font-size: @content-title-font-size;
+    font-size: var(--shaka-title-size);
     color: rgba(255, 255, 255, 55%);
     letter-spacing: 0.04em;
     text-align: center;
@@ -388,7 +388,7 @@
 
   /* Make sure we don't inherit odd font sizes and styles from the environment.
    * TODO: When did this happen?  What forced us to do this? */
-  font-size: 12px;
+  font-size: var(--shaka-font-size-sm);
   font-weight: normal;
   font-style: normal;
 
@@ -401,11 +401,10 @@
    * have these characteristics by default. */
   & > * {
     /* White text or button icons. */
-    color: @general-font-color;
+    color: var(--shaka-font-color);
 
-    /* 48px tall controls. */
-    height: 48px;
-    width: 48px;
+    height: var(--shaka-icon-size);
+    width: var(--shaka-icon-size);
 
     /* Consistent alignment of buttons. */
     line-height: 0.5;
@@ -419,7 +418,7 @@
     cursor: pointer;
     opacity: 0.9;
     transition: opacity cubic-bezier(0.4, 0, 0.6, 1) 100ms;
-    text-shadow: 0 0 2px @general-background-color;
+    text-shadow: 0 0 2px var(--shaka-bg);
 
     /* Use a bit larger icons for some buttons */
     &.shaka-fast-forward-button,
@@ -428,21 +427,16 @@
     &.shaka-skip-previous-button,
     &.shaka-skip-next-button {
       .shaka-ui-icon {
-        font-size: 32px;
+        font-size: var(--shaka-icon-size-lg);
       }
     }
 
-    &.shaka-fullscreen-button {
-      .shaka-ui-icon {
-        font-size: 24px;
-      }
-    }
-
+    &.shaka-fullscreen-button,
     &.shaka-overflow-menu-button {
       position: relative;
 
       .shaka-ui-icon {
-        font-size: 24px;
+        font-size: var(--shaka-icon-size-sm);
       }
     }
 
@@ -467,12 +461,12 @@
   scrollbar-color: rgba(255, 255, 255, 15%) transparent;
   scrollbar-width: thin;
 
-  color: @general-font-color;
+  color: var(--shaka-font-color);
   background-color: rgba(12, 14, 18, 88%);
   border: 1px solid rgba(255, 255, 255, 8%);
   box-shadow: 0 4px 24px rgba(0, 0, 0, 50%);
 
-  font-size: @general-font-size;
+  font-size: var(--shaka-font-size);
   font-family: monospace;
 
   padding: 0;
@@ -609,7 +603,7 @@
   /* These are defaults which are overridden by JS or cue styles. */
   font-size: 20px;
   line-height: 1.4;  // relative to font size.
-  color: @general-font-color;
+  color: var(--shaka-font-color);
 
   span.shaka-text-wrapper {
     display: inline;

--- a/ui/less/general.less
+++ b/ui/less/general.less
@@ -6,6 +6,59 @@
 
 /* General utility mixins and classes with broad applicability. */
 
+/*
+ * CSS custom properties (variables) — replaces all former LESS @variables.
+ * Override any of these on a parent element to theme the player.
+ */
+:root {
+  /* Layout */
+  --shaka-controls-w: 98%;
+
+  /* Typography */
+  --shaka-font-family: roboto, sans-serif;
+  --shaka-font-color: white;
+  --shaka-font-color-secondary: #ccc;
+  --shaka-font-size: 14px;
+  --shaka-font-size-sm: 12px;
+
+  /* Backgrounds */
+  --shaka-bg: rgba(0, 0, 0, 50%);
+  --shaka-bg-hover: rgba(0, 0, 0, 75%);
+  --shaka-bg-90: rgba(0, 0, 0, 90%);
+  --shaka-bg-solid: black;
+  --shaka-bg-menu: rgba(28, 28, 28, 90%);
+
+  /* Content */
+  --shaka-title-size: 18px;
+
+  /* Badge mark */
+  --shaka-badge-color: #fff;
+  --shaka-badge-active: #f00;
+  --shaka-badge-size: 10px;
+
+  /* Tooltip / overflow-menu icon button size */
+  --shaka-icon-size: 48px;
+  --shaka-icon-size-sm: calc(var(--shaka-icon-size) / 2);
+  --shaka-icon-size-lg: calc(var(--shaka-icon-size) * 2 / 3);
+
+  /* Range / seek-bar pieces */
+  --shaka-thumb-color: white;
+  --shaka-track-color: white;
+  --shaka-thumb-size: 12px;
+  --shaka-track-h: 4px;
+  --shaka-touch-size: 40px;
+
+  /* Playback-rate menu */
+  --shaka-rate-border: rgba(255, 255, 255, 50%);
+  --shaka-rate-border-active: rgba(255, 255, 255, 85%);
+  --shaka-rate-bg-active: rgba(255, 255, 255, 10%);
+  --shaka-rate-slider: rgba(255, 255, 255, 25%);
+  --shaka-rate-preset-bg: rgba(255, 255, 255, 10%);
+  --shaka-rate-preset-hover: rgba(255, 255, 255, 18%);
+  --shaka-rate-preset-active: rgba(255, 255, 255, 20%);
+  --shaka-rate-preset-border: rgba(255, 255, 255, 70%);
+}
+
 /* Make a thing unselectable.  There are currently no cases where we make it
  * selectable again. */
 .unselectable() {
@@ -124,24 +177,6 @@
     .hidden();
   }
 }
-
-/* The width of the bottom-section controls: seek bar, ad controls, and
-the control buttons panel. */
-@bottom-controls-width: 98%;
-
-@general-font-family: Roboto, sans-serif;
-@general-font-color: white;
-@general-font-color-secondary: #ccc;
-@general-font-size: 14px;
-@general-background-color: rgba(0, 0, 0, 50%);
-@general-background-color-hover: rgba(0, 0, 0, 75%);
-@general-background-color-mostly-opaque: rgba(0, 0, 0, 90%);
-@general-background-color-opaque: black;
-
-@content-title-font-size: 18px;
-
-@quality-mark-color: #fff;
-@quality-mark-hightlight-color: #f00;
 
 /* Form elements don't inherit font-family from their ancestors by default in
  * most browsers; they fall back to the OS system font instead.  Force them to

--- a/ui/less/overflow_menu.less
+++ b/ui/less/overflow_menu.less
@@ -25,14 +25,16 @@
   overflow-x: hidden;
   overflow-y: auto;
 
-  scrollbar-color: @general-font-color @general-background-color;
+  scrollbar-color:
+    var(--shaka-font-color)
+    var(--shaka-bg);
   scrollbar-width: thin;
 
   /* Don't wrap text to the next line. */
   white-space: nowrap;
 
   /* Styles for the menu itself. */
-  background: rgba(28, 28, 28, 90%);
+  background: var(--shaka-bg-menu);
   border-radius: 12px;
   max-height: 250px;
   min-width: 190px;
@@ -50,13 +52,13 @@
   /* Where the menu appears. */
   position: absolute;
   z-index: 2;
-  bottom: @material-icons-width + 14px;
+  bottom: calc(var(--shaka-icon-size) + 14px);
 
   /* The buttons inside the menu. */
   button {
-    font-size: @general-font-size;
+    font-size: var(--shaka-font-size);
     background: transparent;
-    color: @general-font-color;
+    color: var(--shaka-font-color);
     border: none;
     border-radius: 12px;
     min-height: 30px;
@@ -100,7 +102,7 @@
 
   // If the seekbar is missing, this is positioned lower.
   &.shaka-low-position {
-    bottom: @material-icons-width;
+    bottom: var(--shaka-icon-size);
   }
 }
 
@@ -131,14 +133,30 @@
 
 .shaka-overflow-button-label-inline {
   box-sizing: border-box;
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
-  width: calc(100% - 24px);
-  padding-right: 28px;
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjRweCIgdmlld0JveD0iMCAwIDI0IDI0IiB3aWR0aD0iMjRweCIgZmlsbD0iI2VlZWVlZSI+PHBhdGggZD0iTTAgMGgyNHYyNEgwVjB6IiBmaWxsPSJub25lIi8+PHBhdGggZD0iTTguNTkgMTYuNTlMMTMuMTcgMTIgOC41OSA3LjQxIDEwIDZsNiA2LTYgNi0xLjQxLTEuNDF6Ii8+PC9zdmc+");
-  background-repeat: no-repeat;
-  background-position: right 5px center;
-  background-size: 24px 24px;
+
+  width: calc(100% - var(--shaka-icon-size-sm));
+  padding-right: calc(var(--shaka-icon-size-sm) + 8px);
+
+  position: relative;
+
+  &:after {
+    content: "";
+    position: absolute;
+    right: 5px;
+    top: 50%;
+    transform: translateY(-50%);
+
+    width: var(--shaka-icon-size-sm);
+    height: var(--shaka-icon-size-sm);
+
+    background-color: var(--shaka-font-color);
+
+    mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z'/%3E%3C/svg%3E") no-repeat center;
+    mask-size: contain;
+  }
 }
 
 .shaka-simple-overflow-button-label-inline {
@@ -153,21 +171,21 @@
  * language, the currently-selected resolution, etc. */
 .shaka-current-selection-span {
   /* This is dimmer than the other span, which is the name of the submenu. */
-  font-size: 12px;
+  font-size: var(--shaka-font-size-sm);
   padding-left: 10px;
 }
 
 .shaka-current-auto-quality {
   margin-left: 5px;
   font-size: 11px;
-  color: @general-font-color-secondary;
+  color: var(--shaka-font-color-secondary);
 }
 
 .shaka-quality-mark,
 .shaka-current-quality-mark {
-  color: @quality-mark-hightlight-color;
+  color: var(--shaka-badge-active);
   margin-left: 2px !important;
-  font-size: 10px;
+  font-size: var(--shaka-badge-size);
   height: 17px;
 }
 
@@ -177,12 +195,12 @@
 
 .shaka-overflow-quality-mark,
 .shaka-overflow-playback-rate-mark {
-  background: @quality-mark-hightlight-color;
-  color: @quality-mark-color;
+  background: var(--shaka-badge-active);
+  color: var(--shaka-badge-color);
   border-radius: 2px;
-  font-size: 10px;
+  font-size: var(--shaka-badge-size);
   font-weight: bold;
-  line-height: 10px;
+  line-height: 1;
   text-shadow: none;
   padding: 1px;
   position: absolute;

--- a/ui/less/playback_rate.less
+++ b/ui/less/playback_rate.less
@@ -4,20 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// Step buttons (− / +)
-@playback-rate-step-btn-border: fade(@general-font-color, 50%);
-@playback-rate-step-btn-border-active: fade(@general-font-color, 85%);
-@playback-rate-step-btn-bg-active: fade(@general-font-color, 10%);
-
-// Slider track
-@playback-rate-slider-track: fade(@general-font-color, 25%);
-
-// Preset pill buttons
-@playback-rate-preset-bg: fade(@general-font-color, 10%);
-@playback-rate-preset-bg-hover: fade(@general-font-color, 18%);
-@playback-rate-preset-selected-bg: fade(@general-font-color, 20%);
-@playback-rate-preset-selected-border: fade(@general-font-color, 70%);
-
 /* Menu container */
 
 .shaka-playback-rates {
@@ -36,7 +22,7 @@
   text-align: center;
   font-size: 22px;
   font-weight: 500;
-  color: @general-font-color;
+  color: var(--shaka-font-color);
   font-variant-numeric: tabular-nums;
   padding: 2px 0 10px;
   margin-left: 0;
@@ -60,7 +46,7 @@
   width: 28px;
   height: 28px;
   border-radius: 50% !important;
-  border: 1.5px solid @playback-rate-step-btn-border !important;
+  border: 1.5px solid var(--shaka-rate-border) !important;
   background: transparent !important;
 
   display: inline-flex;
@@ -70,7 +56,7 @@
   font-size: 18px;
   font-weight: 400;
   line-height: 1;
-  color: @general-font-color;
+  color: var(--shaka-font-color);
 
   transition:
     border-color 150ms ease,
@@ -83,19 +69,19 @@
   }
 
   &:hover:not(:disabled) {
-    border-color: @playback-rate-step-btn-border-active !important;
-    background: @playback-rate-step-btn-bg-active !important;
+    border-color: var(--shaka-rate-border-active) !important;
+    background: var(--shaka-rate-bg-active) !important;
   }
 
   .shaka-keyboard-navigation &:focus:not(:disabled) {
-    border-color: @playback-rate-step-btn-border-active !important;
-    background: @playback-rate-step-btn-bg-active !important;
+    border-color: var(--shaka-rate-border-active) !important;
+    background: var(--shaka-rate-bg-active) !important;
   }
 }
 
 .shaka-playback-rate-slider-container {
   flex: 1;
-  background: @playback-rate-slider-track;
+  background: var(--shaka-rate-slider);
 }
 
 /* Preset pill buttons */
@@ -134,25 +120,25 @@
   flex-shrink: 0;
 
   font-size: 13px;
-  color: @general-font-color;
-  background: @playback-rate-preset-bg !important;
+  color: var(--shaka-font-color);
+  background: var(--shaka-rate-preset-bg) !important;
   border: 1.5px solid transparent !important;
 
   transition: background 150ms ease, border-color 150ms ease;
 
   &:hover {
-    background: @playback-rate-preset-bg-hover !important;
+    background: var(--shaka-rate-preset-hover) !important;
   }
 
   .shaka-keyboard-navigation &:focus {
-    background: @playback-rate-preset-bg-hover !important;
+    background: var(--shaka-rate-preset-hover) !important;
   }
 
   &.shaka-chosen-item {
-    background: @playback-rate-preset-selected-bg !important;
-    border-color: @playback-rate-preset-selected-border !important;
+    background: var(--shaka-rate-preset-active) !important;
+    border-color: var(--shaka-rate-preset-border) !important;
     font-weight: 600;
-    color: @general-font-color;
+    color: var(--shaka-font-color);
     margin-left: 0;
   }
 }

--- a/ui/less/range_elements.less
+++ b/ui/less/range_elements.less
@@ -25,16 +25,6 @@
  * track.  And since we are still using a semantically correct input element,
  * the element is inherently accessible. */
 
-/* These control the color and size of the various pieces. */
-@thumb-color: @general-font-color;
-@track-default-color: @general-font-color;
-@thumb-size: 12px;
-@track-height: 4px;
-
-/* The range element has a larger interactive area than its visible size.
- * This value should always be greater than @thumb-size. */
-@touchable-size: 40px;
-
 /* The range container is the div that contains a range element.
  * This div will act as a virtual track to allow us to style the track space.
  * An actual track still exists inside the range element, but is transparent. */
@@ -43,16 +33,16 @@
   .overlay-parent();
 
   /* Vertical margins to occupy the same space as the thumb. */
-  margin: calc((@thumb-size - @track-height) / 2) 6px;
+  margin: calc((var(--shaka-thumb-size) - var(--shaka-track-h)) / 2) 6px;
 
   /* Smaller height to contain the background for the virtual track. */
-  height: @track-height;
+  height: var(--shaka-track-h);
 
   /* Rounded ends on the virtual track. */
-  border-radius: @track-height;
+  border-radius: var(--shaka-track-h);
 
   /* Until we set a gradient background in JS, this will be the track color. */
-  background: @track-default-color;
+  background: var(--shaka-track-color);
 
   /* Override box-sizing to avoid other box-sizing rules break this element */
   box-sizing: content-box;
@@ -72,7 +62,7 @@
   /* The track should be tall enough to contain the thumb without clipping it.
    * It is very tricky to make the thumb show outside the track on IE 11, and
    * it is incompatible with our background gradients. */
-  height: @thumb-size;
+  height: var(--shaka-thumb-size);
 
   /* Some browsers have default backgrounds, colors, or borders for this.
    * Hide them all. */
@@ -92,12 +82,12 @@
   border: none;
 
   /* Make the thumb a circle and set its diameter. */
-  border-radius: @thumb-size;
-  height: @thumb-size;
-  width: @thumb-size;
+  border-radius: var(--shaka-thumb-size);
+  height: var(--shaka-thumb-size);
+  width: var(--shaka-thumb-size);
 
   /* Give it the desired color. */
-  background: @thumb-color;
+  background: var(--shaka-thumb-color);
 }
 
 /* This is the actual range input element. */
@@ -112,12 +102,12 @@
 
   /* The range element should have a minimum touchable height for
    * accessibility. */
-  height: @touchable-size;
+  height: var(--shaka-touch-size);
 
   /* Position the top of the range element so that it is centered on the
    * container. Note that the container is actually smaller than the
    * touchable-size. */
-  top: calc((@track-height - @touchable-size) / 2);
+  top: calc((var(--shaka-track-h) - var(--shaka-touch-size)) / 2);
 
   /* Make sure clicking at the very top of the bar still takes effect and is not
    * confused with clicking the video to play/pause it. */
@@ -197,7 +187,7 @@
   height: 5px;
 
   /* add spacing between seek-bar-container and controls-button-panel */
-  margin-bottom: @track-height;
+  margin-bottom: var(--shaka-track-h);
 
   background-clip: padding-box !important;
   border-top: 4px solid transparent;

--- a/ui/less/thumbnails.less
+++ b/ui/less/thumbnails.less
@@ -13,9 +13,9 @@
   gap: 5px;
 
   .shaka-player-ui-thumbnail-image-container {
-    background-color: @general-background-color-opaque;
-    border: 1px solid @general-background-color-opaque;
-    box-shadow: 0 8px 8px 0 @general-background-color;
+    background-color: var(--shaka-bg-solid);
+    border: 1px solid var(--shaka-bg-solid);
+    box-shadow: 0 8px 8px 0 var(--shaka-bg);
     min-width: 150px;
     overflow: hidden;
     position: relative;
@@ -36,14 +36,14 @@
     justify-content: center;
 
     .shaka-player-ui-thumbnail-time {
-      background-color: @general-background-color;
-      border-radius: @general-font-size;
-      color: @general-font-color;
-      font-size: @general-font-size;
+      background-color: var(--shaka-bg);
+      border-radius: var(--shaka-font-size);
+      color: var(--shaka-font-color);
+      font-size: var(--shaka-font-size);
       padding: 0 5px;
 
       @media (prefers-reduced-transparency) {
-        background-color: @general-background-color-mostly-opaque;
+        background-color: var(--shaka-bg-90);
       }
     }
   }

--- a/ui/less/tooltip.less
+++ b/ui/less/tooltip.less
@@ -24,12 +24,6 @@
  * SOFTWARE.
  */
 
-@material-icons-width: 48px;
-
-.translateX(@percent) {
-  transform: translateX(percentage(@percent));
-}
-
 /* .shaka-tooltips-on enables the tooltips and is only added to the
  * control panel when the 'enableTooltips' option is set to true */
 .shaka-tooltips-on {
@@ -45,28 +39,28 @@
     &:active:after {
       content: attr(aria-label);
 
-      line-height: 20px;
+      line-height: 1.2;
       white-space: nowrap;
-      font-size: @general-font-size;
+      font-size: var(--shaka-font-size);
 
       /* Styling */
-      background: @general-background-color;
-      color: @general-font-color;
+      background: var(--shaka-bg);
+      color: var(--shaka-font-color);
       border-radius: 2px;
       padding: 2px 10px;
 
       /* Positioning */
       position: absolute;
-      bottom: @material-icons-width + 14px;
+      bottom: calc(var(--shaka-icon-size) + 14px);
 
       /* Left attribute is set to half of the width of the parent button */
-      left: calc(@material-icons-width / 2);
+      left: calc(var(--shaka-icon-size) / 2);
 
       /* The tooltip is also translated 50% to appear centered */
-      .translateX(-0.5);
+      transform: translateX(-50%);
 
       @media (prefers-reduced-transparency) {
-        background-color: @general-background-color-mostly-opaque;
+        background-color: var(--shaka-bg-90);
       }
     }
   }
@@ -77,7 +71,7 @@
       &:hover:after,
       &:focus-visible:after,
       &:active:after {
-        bottom: -1 * (@material-icons-width/2);
+        bottom: calc(var(--shaka-icon-size) / 2 * -1);
       }
     }
   }
@@ -88,14 +82,16 @@
       &:hover:after,
       &:focus-visible:after,
       &:active:after {
-        bottom: @material-icons-width;
+        bottom: var(--shaka-icon-size);
       }
     }
   }
 
   /* Adds an additional attribute for the status in .shaka-tooltip-status */
   & > .shaka-tooltip-status {
-    &:hover:after, &:focus-visible:after, &:active:after {
+    &:hover:after,
+    &:focus-visible:after,
+    &:active:after {
       content: attr(aria-label) " (" attr(shaka-status) ")";
     }
   }
@@ -103,18 +99,22 @@
   /* The first tooltip of the panel is not centered on top of the button
    * but rather aligned with the left border of the control panel */
   button:first-child {
-    &:hover:after, &:focus-visible:after, &:active:after {
+    &:hover:after,
+    &:focus-visible:after,
+    &:active:after {
       left: 0;
-      .translateX(0);
+      transform: translateX(0);
     }
   }
 
   /* The last tooltip of the panel is not centered on top of the button
    * but rather aligned with the right border of the control panel */
   button:last-child {
-    &:hover:after, &:focus-visible:after,&:active:after {
-      left: @material-icons-width;
-      .translateX(-1);
+    &:hover:after,
+    &:focus-visible:after,
+    &:active:after {
+      left: var(--shaka-icon-size);
+      transform: translateX(-100%);
     }
   }
 }


### PR DESCRIPTION
The build system is updated to generate two CSS outputs:

A legacy stylesheet (.css) where CSS custom properties are flattened using postcss-custom-properties for compatibility with older browsers. A modern stylesheet (.modern.css) that preserves CSS custom properties for modern browsers.

Both outputs are generated from the same LESS source and processed through Autoprefixer and cssnano, ensuring consistent styling while supporting different browser capabilities. This enables a gradual migration path between legacy and modern UI styling without breaking existing consumers.

Close https://github.com/shaka-project/shaka-player/issues/10145