### PR TITLE
fix(HLS): Fix LL-HLS stall on live playlist updates after #9998

### DIFF
--- a/lib/hls/hls_parser.js
+++ b/lib/hls/hls_parser.js
@@ -4835,7 +4835,7 @@ shaka.hls.HlsParser = class {
           // method.
         } else {
           references.push(reference);
-          if (isNewSegment) {
+          if (isNewSegment || !isNewStream) {
             newReferences.push(reference);
           }
         }

--- a/test/hls/hls_live_unit.js
+++ b/test/hls/hls_live_unit.js
@@ -1918,4 +1918,55 @@ describe('HlsParser live', () => {
     return ManifestParser.makeReference(uri, start, end, baseUri, startByte,
         endByte, timestampOffset, partialReferences, tilesLayout, syncTime);
   }
+
+  it('calls mergeAndEvict on update when segment has partials', async () => {
+    // Regression test for #9998. When a segment has partial segments, it gets
+    // rebuilt on every live update, but without the fix the rebuilt reference
+    // was discarded from mergeAndEvict because its position was already in
+    // mediaSequenceToStartTime. This caused LL-HLS streams to stall.
+
+    const mediaWithPartials = [
+      '#EXTM3U\n',
+      '#EXT-X-TARGETDURATION:5\n',
+      '#EXT-X-MEDIA-SEQUENCE:100\n',
+      '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+      '#EXTINF:2,\n',
+      'main.mp4\n',
+      '#EXTINF:2,\n',
+      'main2.mp4\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial.mp4"\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial2.mp4"\n',
+      '#EXTINF:2,\n',
+      'main3.mp4\n',
+    ].join('');
+
+    const mediaWithMorePartials = [
+      '#EXTM3U\n',
+      '#EXT-X-TARGETDURATION:5\n',
+      '#EXT-X-MEDIA-SEQUENCE:100\n',
+      '#EXT-X-MAP:URI="init.mp4",BYTERANGE="616@0"\n',
+      '#EXTINF:2,\n',
+      'main.mp4\n',
+      '#EXTINF:2,\n',
+      'main2.mp4\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial.mp4"\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial2.mp4"\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial3.mp4"\n',
+      '#EXT-X-PART:DURATION=1.0,URI="partial4.mp4"\n',
+      '#EXTINF:2,\n',
+      'main3.mp4\n',
+    ].join('');
+
+    const manifest = await testInitialManifest(
+        master, mediaWithPartials);
+
+    const video = manifest.variants[0].video;
+    goog.asserts.assert(video.segmentIndex, 'Segment index should exist!');
+
+    spyOn(video.segmentIndex, 'mergeAndEvict').and.callThrough();
+
+    await testUpdate(manifest, mediaWithMorePartials);
+
+    expect(video.segmentIndex.mergeAndEvict).toHaveBeenCalled();
+  });
 });  // describe('HlsParser live')


### PR DESCRIPTION
Fixes https://github.com/shaka-project/shaka-player/issues/10149

PR #9998 (`perf(HLS): skip merging known segments on live playlist updates`) introduced a regression where low-latency HLS live streams stall after ~10 seconds of playback. The video and audio simply stop with no error.

### Root Cause

`createSegments_()` keeps a `mediaSequenceToStartTime` map to track which segments it has already seen. The optimization only passes **new** segments (those not yet in the map) to `mergeAndEvict()`:

```js
// line 4838
if (isNewSegment) {
    newReferences.push(reference);
}
```

However, in LL-HLS, a segment's partial references **grow** across playlist refreshes — e.g., a segment starts with 2 partials, then 4, then 8, until the segment is complete. The `firstReferenceToCreate` logic at line 4665 correctly detects segments with active partials and triggers a **rebuild**, but the rebuilt reference is **not** included in `newReferences` because its position already exists in `mediaSequenceToStartTime`. So `mergeAndEvict()` never receives the updated reference, the segment index retains **stale partial data**, and the player stalls once it exhausts those stale partials — roughly 10 seconds of content.

### The Fix

**1 line, no behavioral impact on VOD or non-low-latency streams.**

```diff
- if (isNewSegment) {
+ if (isNewSegment || !isNewStream) {
```

During live updates (`isNewStream = false`), **all** rebuilt segments are now passed to `mergeAndEvict`, not just the truly new ones. This is correct because rebuilt segments (triggered by partials or EXTINF changes) have updated content that must replace the stale data in the segment index.

**No performance regression:** When there are truly no changes (all segments known, no partials, no EXTINF changes), `firstReferenceToCreate` stays at `hlsSegments.length`, so all segments are skipped, `references` is empty, and `mergeAndEvict` is never called — preserving the optimization.

### Steps to Reproduce

1. Play any LL-HLS live stream (e.g., with `#EXT-X-SERVER-CONTROL` and partial segments)
2. Observe playback stops after ~8–12 seconds with no error