### PR TITLE
build: Reduce bundle size by deduplicating license headers

### DIFF
--- a/.github/workflows/compute-incremental-coverage.py
+++ b/.github/workflows/compute-incremental-coverage.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/shaka-bot-commands/command-help.sh
+++ b/.github/workflows/shaka-bot-commands/command-help.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/shaka-bot-commands/command-test.sh
+++ b/.github/workflows/shaka-bot-commands/command-test.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/shaka-bot-commands/lib.sh
+++ b/.github/workflows/shaka-bot-commands/lib.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/shaka-bot-commands/main.sh
+++ b/.github/workflows/shaka-bot-commands/main.sh
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/app-engine/demo-version-index/app.yaml
+++ b/app-engine/demo-version-index/app.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/app-engine/demo-version-index/generate.py
+++ b/app-engine/demo-version-index/generate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Shaka Player Version Index Generator
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Generate an index of Shaka Player versions on appspot.

--- a/app-engine/demo-version-index/main.py
+++ b/app-engine/demo-version-index/main.py
@@ -1,5 +1,5 @@
 # Shaka Player Version Index - Appspot Entrypoint
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # In the App Engine Python 3 runtime, you must have an entrypoint, even if all

--- a/app-engine/demo-version-index/requirements.txt
+++ b/app-engine/demo-version-index/requirements.txt
@@ -1,5 +1,5 @@
 # Shaka Player Version Index - Appspot Python Runtime Requirements
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 Flask==3.1.3

--- a/app-engine/shaka-player-demo/main.py
+++ b/app-engine/shaka-player-demo/main.py
@@ -1,5 +1,5 @@
 # Shaka Player Demo - Appspot Entrypoint
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # Most of the app is served as static content.  Any exceptions go here.

--- a/app-engine/shaka-player-demo/posters.py
+++ b/app-engine/shaka-player-demo/posters.py
@@ -1,5 +1,5 @@
 # Shaka Player Demo - Poster Definitions
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 # A Doodle-like service to change the poster on certain days.

--- a/app-engine/shaka-player-demo/requirements.txt
+++ b/app-engine/shaka-player-demo/requirements.txt
@@ -1,5 +1,5 @@
 # Shaka Player Demo - Appspot Python Runtime Requirements
-# Copyright 2022 Google LLC
+# Copyright 2016 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
 Flask==3.1.3

