### PR TITLE
fix(HLS): Fix audio/video desync in muxed TS segments mode

### DIFF
--- a/lib/media/media_source_engine.js
+++ b/lib/media/media_source_engine.js
@@ -1266,11 +1266,17 @@ shaka.media.MediaSourceEngine = class {
     }
 
     if (!fromSplit && this.needSplitMuxedContent_) {
-      const audioAppendBufferInfo = await this.appendBuffer(
-          ContentType.AUDIO, data, reference, stream, hasClosedCaptions, seeked,
-          adaptation, isChunkedData, /* fromSplit= */ true);
+      // Video first: its segments are cut on keyframes, so its embedded
+      // timestamps land exactly on the segment boundary. Audio's own
+      // timestamps do not (frames rarely align with the cut point), so in
+      // segments mode we anchor audio's timestampOffset to video's instead of
+      // recomputing it independently. That requires video's offset for this
+      // segment to already be known, hence the ordering.
       const videoAppendBufferInfo = await this.appendBuffer(
           ContentType.VIDEO, data, reference, stream, hasClosedCaptions, seeked,
+          adaptation, isChunkedData, /* fromSplit= */ true);
+      const audioAppendBufferInfo = await this.appendBuffer(
+          ContentType.AUDIO, data, reference, stream, hasClosedCaptions, seeked,
           adaptation, isChunkedData, /* fromSplit= */ true);
       return videoAppendBufferInfo.mediaTimestamp != null ?
           videoAppendBufferInfo : audioAppendBufferInfo;
@@ -1358,16 +1364,51 @@ shaka.media.MediaSourceEngine = class {
             this.audioCompensation_.resolve(compensation);
           }
         }
-        let realTimestamp = timestamp;
-        const RAW_FORMATS = shaka.util.MimeUtils.RAW_FORMATS;
-        // For formats without containers and using segments mode, we need to
-        // adjust TimestampOffset relative to 0 because segments do not have
-        // any timestamp information.
-        if (!this.sequenceMode_ &&
-            RAW_FORMATS.includes(this.sourceBufferTypes_.get(contentType))) {
-          realTimestamp = 0;
+        let calculatedTimestampOffset;
+        const SourceBufferMode =
+            shaka.media.MediaSourceEngine.SourceBufferMode_;
+        const anchorAudioToVideo =
+            contentType == ContentType.AUDIO && this.needSplitMuxedContent_ &&
+            !this.sequenceMode_ && this.firstVideoTimestamp_ != null &&
+            this.sourceBuffers_.has(ContentType.VIDEO) &&
+            // Some platforms put an audio-only mp4 SourceBuffer into
+            // 'sequence' mode even though Shaka is using 'segments' mode
+            // overall (observed for MP3-in-MP4 on Chrome). In that mode the
+            // browser derives each append's placement from where the
+            // previous one ended, not from timestampOffset, so anchoring to
+            // video here would be silently ignored; fall through to the
+            // per-segment recomputation below instead.
+            this.sourceBuffers_.get(ContentType.AUDIO).mode ==
+                SourceBufferMode.SEGMENTS;
+        if (anchorAudioToVideo) {
+          // Muxed content split into separate audio/video SourceBuffers: in
+          // segments mode, video's per-segment offset is trustworthy because
+          // segments are cut on keyframes, so video's embedded timestamp
+          // lands exactly on the segment boundary. Audio's own embedded
+          // timestamp does not (frames rarely align with the cut point, so it
+          // jitters by a fraction of a frame from segment to segment).
+          // Recomputing audio's offset independently every segment chases
+          // that harmless jitter, which forces an abort() + splice on nearly
+          // every append (see abort_ above) and slowly erodes the buffered
+          // audio. Anchor audio to video's offset instead, adjusted by the
+          // fixed compensation between the two tracks measured on the first
+          // segment. See https://github.com/shaka-project/shaka-player/issues/10341
+          const videoTimestampOffset =
+              this.sourceBuffers_.get(ContentType.VIDEO).timestampOffset;
+          const compensation = await this.audioCompensation_.promise;
+          calculatedTimestampOffset = videoTimestampOffset + compensation;
+        } else {
+          let realTimestamp = timestamp;
+          const RAW_FORMATS = shaka.util.MimeUtils.RAW_FORMATS;
+          // For formats without containers and using segments mode, we need
+          // to adjust TimestampOffset relative to 0 because segments do not
+          // have any timestamp information.
+          if (!this.sequenceMode_ &&
+              RAW_FORMATS.includes(this.sourceBufferTypes_.get(contentType))) {
+            realTimestamp = 0;
+          }
+          calculatedTimestampOffset = reference.startTime - realTimestamp;
         }
-        const calculatedTimestampOffset = reference.startTime - realTimestamp;
         const timestampOffsetDifference =
             Math.abs(timestampOffset - calculatedTimestampOffset);
         if ((timestampOffsetDifference >= 0.001 || seeked || adaptation) &&


### PR DESCRIPTION
In segments mode, muxed HLS TS content recomputed each track's timestampOffset independently from its own embedded PTS. Audio's PES timestamps jitter by a fraction of a frame relative to the segment boundary (unlike video, which is keyframe-aligned), so nearly every audio append triggered an unnecessary abort()+splice that slowly trimmed buffered audio, causing lip-sync drift on long-running live streams. Anchor audio's offset to video's instead, falling back to the old per-segment computation when the audio SourceBuffer is (unexpectedly) in native 'sequence' mode, such as observed for MP3-in-MP4 on Chrome.

Fixes #10341