### PR TITLE
chore: Set native issue type from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report a bug to help us improve
-labels: ["type: bug"]
+type: Bug
 body:
   - type: checkboxes
     id: faq

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Suggest an idea for this project
-labels: ["type: enhancement"]
+type: Feature
 body:
   - type: checkboxes
     id: faq

--- a/.github/ISSUE_TEMPLATE/question.yaml
+++ b/.github/ISSUE_TEMPLATE/question.yaml
@@ -1,6 +1,6 @@
 name: Question
 description: An open-ended question or discussion about Shaka Player, but not a bug report or feature request
-labels: ["type: question"]
+type: Question
 body:
   - type: checkboxes
     id: faq


### PR DESCRIPTION
Replace the 'type: ...' label on each issue form with the native issue
'type' field: Bug, Feature, and Question.