### PR TITLE
fix(Ads): Restrict interstitial URIs to http(s) schemes

### DIFF
--- a/lib/ads/interstitial_ad_manager.js
+++ b/lib/ads/interstitial_ad_manager.js
@@ -956,6 +956,24 @@ shaka.ads.InterstitialAdManager = class {
     shaka.log.info('Starting interstitial',
         interstitial.startTime, 'at', this.lastTime_);
 
+    // Interstitial URIs are loaded as ad content (e.g. assigned to an
+    // <iframe>/<img> source or loaded by the player). Restrict them to http(s)
+    // schemes so that other schemes cannot be used as an element source.
+    // Control characters and whitespace are stripped first because browsers
+    // ignore them when resolving the scheme of a URL.
+    if (interstitial.uri) {
+      const normalizedUri = interstitial.uri.replace(/[\u0000-\u0020]+/g, '');
+      const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+.\-]*):/.exec(normalizedUri);
+      const scheme = schemeMatch ? schemeMatch[1].toLowerCase() : null;
+      if (scheme && scheme != 'http' && scheme != 'https') {
+        shaka.log.warning(
+            'Ignoring interstitial with unsupported URI scheme:',
+            interstitial.uri);
+        this.sendEvent_(shaka.ads.Utils.AD_ERROR, new Map());
+        return;
+      }
+    }
+
     this.lastPlayedAd_ = interstitial;
 
     this.determineIfUsingBaseVideo_();


### PR DESCRIPTION
Interstitial and overlay URIs — including those parsed from DASH `OverlayEvent` manifests — are used as ad content and may be assigned to an `<iframe>` or `<img>` element source in `setupStaticAd_`. Currently the URI is used as-is, with no validation of its scheme.

This change validates the scheme in `setupAd_` (covering all interstitial sources) and ignores any interstitial whose scheme is not `http`/`https`, emitting an `AD_ERROR`, so that other schemes cannot be used as an element source. Relative URIs (no scheme) are unaffected and still resolve against the manifest base.

Control characters and whitespace are stripped before the scheme check, since browsers ignore them when resolving a URL's scheme.

Happy to add a unit test in `interstitial_ad_manager_unit.js` if you would like one with this.