### PR TITLE
feat(Cast): Dynamically proxy player and ad events using FakeEventTarget.ALL_EVENTS

### DIFF
--- a/lib/cast/cast_proxy.js
+++ b/lib/cast/cast_proxy.js
@@ -357,17 +357,14 @@ shaka.cast.CastProxy = class extends shaka.util.FakeEventTarget {
           (event) => this.videoProxyLocalEvent_(event));
     }
 
-    for (const key in shaka.util.FakeEvent.EventName) {
-      const name = shaka.util.FakeEvent.EventName[key];
-      this.eventManager_.listen(this.localPlayer_, name,
-          (event) => this.playerProxyLocalEvent_(event));
-    }
+    this.eventManager_.listen(this.localPlayer_,
+        shaka.util.FakeEventTarget.ALL_EVENTS,
+        (event) => this.playerProxyLocalEvent_(event));
 
     if (this.localAdManager_) {
-      for (const name of shaka.cast.CastUtils.AdManagerEvents) {
-        this.eventManager_.listen(this.localAdManager_, name,
-            (event) => this.adManagerProxyLocalEvent_(event));
-      }
+      this.eventManager_.listen(this.localAdManager_,
+          shaka.util.FakeEventTarget.ALL_EVENTS,
+          (event) => this.adManagerProxyLocalEvent_(event));
     }
 
     // We would like to use Proxy here, but it is not supported on Safari.

--- a/lib/cast/cast_receiver.js
+++ b/lib/cast/cast_receiver.js
@@ -295,27 +295,24 @@ shaka.cast.CastReceiver = class extends shaka.util.FakeEventTarget {
           this.video_, name, (event) => this.proxyEvent_('video', event));
     }
 
-    for (const key in shaka.util.FakeEvent.EventName) {
-      const name = shaka.util.FakeEvent.EventName[key];
-      this.eventManager_.listen(
-          this.player_, name, (event) => this.proxyEvent_('player', event));
-    }
+    this.eventManager_.listen(this.player_,
+        shaka.util.FakeEventTarget.ALL_EVENTS,
+        (event) => this.proxyEvent_('player', event));
 
     if (this.adManager_) {
-      for (const name of shaka.cast.CastUtils.AdManagerEvents) {
-        this.eventManager_.listen(this.adManager_, name, (event) => {
-          if (event.type == 'ad-started') {
-            this.currentAd_ = this.adManager_.getCurrentAd();
-            // Reset update message frequency values after new ad.
-            this.updateNumber_ = 0;
-            this.targets_['currentAd'] = this.currentAd_;
-          } else if (event.type == 'ad-stopped') {
-            this.currentAd_ = null;
-            this.targets_['currentAd'] = this.currentAd_;
-          }
-          this.proxyEvent_('adManager', event);
-        });
-      }
+      this.eventManager_.listen(this.adManager_,
+          shaka.util.FakeEventTarget.ALL_EVENTS, (event) => {
+            if (event.type == 'ad-started') {
+              this.currentAd_ = this.adManager_.getCurrentAd();
+              // Reset update message frequency values after new ad.
+              this.updateNumber_ = 0;
+              this.targets_['currentAd'] = this.currentAd_;
+            } else if (event.type == 'ad-stopped') {
+              this.currentAd_ = null;
+              this.targets_['currentAd'] = this.currentAd_;
+            }
+            this.proxyEvent_('adManager', event);
+          });
     }
 
     // Do not start excluding values from update messages until the video is

