### PR TITLE
feat(Demo): Replace Material Icons font with inline SVGs

### DIFF
--- a/demo/asset_card.js
+++ b/demo/asset_card.js
@@ -8,6 +8,7 @@ goog.provide('shakaDemo.AssetCard');
 
 goog.require('goog.asserts');
 goog.require('shakaAssets');
+goog.require('shakaDemo.Icons');
 goog.require('shakaDemo.Tooltips');
 goog.requireType('ShakaDemoAssetInfo');
 
@@ -355,13 +356,11 @@ shakaDemo.AssetCard = class {
      * @param {!Element} button
      * @param {!Element} attachPoint If there is no attach point, just pass the
      *  button in here.
-     * @param {string} iconText
+     * @param {string} iconPath
      */
-    const styleAsDownloadButton = (button, attachPoint, iconText) => {
+    const styleAsDownloadButton = (button, attachPoint, iconPath) => {
       attachPoint.classList.add('asset-card-corner-button');
-      const icon = document.createElement('i');
-      icon.textContent = iconText;
-      icon.classList.add('material-icons-round');
+      const icon = shakaDemo.Icons.makeSvgIcon(iconPath);
       button.appendChild(icon);
     };
 
@@ -378,21 +377,23 @@ shakaDemo.AssetCard = class {
       // that is the element this has to move with CSS, otherwise the tooltip
       // will end up coming out of the wrong place.
       const attachPoint = button.parentElement || button;
-      styleAsDownloadButton(button, attachPoint, 'get_app');
+      styleAsDownloadButton(button, attachPoint, shakaDemo.Icons.DOWNLOAD);
       return;
     }
     if (this.asset_.isStored()) {
       const deleteButton = this.addButton(null, () => {
         this.attachDeleteDialog_(deleteButton);
       });
-      styleAsDownloadButton(deleteButton, deleteButton, 'offline_pin');
+      styleAsDownloadButton(
+          deleteButton, deleteButton, shakaDemo.Icons.OFFLINE_PIN);
     } else {
       const downloadButton = this.addButton(null, async () => {
         downloadButton.disabled = true;
         await this.asset_.storeCallback();
         this.remakeButtons();
       });
-      styleAsDownloadButton(downloadButton, downloadButton, 'get_app');
+      styleAsDownloadButton(
+          downloadButton, downloadButton, shakaDemo.Icons.DOWNLOAD);
     }
   }
 

--- a/demo/cast_receiver/index.html
+++ b/demo/cast_receiver/index.html
@@ -22,9 +22,7 @@
     <title>Shaka Player Cast Demo</title>
 
     <link rel="preconnect" href="https://www.gstatic.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Round&display=block" />
     <link rel="stylesheet" href="../../dist/controls.css">
     <link rel="stylesheet" href="receiver_app.css">
 

--- a/demo/config.js
+++ b/demo/config.js
@@ -10,6 +10,7 @@ goog.provide('shakaDemo.Config');
 goog.require('goog.asserts');
 goog.require('shakaDemo.BoolInput');
 goog.require('shakaDemo.DatalistInput');
+goog.require('shakaDemo.Icons');
 goog.require('shakaDemo.InputContainer');
 goog.require('shakaDemo.NumberInput');
 goog.require('shakaDemo.SelectInput');
@@ -851,9 +852,7 @@ shakaDemo.Config = class {
       deleteBtn.classList.add(
           'pref-entry-delete', 'mdl-button', 'mdl-js-button',
           'mdl-button--icon');
-      const deleteIcon = document.createElement('i');
-      deleteIcon.classList.add('material-icons-round');
-      deleteIcon.textContent = 'close';
+      const deleteIcon = shakaDemo.Icons.makeSvgIcon(shakaDemo.Icons.CLOSE);
       deleteBtn.appendChild(deleteIcon);
       const indexForDelete = i;
       deleteBtn.addEventListener('click', () => {

--- a/demo/custom.js
+++ b/demo/custom.js
@@ -11,6 +11,7 @@ goog.provide('shakaDemo.Custom');
 goog.require('ShakaDemoAssetInfo');
 goog.require('shakaDemo.AssetCard');
 goog.require('shakaDemo.BoolInput');
+goog.require('shakaDemo.Icons');
 goog.require('shakaDemo.Input');
 goog.require('shakaDemo.InputContainer');
 goog.require('shakaDemo.TextInput');
@@ -60,7 +61,7 @@ shakaDemo.Custom = class {
     container.appendChild(addButtonContainer);
     // Style it as an MDL Floating Action Button (FAB).
     const buttonStyle = shakaDemo.Custom.ButtonStyle_.FAB;
-    const addButton = this.makeButton_('add', buttonStyle, () => {
+    const addButton = this.makeButton_(shakaDemo.Icons.ADD, buttonStyle, () => {
       this.showAssetDialog_(ShakaDemoAssetInfo.makeBlankAsset());
     });
     addButtonContainer.appendChild(addButton);
@@ -1116,6 +1117,8 @@ shakaDemo.Custom = class {
 
   /**
    * @param {string} name
+   *   For RAISED and PLAIN buttons, the text to display.  For FAB buttons, the
+   *   SVG path data of the icon to display (see shakaDemo.Icons).
    * @param {shakaDemo.Custom.ButtonStyle_} buttonStyle
    *   What style should this button be in?
    * @param {function()} callback
@@ -1125,14 +1128,11 @@ shakaDemo.Custom = class {
   makeButton_(name, buttonStyle, callback) {
     const button = document.createElement('button');
     switch (buttonStyle) {
-      case shakaDemo.Custom.ButtonStyle_.FAB: {
+      case shakaDemo.Custom.ButtonStyle_.FAB:
         button.classList.add('mdl-button--fab');
         button.classList.add('mdl-button--colored');
-        const icon = document.createElement('i');
-        icon.classList.add('material-icons-round');
-        icon.textContent = name;
-        button.appendChild(icon);
-      } break;
+        button.appendChild(shakaDemo.Icons.makeSvgIcon(name));
+        break;
       case shakaDemo.Custom.ButtonStyle_.RAISED:
         button.textContent = name;
         button.classList.add('mdl-button--raised');

--- a/demo/demo.less
+++ b/demo/demo.less
@@ -22,17 +22,16 @@
 @progress-circle-size: 45px;
 @progress-circle-thickness: 5px;
 
-/* This class name is used by MDL, but we use a slightly different font.  So
- * here we override the font family for the MDL class.  Without this, the menu
- * on the left side of the screen has no icon. */
-.material-icons {
-  font-family: "Material Icons Round";
-}
-
-/* Conflicting styles between the icons font & the MDL buttons caused some
- * icons not to be centered in their MDL button.  This fixes it. */
-.mdl-button .material-icons {
-  line-height: 36px;
+/* The demo's icons are inline SVGs (see demo/icons.js), matching the player
+ * UI's switch away from an icon font.  The path data is painted with the
+ * inherited text color, and vertical-align centers the icon inside MDL
+ * buttons. */
+.demo-icon {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  fill: currentcolor;
+  vertical-align: middle;
 }
 
 /* This is a less mixin only, rather than a CSS class. MDL has an equivalent
@@ -412,9 +411,11 @@ html, body {
   padding: 0 16px;
 }
 
-.app-header .mdl-layout__drawer-button .material-icons {
+/* The drawer toggle button's gear icon is an inline SVG, injected into MDL's
+ * button in setupPlayer_ (main.js) and sized by the .demo-icon rule above. */
+.app-header .mdl-layout__drawer-button .material-icons svg {
   &:hover {
-    /* Spin the gear icon in the settings menu when hovered. */
+    /* Spin the gear icon when hovered. */
     transform: rotate(90deg);
   }
 
@@ -467,6 +468,9 @@ footer .mdl-mega-footer__link-list {
   /* Constrain to the window if necessary, so that it doesn't overflow small
    * mobile screens. */
   max-width: 100%;
+
+  /* A little vertical padding is needed to make it look balanced. */
+  padding: 1em 0;
 }
 
 /* When the drawer is open, MDL sets overflow: hidden on the main content

--- a/demo/icons.js
+++ b/demo/icons.js
@@ -1,0 +1,68 @@
+/*! @license
+ * Shaka Player
+ * Copyright 2016 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+
+goog.provide('shakaDemo.Icons');
+
+/* The SVG path-data constants below are long single lines. */
+/* eslint @stylistic/max-len: ["error", { "code": 1000 }] */
+
+
+/**
+ * SVG path data for the icons used by the demo, plus a helper to render them as
+ * inline SVG elements.  This mirrors the approach used by the player UI (see
+ * shaka.ui.Enums and shaka.ui.Icon), but is kept self-contained so the demo
+ * does not depend on UI-internal classes.
+ *
+ * The path data is from the Material Symbols Rounded (filled) set, on the same
+ * "0 -960 960 960" viewBox the player UI uses, fetched from:
+ * https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsrounded/<icon>/fill1/24px.svg
+ */
+shakaDemo.Icons = class {
+  /**
+   * Builds an inline SVG icon element from one of the path-data constants
+   * below.
+   *
+   * @param {string} path
+   * @return {!Element}
+   */
+  static makeSvgIcon(path) {
+    const svgNs = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(svgNs, 'svg');
+    svg.classList.add('demo-icon');
+    svg.setAttribute('viewBox', '0 -960 960 960');
+    // Screen readers should ignore decorative icons.
+    svg.setAttribute('aria-hidden', 'true');
+    const pathElement = document.createElementNS(svgNs, 'path');
+    pathElement.setAttribute('d', path);
+    svg.appendChild(pathElement);
+    return svg;
+  }
+};
+
+
+/** @const {string} */
+shakaDemo.Icons.CLOSE = 'M480-424 284-228q-11 11-28 11t-28-11q-11-11-11-28t11-28l196-196-196-196q-11-11-11-28t11-28q11-11 28-11t28 11l196 196 196-196q11-11 28-11t28 11q11 11 11 28t-11 28L536-480l196 196q11 11 11 28t-11 28q-11 11-28 11t-28-11L480-424Z';
+
+
+/** @const {string} */
+shakaDemo.Icons.HELP = 'M513.5-254.5Q528-269 528-290t-14.5-35.5Q499-340 478-340t-35.5 14.5Q428-311 428-290t14.5 35.5Q457-240 478-240t35.5-14.5ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm4-572q25 0 43.5 16t18.5 40q0 22-13.5 39T502-525q-23 20-40.5 44T444-427q0 14 10.5 23.5T479-394q15 0 25.5-10t13.5-25q4-21 18-37.5t30-31.5q23-22 39.5-48t16.5-58q0-51-41.5-83.5T484-720q-38 0-72.5 16T359-655q-7 12-4.5 25.5T368-609q14 8 29 5t25-17q11-15 27.5-23t34.5-8Z';
+
+
+/** @const {string} */
+shakaDemo.Icons.DOWNLOAD = 'M480-337q-8 0-15-2.5t-13-8.5L308-492q-12-12-11.5-28t11.5-28q12-12 28.5-12.5T365-549l75 75v-286q0-17 11.5-28.5T480-800q17 0 28.5 11.5T520-760v286l75-75q12-12 28.5-11.5T652-548q11 12 11.5 28T652-492L508-348q-6 6-13 8.5t-15 2.5ZM240-160q-33 0-56.5-23.5T160-240v-80q0-17 11.5-28.5T200-360q17 0 28.5 11.5T240-320v80h480v-80q0-17 11.5-28.5T760-360q17 0 28.5 11.5T800-320v80q0 33-23.5 56.5T720-160H240Z';
+
+
+/** @const {string} */
+shakaDemo.Icons.OFFLINE_PIN = 'M360-280h240q17 0 28.5-11.5T640-320q0-17-11.5-28.5T600-360H360q-17 0-28.5 11.5T320-320q0 17 11.5 28.5T360-280Zm78-232-58-58q-11-11-28-11t-28 11q-11 11-11 28t11 28l86 86q12 12 28 12t28-12l170-170q12-12 11.5-28.5T635-654q-12-11-28.5-10.5T579-653L438-512Zm42 432q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z';
+
+
+/** @const {string} */
+shakaDemo.Icons.ADD = 'M440-440H240q-17 0-28.5-11.5T200-480q0-17 11.5-28.5T240-520h200v-200q0-17 11.5-28.5T480-760q17 0 28.5 11.5T520-720v200h200q17 0 28.5 11.5T760-480q0 17-11.5 28.5T720-440H520v200q0 17-11.5 28.5T480-200q-17 0-28.5-11.5T440-240v-200Z';
+
+
+/** @const {string} */
+shakaDemo.Icons.SETTINGS = 'M433-80q-27 0-46.5-18T363-142l-9-66q-13-5-24.5-12T307-235l-62 26q-25 11-50 2t-39-32l-47-82q-14-23-8-49t27-43l53-40q-1-7-1-13.5v-27q0-6.5 1-13.5l-53-40q-21-17-27-43t8-49l47-82q14-23 39-32t50 2l62 26q11-8 23-15t24-12l9-66q4-26 23.5-44t46.5-18h94q27 0 46.5 18t23.5 44l9 66q13 5 24.5 12t22.5 15l62-26q25-11 50-2t39 32l47 82q14 23 8 49t-27 43l-53 40q1 7 1 13.5v27q0 6.5-2 13.5l53 40q21 17 27 43t-8 49l-48 82q-14 23-39 32t-50-2l-60-26q-11 8-23 15t-24 12l-9 66q-4 26-23.5 44T527-80h-94Zm49-260q58 0 99-41t41-99q0-58-41-99t-99-41q-59 0-99.5 41T342-480q0 58 40.5 99t99.5 41Z';

--- a/demo/index.html
+++ b/demo/index.html
@@ -25,13 +25,11 @@
     <title>Shaka Player Demo</title>
 
     <link rel="preconnect" href="https://www.gstatic.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com">
     <link rel="preconnect" href="https://storage.googleapis.com">
 
     <link rel="manifest" href="app_manifest.json">
     <link rel="icon" href="favicon.ico">
 
-    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons+Round&display=block" />
     <link rel="stylesheet" href="../dist/demo.css">
     <link rel="stylesheet" href="../dist/controls.css">
 
@@ -111,7 +109,7 @@ UNCOMPILED_JS = [
         <div id="hamburger-menu-title" class="mdl-layout-title">
           <div>Shaka Player Demo Config</div>
           <div class="mdl-layout-spacer"></div>
-          <button id="drawer-close-button" class="mdl-button mdl-js-button mdl-button--icon should-disable-on-fail"><i class="material-icons-round">close</i></button>
+          <button id="drawer-close-button" class="mdl-button mdl-js-button mdl-button--icon should-disable-on-fail"><svg class="demo-icon" viewBox="0 -960 960 960" aria-hidden="true"><path d="M480-424 284-228q-11 11-28 11t-28-11q-11-11-11-28t11-28l196-196-196-196q-11-11-11-28t11-28q11-11 28-11t28 11l196 196 196-196q11-11 28-11t28 11q11 11 11 28t-11 28L536-480l196 196q11 11 11 28t-11 28q-11 11-28 11t-28-11L480-424Z"/></svg></button>
         </div>
         <nav class="mdl-navigation" id="hamburger-menu-contents">
         </nav>

--- a/demo/input_container.js
+++ b/demo/input_container.js
@@ -8,6 +8,7 @@
 goog.provide('shakaDemo.InputContainer');
 
 
+goog.require('shakaDemo.Icons');
 goog.require('shakaDemo.Tooltips');
 
 /**
@@ -141,9 +142,7 @@ shakaDemo.InputContainer = class {
     link.classList.add('mdl-js-ripple-effect');
     link.classList.add('mdl-button--colored');
 
-    const icon = document.createElement('i');
-    icon.classList.add('material-icons-round');
-    icon.textContent = 'help';
+    const icon = shakaDemo.Icons.makeSvgIcon(shakaDemo.Icons.HELP);
 
     link.appendChild(icon);
     parentDiv.appendChild(link);

--- a/demo/main.js
+++ b/demo/main.js
@@ -10,6 +10,7 @@ goog.provide('shakaDemo.Main');
 goog.require('ShakaDemoAssetInfo');
 goog.require('goog.asserts');
 goog.require('shakaDemo.CloseButton');
+goog.require('shakaDemo.Icons');
 goog.require('shakaDemo.Utils');
 goog.require('shakaDemo.Visualizer');
 goog.require('shakaDemo.VisualizerButton');
@@ -80,9 +81,11 @@ shakaDemo.Main = class {
     /** @private {?number} */
     this.currentErrorSeverity_ = null;
 
-    // Override the icon for the MDL library's menu button.
+    // The demo no longer loads an icon font, so suppress MDL's font-based menu
+    // glyph.  We inject our own inline SVG gear icon into the drawer button
+    // once MDL has created it (see the drawer setup in setupPlayer_).
     // eslint-disable-next-line no-restricted-syntax
-    MaterialLayout.prototype.Constant_.MENU_ICON = 'settings';
+    MaterialLayout.prototype.Constant_.MENU_ICON = '';
 
     /** @private {?shakaDemo.Visualizer} */
     this.visualizer_ = null;
@@ -493,6 +496,13 @@ shakaDemo.Main = class {
     // are pressed also.
     const drawerButton = document.querySelector('.mdl-layout__drawer-button');
     goog.asserts.assert(drawerButton, 'There should be a drawer button.');
+    // MDL created the drawer button's (now-empty) icon element; fill it with
+    // the demo's gear icon as an inline SVG, since the icon font is gone.
+    const drawerButtonIcon = drawerButton.querySelector('.material-icons');
+    goog.asserts.assert(
+        drawerButtonIcon, 'There should be a drawer button icon.');
+    drawerButtonIcon.appendChild(
+        shakaDemo.Icons.makeSvgIcon(shakaDemo.Icons.SETTINGS));
     const openDrawer = () => {
       this.dispatchEventWithName_('shaka-main-drawer-state-change');
       this.showElement_(drawerCloseButton);


### PR DESCRIPTION
The player UI previously moved from a Material Design icons font to inline SVGs, but the demo still loaded the "Material Icons Round" web font from Google Fonts. Convert the demo to inline SVGs and drop the font dependency.

- Add demo/icons.js: the SVG path data the demo needs plus a small makeSvgIcon helper, mirroring shaka.ui.Icon but self-contained so the demo does not depend on UI-internal classes.
- Convert the demo's own icon usages (config, input_container, asset_card, custom, and the drawer close button in index.html) to inline SVGs.
- Render MDL's drawer toggle button (a settings gear, set via MDL's MENU_ICON) by appending an inline SVG to MDL's icon element in setupPlayer_, instead of relying on the font.
- Remove the Google Fonts stylesheet link and the now-dead fonts.gstatic preconnect from both demo HTML files, and drop the .material-icons font-family override and line-height fix from demo.less.