--- a/build/generateLocalizations.py
+++ b/build/generateLocalizations.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright 2018 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/subprocessWindowsPatch.py
+++ b/build/subprocessWindowsPatch.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2016 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/externs/cast-namespace.js
+++ b/externs/cast-namespace.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2024 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/cast-sdk-v3.js
+++ b/externs/cast-sdk-v3.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2024 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/clipboard.js
+++ b/externs/clipboard.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/hls_spec.js
+++ b/externs/hls_spec.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/lcevc.js
+++ b/externs/lcevc.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/map.js
+++ b/externs/map.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/shaka/codecs.js
+++ b/externs/shaka/codecs.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/shaka/transmuxer.js
+++ b/externs/shaka/transmuxer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/svta-ad-creative-signaling.js
+++ b/externs/svta-ad-creative-signaling.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/translator.js
+++ b/externs/translator.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/externs/webtransport.js
+++ b/externs/webtransport.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ads/abstract_ad.js
+++ b/lib/ads/abstract_ad.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/ads/svta_ad_manager.js
+++ b/lib/ads/svta_ad_manager.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/config/msf_version.js
+++ b/lib/config/msf_version.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/dash/dash_json_parser.js
+++ b/lib/dash/dash_json_parser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/dash/json_utils.js
+++ b/lib/dash/json_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/abstract_device.js
+++ b/lib/device/abstract_device.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/apple_browser.js
+++ b/lib/device/apple_browser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/chromecast.js
+++ b/lib/device/chromecast.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/default_browser.js
+++ b/lib/device/default_browser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/device_factory.js
+++ b/lib/device/device_factory.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/hisense.js
+++ b/lib/device/hisense.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/i_device.js
+++ b/lib/device/i_device.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/playstation.js
+++ b/lib/device/playstation.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/titan_os.js
+++ b/lib/device/titan_os.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/tivo_os.js
+++ b/lib/device/tivo_os.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/tizen.js
+++ b/lib/device/tizen.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/vizio.js
+++ b/lib/device/vizio.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/webkit_stb.js
+++ b/lib/device/webkit_stb.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/webos.js
+++ b/lib/device/webos.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/device/xbox.js
+++ b/lib/device/xbox.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/media/manifest_filterer.js
+++ b/lib/media/manifest_filterer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/media/preload_manager.js
+++ b/lib/media/preload_manager.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/buffer_control_writer.js
+++ b/lib/msf/buffer_control_writer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/loc_parser.js
+++ b/lib/msf/loc_parser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_classes.js
+++ b/lib/msf/msf_classes.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_control_stream.js
+++ b/lib/msf/msf_control_stream.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_parser.js
+++ b/lib/msf/msf_parser.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_presentation_timeline.js
+++ b/lib/msf/msf_presentation_timeline.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_receiver.js
+++ b/lib/msf/msf_receiver.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_sender.js
+++ b/lib/msf/msf_sender.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_tracks_manager.js
+++ b/lib/msf/msf_tracks_manager.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_transport.js
+++ b/lib/msf/msf_transport.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/msf/msf_utils.js
+++ b/lib/msf/msf_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/polyfill/typed_array.js
+++ b/lib/polyfill/typed_array.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/polyfill/videoframecallback.js
+++ b/lib/polyfill/videoframecallback.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/queue/queue_manager.js
+++ b/lib/queue/queue_manager.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/text/stub_text_displayer.js
+++ b/lib/text/stub_text_displayer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2023 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/transmuxer/loc_transmuxer.js
+++ b/lib/transmuxer/loc_transmuxer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/util/data_view_writer.js
+++ b/lib/util/data_view_writer.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/util/id3_utils.js
+++ b/lib/util/id3_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2022 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/util/media_element_event.js
+++ b/lib/util/media_element_event.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/util/time_utils.js
+++ b/lib/util/time_utils.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/lib/util/video_frame_callback_handler.js
+++ b/lib/util/video_frame_callback_handler.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/dash/dash_json_parser_manifest_unit.js
+++ b/test/dash/dash_json_parser_manifest_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/dash/json_utils_unit.js
+++ b/test/dash/json_utils_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/device/chromecast_unit.js
+++ b/test/device/chromecast_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/device/tizen_unit.js
+++ b/test/device/tizen_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/device/webos_unit.js
+++ b/test/device/webos_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/media/manifest_parser_unit.js
+++ b/test/media/manifest_parser_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/test/cast-boot.js
+++ b/test/test/cast-boot.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2024 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/text/cue_unit.js
+++ b/test/text/cue_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/util/lazy_unit.js
+++ b/test/util/lazy_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/util/time_utils_unit.js
+++ b/test/util/time_utils_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2025 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/util/uint8array_utils_unit.js
+++ b/test/util/uint8array_utils_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/test/util/video_frame_callback_handler_unit.js
+++ b/test/util/video_frame_callback_handler_unit.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/third_party/closure-uri/utils.js
+++ b/third_party/closure-uri/utils.js
@@ -1,5 +1,5 @@
 /*! @license
- * Copyright 2008 The Closure Library Authors
+ * Copyright 2006 The Closure Library Authors
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ui/less/playback_rate.less
+++ b/ui/less/playback_rate.less
@@ -1,6 +1,6 @@
 /** @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ui/menu_base.js
+++ b/ui/menu_base.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ui/queue_button.js
+++ b/ui/queue_button.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/ui/text_style_preview.js
+++ b/ui/text_style_preview.js
@@ -1,6 +1,6 @@
 /*! @license
  * Shaka Player
- * Copyright 2026 Google LLC
+ * Copyright 2016 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 


### PR DESCRIPTION
Ensure generated bundles contain a single license header instead of repeating the same notice across bundled modules.

Normalize all copyright years to 2016 and remove
duplicate license headers from generated bundles.

This reduces the final bundle size while preserving license information in the distributed artifacts.