### PR TITLE
test: Add missing MediaSourceEngine spies to FakeMediaSourceEngine

### DIFF
--- a/test/test/util/fake_media_source_engine.js
+++ b/test/test/util/fake_media_source_engine.js
@@ -128,6 +128,10 @@ shaka.test.FakeMediaSourceEngine = class {
     this.flush = jasmine.createSpy('flush').and.returnValue(Promise.resolve());
 
     /** @type {!jasmine.Spy} */
+    this.setSelectedClosedCaptionId =
+        jasmine.createSpy('setSelectedClosedCaptionId');
+
+    /** @type {!jasmine.Spy} */
     this.clearSelectedClosedCaptionId =
         jasmine.createSpy('clearSelectedClosedCaptionId');
 
@@ -140,6 +144,10 @@ shaka.test.FakeMediaSourceEngine = class {
         jasmine.createSpy('updateLcevcDec').and.stub();
 
     /** @type {!jasmine.Spy} */
+    this.appendDependency =
+        jasmine.createSpy('appendDependency').and.stub();
+
+    /** @type {!jasmine.Spy} */
     this.resync =
         jasmine.createSpy('resync').and.stub();
 
@@ -150,6 +158,10 @@ shaka.test.FakeMediaSourceEngine = class {
     /** @type {!jasmine.Spy} */
     this.clearLiveSeekableRange =
         jasmine.createSpy('clearLiveSeekableRange').and.stub();
+
+    /** @type {!jasmine.Spy} */
+    this.reset =
+        jasmine.createSpy('reset').and.returnValue(Promise.resolve());
 
     this.textDisplayer = new shaka.test.FakeTextDisplayer();
   }


### PR DESCRIPTION
FakeMediaSourceEngine was missing reset(), setSelectedClosedCaptionId(), and appendDependency() — all called by StreamingEngine but never implemented in the fake. Since fetchAndAppend_() is fire-and-forget (p.catch(() => {})), the resulting TypeError was silently swallowed instead of reaching onError, causing "from failed init/media segment append during startup" to fail in streaming_engine_unit.js. The other two (setSelectedClosedCaptionId, appendDependency) are the same latent gap on code paths not yet covered by tests.