--- a/lib/cast/cast_utils.js
+++ b/lib/cast/cast_utils.js
@@ -499,52 +499,6 @@ shaka.cast.CastUtils.AdManagerPromiseMethods = [
 
 
 /**
- * shaka.extern.IAdManager events that are proxied while casting.
- * @const {!Array<string>}
- */
-shaka.cast.CastUtils.AdManagerEvents = [
-  'ads-loaded',
-  'ad-started',
-  'ad-first-quartile',
-  'ad-midpoint',
-  'ad-third-quartile',
-  'ad-complete',
-  'ad-stopped',
-  'ad-skipped',
-  'ad-volume-changed',
-  'ad-muted',
-  'ad-paused',
-  'ad-resumed',
-  'ad-skip-state-changed',
-  'ad-cue-points-changed',
-  'ima-ad-manager-loaded',
-  'ima-stream-manager-loaded',
-  'ad-clicked',
-  'ad-progress',
-  'ad-buffering',
-  'ad-impression',
-  'ad-duration-changed',
-  'ad-closed',
-  'ad-loaded',
-  'all-ads-completed',
-  'ad-linear-changed',
-  'ad-metadata',
-  'ad-recoverable-error',
-  'ad-error',
-  'ad-break-ready',
-  'ad-interaction',
-  'ad-content-pause-requested',
-  'ad-content-resume-requested',
-  'ad-content-attach-requested',
-  'ad-playing',
-  'ad-break-started',
-  'ad-break-ended',
-  'ad-interstitial-preload',
-  'ad-interstitial-preloaded',
-];
-
-
-/**
  * Current ad getter methods that are proxied while casting.
  * The key is the method, the value is the frequency of updates.
  * Frequency 1 translates to every update; frequency 2 to every 2 updates, etc.

--- a/lib/util/fake_event_target.js
+++ b/lib/util/fake_event_target.js
@@ -62,7 +62,7 @@ shaka.util.FakeEventTarget = class {
    * @exportInterface
    */
   listenToAllEvents(listener) {
-    this.addEventListener(shaka.util.FakeEventTarget.ALL_EVENTS_, listener);
+    this.addEventListener(shaka.util.FakeEventTarget.ALL_EVENTS, listener);
   }
 
   /**
@@ -103,7 +103,7 @@ shaka.util.FakeEventTarget = class {
 
     let listeners = this.listeners_.get(event.type) || [];
     const universalListeners =
-      this.listeners_.get(shaka.util.FakeEventTarget.ALL_EVENTS_);
+      this.listeners_.get(shaka.util.FakeEventTarget.ALL_EVENTS);
     if (universalListeners) {
       listeners = listeners.concat(universalListeners);
     }
@@ -160,6 +160,5 @@ shaka.util.FakeEventTarget.ListenerType;
 
 /**
  * @const {string}
- * @private
  */
-shaka.util.FakeEventTarget.ALL_EVENTS_ = 'All';
+shaka.util.FakeEventTarget.ALL_EVENTS = '__shaka_all_events__';

--- a/test/cast/cast_proxy_unit.js
+++ b/test/cast/cast_proxy_unit.js
@@ -401,7 +401,7 @@ describe('CastProxy', () => {
         expect(proxyListener).not.toHaveBeenCalled();
         const fakeEvent = new FakeEvent(
             'buffering', (new Map()).set('detail', 8675309));
-        mockPlayer.listeners['buffering'](fakeEvent);
+        mockPlayer.listeners[shaka.util.FakeEventTarget.ALL_EVENTS](fakeEvent);
         expect(proxyListener).toHaveBeenCalledWith(jasmine.objectContaining({
           type: 'buffering',
           detail: 8675309,
@@ -420,7 +420,7 @@ describe('CastProxy', () => {
         expect(proxyListener).not.toHaveBeenCalled();
         const fakeEvent = new FakeEvent(
             'buffering', (new Map()).set('detail', 8675309));
-        mockPlayer.listeners['buffering'](fakeEvent);
+        mockPlayer.listeners[shaka.util.FakeEventTarget.ALL_EVENTS](fakeEvent);
         expect(proxyListener).not.toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
- Exposed and renamed `shaka.util.FakeEventTarget.ALL_EVENTS_` to `ALL_EVENTS`, updating its value to `__shaka_all_events__` to prevent string collisions.
- Refactored `CastProxy` and `CastReceiver` to subscribe directly to this wildcard event for both the Player and the AdManager instances.
- Removed the hardcoded `shaka.cast.CastUtils.AdManagerEvents` array and eliminated the loops that iterated over static event lists.

This makes the casting event proxy layer completely dynamic, cleaner, and future-proof against new event additions to either the Player or the AdManager.